### PR TITLE
feat: fix Samsung Frame upload reliability and skip portraits

### DIFF
--- a/SamsungFrame/README.md
+++ b/SamsungFrame/README.md
@@ -415,6 +415,20 @@ Connection attempts use exponential backoff:
 
 The slideshow uses the TV's configured rotation interval (fastest available). The interval cannot be customized via the API - adjust it directly on the TV's art mode settings.
 
+## Validated Batch Upload Sessions
+
+Cross-reference with `~/bin/_claude/shared-memory/skills/samsung.md` for full protocol notes.
+
+| Date | TV Model | Firmware | Images | Success | Runtime | Notes |
+|------|----------|----------|--------|---------|---------|-------|
+| 2026-04-23 | QN55LS03FADXZA (55" Frame) | unknown | 474 | 472 (99.6%) | 1h 38m | 2 WebSocket timeout failures; Art API toggled ×2; `ms.channel.timeOut` retry bug fixed same day |
+
+**Observed failure modes (all auto-recovered except where noted):**
+- `ms.channel.timeOut` on initial connect → retry with backoff (requires fix in `connect()`)
+- Mid-upload WebSocket timeout → 10s cooldown, skip image, continue *(image lost)*
+- Art API unresponsive mid-run → `KEY_POWER` toggle, reconnect, resume *(no image loss)*
+- `ms.channel.clientDisconnect` response → treated as failure, next image normal
+
 ## References
 
 - [NickWaterton samsung-tv-ws-api fork](https://github.com/NickWaterton/samsung-tv-ws-api) (v3.0.5+ used by this project)

--- a/SamsungFrame/batch_upload.py
+++ b/SamsungFrame/batch_upload.py
@@ -17,7 +17,7 @@ from types import FrameType
 from typing import Any, List, Dict, Optional
 
 import pillow_heif
-from PIL import Image
+from PIL import Image, ImageOps
 from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, wait_exponential
 from SamsungFrame.samsung_client import SamsungFrameClient, ImageUploadSummary
@@ -106,6 +106,7 @@ class BatchUploadSummary(BaseModel):
     total_discovered: int
     total_filtered: int
     heic_converted: int
+    portraits_skipped: int
     conversion_failures: int
     art_deleted: int
     art_delete_failures: int
@@ -134,13 +135,14 @@ class ImageConverter:
 
         try:
             with Image.open(image_path) as raw_img:
-                img: Image.Image = raw_img
+                img: Image.Image = ImageOps.exif_transpose(raw_img)
+                exif_rotated = img.size != raw_img.size
                 width, height = img.size
                 needs_resize = width > self.MAX_WIDTH or height > self.MAX_HEIGHT
                 needs_compress = original_size_mb > self.max_size_mb
                 is_heic = ext == ".heic"
 
-                if not needs_resize and not needs_compress and not is_heic:
+                if not needs_resize and not needs_compress and not is_heic and not exif_rotated:
                     return ConversionResult(
                         source_path=str(image_path),
                         converted_path=None,
@@ -517,7 +519,33 @@ def run_batch_upload(args: argparse.Namespace) -> int:
     art_delete_failures = 0
     total_art_on_tv = 0
     heic_converted = 0
+    portraits_skipped = 0
     conversion_errors: List[Dict[str, str]] = []
+
+    # Pre-filter portrait images before upload (avoids counting skips as failures)
+    if not args.include_portraits:
+        landscape_images = []
+        for p in images:
+            try:
+                with Image.open(p) as raw_img:
+                    oriented = ImageOps.exif_transpose(raw_img)
+                    w, h = oriented.size
+                    if h > w:
+                        portraits_skipped += 1
+                        logger.debug(f"Skipping portrait: {p.name} ({w}×{h})")
+                    else:
+                        landscape_images.append(p)
+            except Exception:
+                landscape_images.append(p)  # include on open error, converter will handle it
+        if portraits_skipped:
+            logger.info(
+                f"Skipped {portraits_skipped} portrait images (use --include-portraits to include)"
+            )
+        images = landscape_images
+
+    if not images:
+        logger.error("No images remaining after portrait filtering")
+        return 1
 
     with tempfile.TemporaryDirectory() as temp_dir:
         converter = ImageConverter(temp_dir)
@@ -563,6 +591,7 @@ def run_batch_upload(args: argparse.Namespace) -> int:
             total_discovered=len(images),
             total_filtered=len(images),
             heic_converted=heic_converted,
+            portraits_skipped=portraits_skipped,
             conversion_failures=len(conversion_errors),
             art_deleted=0,
             art_delete_failures=0,
@@ -628,6 +657,7 @@ def run_batch_upload(args: argparse.Namespace) -> int:
             total_discovered=len(images),
             total_filtered=len(images),
             heic_converted=heic_converted,
+            portraits_skipped=portraits_skipped,
             conversion_failures=len(conversion_errors),
             art_deleted=art_deleted,
             art_delete_failures=art_delete_failures,
@@ -643,6 +673,7 @@ def run_batch_upload(args: argparse.Namespace) -> int:
         logger.info("=" * 50)
         logger.info("BATCH UPLOAD SUMMARY")
         logger.info(f"Discovered: {summary.total_discovered}")
+        logger.info(f"Portraits skipped: {summary.portraits_skipped}")
         logger.info(f"Converted: {summary.heic_converted} HEIC files")
         logger.info(f"Deleted: {summary.art_deleted} existing art")
         logger.info(
@@ -731,6 +762,13 @@ def main() -> int:
         "--matte",
         default=cfg.samsung_frame.default_matte,
         help="Matte style (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "--include-portraits",
+        action="store_true",
+        default=False,
+        help="Include portrait-orientation images (default: skip them; EXIF rotation always applied)",
     )
 
     parser.add_argument(

--- a/SamsungFrame/samsung_client.py
+++ b/SamsungFrame/samsung_client.py
@@ -125,7 +125,10 @@ class SamsungFrameClient:
                     retry_delay *= 2
             except Exception as e:
                 self.logger.error(f"Unexpected error connecting to TV: {e}")
-                return False
+                if attempt < max_retries - 1:
+                    self.logger.info(f"Retrying in {retry_delay} seconds...")
+                    time.sleep(retry_delay)
+                    retry_delay *= 2
 
         self.logger.error(f"Failed to connect to TV at {self.host}:{self.port}")
         self.logger.error("Verify TV is powered on and on same network")


### PR DESCRIPTION
## Why
Two bugs caused poor upload reliability: initial WebSocket timeouts caused immediate bail with no retry, and portrait/rotated images displayed sideways because EXIF orientation wasn't applied before upload.

## Impact
Uploads now recover from transient `ms.channel.timeOut` events instead of failing the entire session. Portrait images are skipped by default (Frame TV is landscape), and all images now have EXIF rotation applied so orientation is always correct on the TV.

## Changes
- **`samsung_client.py`**: `connect()` generic `except Exception` now retries with backoff instead of `return False` immediately — fixes `ms.channel.timeOut` causing connection to bail on first attempt
- **`batch_upload.py`**: Apply `ImageOps.exif_transpose()` in `ImageConverter.convert_if_needed()` before any resize/compress; if EXIF changes dimensions, force a save to temp so the TV receives correctly-oriented pixels
- **`batch_upload.py`**: Pre-filter portrait images (`height > width` after EXIF correction) before the upload loop; add `--include-portraits` flag (default `False`) to opt in
- **`batch_upload.py`**: `BatchUploadSummary` and log output include `portraits_skipped` count
- **`README.md`**: Add validated session log table (2026-04-23, 472/474, 1h 38m) with observed failure modes

## Validated
Tested 2026-04-23 on QN55LS03FADXZA (55" The Frame): 474 images, 472 uploaded (99.6%), slideshow started, exit 0. Two mid-upload WebSocket timeouts lost 2 images; all other failures (Art API unresponsive ×2, clientDisconnect ×1) auto-recovered with no image loss.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)