### PR TITLE
Add support for second Rachio device in collection, status, and reporting

### DIFF
--- a/RachioFlume/main.py
+++ b/RachioFlume/main.py
@@ -122,13 +122,19 @@ def show_status(args):
             logger.error(f"Error: {status['error']}")
             return 1
 
-        active_zone = status["active_zone"]
-        if active_zone["zone_number"]:
-            logger.info(
-                f"Active Zone: #{active_zone['zone_number']} - {active_zone['zone_name']}"
-            )
+        # Show information about multiple devices
+        logger.info(f"Rachio Devices: {status.get('rachio_devices_count', 1)}")
+        
+        # Show all active zones from all devices
+        active_zones = status.get("active_zones", [])
+        if active_zones:
+            logger.info("Active Zones:")
+            for zone in active_zones:
+                logger.info(
+                    f"  Device {zone['device']}: Zone #{zone['zone_number']} - {zone['zone_name']}"
+                )
         else:
-            logger.info("Active Zone: None")
+            logger.info("Active Zones: None")
 
         if status["current_usage_rate_gpm"]:
             logger.info(


### PR DESCRIPTION
## Summary
- Adds support for multiple Rachio devices in the water tracking system
- Configurable via new `RACHIO_ID_2` constant in Constants.py
- Maintains backward compatibility with existing single-device setups

## Changes Made
- **Configuration**: Added `RACHIO_ID_2` option to Constants.py.sample
- **Collection**: Updated `WaterTrackingCollector` to dynamically handle 1-N Rachio devices
- **Status**: Enhanced status display to show device count and active zones from all devices  
- **Reporting**: All zones from both devices are automatically included in reports
- **Compatibility**: Preserved existing single `active_zone` format for backward compatibility

## Testing
- ✅ Single device operation (when only `RACHIO_ID` configured)
- ✅ Status command shows device count and active zones per device
- ✅ Reports include zones from all configured devices
- ✅ Collection works across multiple devices simultaneously

## Technical Details
The collector now:
1. Dynamically creates RachioClient instances based on available device IDs
2. Iterates through all devices during data collection
3. Aggregates zones and events from all devices
4. Provides enhanced status information while maintaining compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)