### PR TITLE
feat: PersonalCalSync — show real event titles, fix empty-window sync bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ lib/tokens
 
 # Samsung upload history
 config/samsung_upload_history.json
+
+# Claude Code worktrees
+.claude/worktrees/

--- a/PersonalCalSync/README.md
+++ b/PersonalCalSync/README.md
@@ -54,21 +54,30 @@ After initial setup, use [`clasp`](https://github.com/google/clasp) to push loca
 
 ### One-time clasp setup
 
+**1. Install clasp:**
+
 ```bash
 npm install -g @google/clasp
-clasp login   # opens browser, log in as your enterprise account
 ```
 
-Find your Script ID: `script.google.com` → your project → **Project Settings** → **IDs** → Script ID.
+**2. Log in** (opens browser — sign in as your **enterprise** Google account, the one that owns the Apps Script project):
 
-Store it in `config/local.yaml` (gitignored) so Claude can run deploys for you:
+```bash
+clasp login
+```
+
+Credentials are saved to `~/.clasprc.json`. You only need to do this once per machine.
+
+**3. Find your Script ID:** `script.google.com` → your project → **Project Settings** → **IDs** → Script ID.
+
+**4. Store it in `config/local.yaml`** (gitignored) so Claude can run deploys for you without being asked:
 
 ```yaml
 personal_cal_sync:
   script_id: "your_script_id_here"
 ```
 
-Then link this directory to your Apps Script project:
+**5. Link this directory** to your Apps Script project:
 
 ```bash
 cd PersonalCalSync
@@ -84,7 +93,7 @@ cd PersonalCalSync
 clasp push        # uploads calendar-sync.gs to Apps Script
 ```
 
-Verify in the Apps Script editor that the file updated, then run `initialSync` manually once to confirm the new code works before the trigger picks it up.
+To trigger an immediate sync after pushing (instead of waiting for the 15-minute timer), open the Apps Script editor, select `initialSync` from the function dropdown, and click **Run**.
 
 ### `.clasp.json` and secrets
 

--- a/PersonalCalSync/README.md
+++ b/PersonalCalSync/README.md
@@ -60,7 +60,11 @@ After initial setup, use [`clasp`](https://github.com/google/clasp) to push loca
 npm install -g @google/clasp
 ```
 
-**2. Log in** (opens browser — sign in as your **enterprise** Google account, the one that owns the Apps Script project):
+**2. Enable the Apps Script API** on your enterprise account:
+
+Visit [script.google.com/home/usersettings](https://script.google.com/home/usersettings) and toggle **Google Apps Script API** to **On**. Without this, `clasp push` will fail with a 403. Only needed once per Google account.
+
+**3. Log in** (opens browser — sign in as your **enterprise** Google account, the one that owns the Apps Script project):
 
 ```bash
 clasp login
@@ -68,16 +72,16 @@ clasp login
 
 Credentials are saved to `~/.clasprc.json`. You only need to do this once per machine.
 
-**3. Find your Script ID:** `script.google.com` → your project → **Project Settings** → **IDs** → Script ID.
+**4. Find your Script ID:** `script.google.com` → your project → **Project Settings** → **IDs** → Script ID.
 
-**4. Store it in `config/local.yaml`** (gitignored) so Claude can run deploys for you without being asked:
+**5. Store it in `config/local.yaml`** (gitignored) so Claude can run deploys for you without being asked:
 
 ```yaml
 personal_cal_sync:
   script_id: "your_script_id_here"
 ```
 
-**5. Link this directory** to your Apps Script project:
+**6. Link this directory** to your Apps Script project:
 
 ```bash
 cd PersonalCalSync

--- a/PersonalCalSync/README.md
+++ b/PersonalCalSync/README.md
@@ -1,6 +1,6 @@
 # Personal Calendar Sync
 
-Syncs personal Google Calendar events to your enterprise Google Calendar as "busy" blocker events (Tomato colored). Prevents coworkers from booking over your personal commitments.
+Syncs personal Google Calendar events to your enterprise Google Calendar as private busy-blocker events (tomato colored). Prevents coworkers from booking over your personal commitments.
 
 ## Why
 
@@ -10,7 +10,8 @@ Enterprise Google Workspace often blocks external calendar access via `CalendarA
 
 - Fetches your personal calendar via its secret iCal URL (HTTP, bypasses enterprise restrictions)
 - Parses ICS format including RRULE expansion for recurring events
-- Creates/updates/deletes "Personal (Busy)" blocker events on your enterprise calendar
+- Creates/updates/deletes blocker events on your enterprise calendar using the **real event title** from your personal calendar
+- Blocker events are marked `PRIVATE` — coworkers see "Busy", only you see the title
 - Skips declined events and cancelled instances
 - Batches writes to avoid Google API rate limits
 - Runs every 15 minutes via Apps Script trigger
@@ -20,39 +21,72 @@ Enterprise Google Workspace often blocks external calendar access via `CalendarA
 ### 1. Get your secret iCal URL
 
 1. Open [Google Calendar](https://calendar.google.com) logged in as your **personal** account
-2. Settings (gear) > click your calendar name in the left sidebar
+2. Settings (gear) → click your calendar name in the left sidebar
 3. Scroll to **"Integrate calendar"**
 4. Copy **"Secret address in iCal format"** (NOT the public one)
 
 ### 2. Create the Apps Script project
 
 1. Open [script.google.com](https://script.google.com) logged in as your **enterprise** account
-2. New Project > delete placeholder code
+2. New Project → delete placeholder code
 3. Paste contents of `calendar-sync.gs`
 4. Replace `PASTE_YOUR_SECRET_ICAL_URL_HERE` with your secret iCal URL
 5. Save
 
 ### 3. Run initial sync
 
-1. Select `initialSync` from the function dropdown > click **Run**
+1. Select `initialSync` from the function dropdown → click **Run**
 2. Approve calendar permissions when prompted
-3. Check your enterprise calendar for red "Personal (Busy)" events
+3. Check your enterprise calendar for red blocker events
 
 ### 4. Set up automatic sync
 
-1. Left sidebar > **Triggers** (clock icon) > **Add Trigger**
+1. Left sidebar → **Triggers** (clock icon) → **Add Trigger**
 2. Function: `syncCalendar`
 3. Event source: Time-driven
 4. Type: Minutes timer
 5. Interval: Every 15 minutes
 6. Save
 
+## Deploying updates
+
+After initial setup, use [`clasp`](https://github.com/google/clasp) to push local edits without copy-pasting.
+
+### One-time clasp setup
+
+```bash
+npm install -g @google/clasp
+clasp login   # opens browser, log in as your enterprise account
+```
+
+Then link this directory to your existing Apps Script project:
+
+```bash
+cd PersonalCalSync
+clasp clone <SCRIPT_ID>   # Script ID is in script.google.com → Project Settings → IDs
+```
+
+This creates `.clasp.json` (gitignored — contains your script ID) and `appsscript.json`.
+
+### Pushing changes
+
+```bash
+cd PersonalCalSync
+clasp push        # uploads calendar-sync.gs to Apps Script
+```
+
+Verify in the Apps Script editor that the file updated, then run `initialSync` manually once to confirm the new code works before the trigger picks it up.
+
+### `.clasp.json` and secrets
+
+`.clasp.json` contains the script ID (not sensitive) but no credentials. The iCal URL lives only inside the Apps Script editor and is never committed to this repo.
+
 ## Configuration
 
 | Variable | Default | Description |
 |---|---|---|
 | `PERSONAL_ICAL_URL` | — | Your secret iCal URL |
-| `BLOCKER_TITLE` | `Personal (Busy)` | Title shown on enterprise calendar |
+| `BLOCKER_TITLE_FALLBACK` | `Personal (Busy)` | Title used only if SUMMARY is missing from iCal |
 | `SYNC_DAYS_AHEAD` | `30` | How far ahead to sync |
 | `BATCH_SIZE` | `10` | Events created before pausing |
 | `BATCH_PAUSE_MS` | `2000` | Pause duration between batches (ms) |
@@ -65,7 +99,17 @@ Enterprise Google Workspace often blocks external calendar access via `CalendarA
 | `syncCalendar()` | Standard sync (used by trigger) |
 | `cleanupAllBlockers()` | Remove all synced blocker events |
 
-## Security
+## Privacy model
 
-- The secret iCal URL grants read-only access to your personal calendar. Do not share it or commit it to a public repo.
-- Blocker events are created with `Visibility.PRIVATE` — coworkers see "Busy" but not the blocker title.
+| Who sees what | Value |
+|---|---|
+| You (calendar owner) | Real event title (e.g. "Doctor appt") |
+| Coworkers scheduling you | "Busy" only — no title, no details |
+| Coworkers with full calendar access | Still sees "Busy" (PRIVATE visibility) |
+
+The secret iCal URL grants read-only access to your personal calendar. Do not share it or commit it to a public repo.
+
+## Known limitations
+
+- Timezone: `TZID`-qualified timestamps are parsed as local (Apps Script server) timezone. Events on personal calendars in different timezones may be off by one hour during DST transitions.
+- Sync window: only the next 30 days are checked. Events beyond `SYNC_DAYS_AHEAD` that were previously synced will not be cleaned up until they fall within the window.

--- a/PersonalCalSync/README.md
+++ b/PersonalCalSync/README.md
@@ -59,11 +59,20 @@ npm install -g @google/clasp
 clasp login   # opens browser, log in as your enterprise account
 ```
 
-Then link this directory to your existing Apps Script project:
+Find your Script ID: `script.google.com` → your project → **Project Settings** → **IDs** → Script ID.
+
+Store it in `config/local.yaml` (gitignored) so Claude can run deploys for you:
+
+```yaml
+personal_cal_sync:
+  script_id: "your_script_id_here"
+```
+
+Then link this directory to your Apps Script project:
 
 ```bash
 cd PersonalCalSync
-clasp clone <SCRIPT_ID>   # Script ID is in script.google.com → Project Settings → IDs
+clasp clone <SCRIPT_ID>   # same ID as above
 ```
 
 This creates `.clasp.json` (gitignored — contains your script ID) and `appsscript.json`.

--- a/PersonalCalSync/calendar-sync.gs
+++ b/PersonalCalSync/calendar-sync.gs
@@ -15,7 +15,7 @@
 
 var PERSONAL_ICAL_URL = 'PASTE_YOUR_SECRET_ICAL_URL_HERE';
 var BLOCKER_TAG = '[PERSONAL_SYNC:';
-var BLOCKER_TITLE = 'Personal (Busy)';
+var BLOCKER_TITLE_FALLBACK = 'Personal (Busy)';
 var SYNC_DAYS_AHEAD = 30;
 
 var BATCH_SIZE = 10;
@@ -27,9 +27,12 @@ function syncCalendar() {
   var endDate = new Date(now.getTime() + SYNC_DAYS_AHEAD * 24 * 60 * 60 * 1000);
 
   var personalEvents = fetchPersonalEvents(startDate, endDate);
-  if (personalEvents === null || personalEvents.length === 0) {
-    Logger.log('No personal events found.');
+  if (personalEvents === null) {
+    Logger.log('Failed to fetch personal events, skipping sync to preserve existing blockers.');
     return;
+  }
+  if (personalEvents.length === 0) {
+    Logger.log('No personal events found in window.');
   }
 
   Logger.log('Found ' + personalEvents.length + ' personal events in window.');
@@ -139,7 +142,8 @@ function parseICS(icsText, startDate, endDate) {
     var exdates = extractAllEXDATEs(block);
 
     if (rrule) {
-      var instances = expandRRule(rrule, dtStart, duration, isAllDay, exdates, startDate, endDate, uid, overridesByUid[uid] || {});
+      var masterTitle = extractICSField(block, 'SUMMARY');
+      var instances = expandRRule(rrule, dtStart, duration, isAllDay, exdates, startDate, endDate, uid, overridesByUid[uid] || {}, masterTitle);
       for (var j = 0; j < instances.length; j++) {
         events.push(instances[j]);
       }
@@ -148,8 +152,10 @@ function parseICS(icsText, startDate, endDate) {
         dtEnd = new Date(dtStart.getTime() + duration);
       }
       if (dtEnd >= startDate && dtStart <= endDate) {
+        var title = extractICSField(block, 'SUMMARY');
         events.push({
           uid: uid,
+          title: title || BLOCKER_TITLE_FALLBACK,
           start: dtStart,
           end: dtEnd,
           isAllDay: isAllDay
@@ -196,7 +202,7 @@ function isDeclinedEvent(block) {
 
 // --- RRULE Expansion ---
 
-function expandRRule(rrule, dtStart, duration, isAllDay, exdates, windowStart, windowEnd, uid, overrides) {
+function expandRRule(rrule, dtStart, duration, isAllDay, exdates, windowStart, windowEnd, uid, overrides, masterTitle) {
   var parts = parseRRuleParts(rrule);
   var freq = parts['FREQ'];
   var interval = parseInt(parts['INTERVAL'] || '1');
@@ -230,6 +236,7 @@ function expandRRule(rrule, dtStart, duration, isAllDay, exdates, windowStart, w
         var instanceEnd = new Date(candidate.getTime() + duration);
 
         // Check for override (modified instance)
+        var instanceTitle = masterTitle;
         var override = overrides[candidate.getTime()];
         if (override) {
           var ovStart = extractICSDateTime(override, 'DTSTART');
@@ -241,10 +248,13 @@ function expandRRule(rrule, dtStart, duration, isAllDay, exdates, windowStart, w
             candidate = ovStart;
             instanceEnd = ovEnd || new Date(ovStart.getTime() + duration);
           }
+          var ovTitle = extractICSField(override, 'SUMMARY');
+          if (ovTitle) instanceTitle = ovTitle;
         }
 
         instances.push({
           uid: uid + '_' + candidate.getTime(),
+          title: instanceTitle || BLOCKER_TITLE_FALLBACK,
           start: candidate,
           end: instanceEnd,
           isAllDay: isAllDay
@@ -488,9 +498,9 @@ function createBlocker(enterpriseCal, pe) {
   var blocker;
 
   if (pe.isAllDay) {
-    blocker = enterpriseCal.createAllDayEvent(BLOCKER_TITLE, pe.start, pe.end);
+    blocker = enterpriseCal.createAllDayEvent(pe.title, pe.start, pe.end);
   } else {
-    blocker = enterpriseCal.createEvent(BLOCKER_TITLE, pe.start, pe.end);
+    blocker = enterpriseCal.createEvent(pe.title, pe.start, pe.end);
   }
 
   blocker.setDescription(description);
@@ -498,7 +508,7 @@ function createBlocker(enterpriseCal, pe) {
   blocker.setVisibility(CalendarApp.Visibility.PRIVATE);
   blocker.removeAllReminders();
 
-  Logger.log('Created blocker: ' + pe.start);
+  Logger.log('Created blocker: ' + pe.title + ' @ ' + pe.start);
   return blocker;
 }
 
@@ -519,8 +529,13 @@ function updateBlockerIfNeeded(blocker, pe) {
     }
   }
 
+  if (blocker.getTitle() !== pe.title) {
+    blocker.setTitle(pe.title);
+    changed = true;
+  }
+
   if (changed) {
-    Logger.log('Updated blocker: ' + pe.start);
+    Logger.log('Updated blocker: ' + pe.title + ' @ ' + pe.start);
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ uv run python RachioFlume/main.py
 | 🌐 **NetworkCheck** | Network uplink testing and connectivity monitoring utilities for reliable internet connections. | - |
 | 🖥️ **NodeCheck** | System node monitoring with continuous heartbeat tracking and automated device management. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/NodeCheck/README.md) |
 | 🔧 **OpenAIAdmin** | OpenAI project management and administration tools for API governance and usage tracking. | - |
+| 📅 **PersonalCalSync** | Google Apps Script that syncs personal calendar events to enterprise calendar as private busy-blockers, preserving real event titles visible only to you. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/PersonalCalSync/README.md) |
 | 💧 **RachioFlume** | Water usage tracking integration between Rachio irrigation systems and Flume water monitoring. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/RachioFlume/README.md) |
 | 🖼️ **SamsungFrame** | Samsung Frame TV art manager with batch upload, HEIC conversion, and slideshow control. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/SamsungFrame/README.md) |
 | ⚡ **Tesla** | Tesla Powerwall monitoring and intelligent power management automation for home energy optimization. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/Tesla/README.md) |

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -218,6 +218,10 @@ flume:
   user_email: ""  
   password: ""  
 
+# === PersonalCalSync (Google Apps Script) ===
+personal_cal_sync:
+  script_id: ""   # Apps Script project ID — override in config/local.yaml
+
 # === Constants ===
 my_external_ip: "hoiboi.tplinkdns.com"
 seconds_in_day: 86400


### PR DESCRIPTION
## Why

The sync script showed all blockers as generic \"Personal (Busy)\" regardless of what the event actually was, making the enterprise calendar owner's own view unhelpful. A separate bug caused stale blockers to survive when all personal events in the sync window were deleted.

## Impact

Enterprise calendar now shows real personal event titles (visible only to the owner — coworkers still see \"Busy\" due to \`PRIVATE\` visibility). Stale blockers are properly cleaned up when a personal calendar window empties.

## Changes

- Extract \`SUMMARY\` from ICS and use as blocker title for both one-off and recurring events (including per-instance title overrides in a series)
- \`updateBlockerIfNeeded\` now syncs title drift on existing blockers — old \"Personal (Busy)\" blockers auto-migrate on next sync run
- Fix: split \`personalEvents === null\` (fetch failure, skip sync) from \`personalEvents.length === 0\` (no events, still run deletion pass)
- \`BLOCKER_TITLE\` → \`BLOCKER_TITLE_FALLBACK\`, used only when \`SUMMARY\` is missing from iCal
- \`README\`: full clasp deployment workflow including Apps Script API enable step, \`config/local.yaml\` script ID storage, privacy model table, known limitations
- \`config/default.yaml\` + \`config/local.yaml\`: add \`personal_cal_sync.script_id\` so Claude can deploy without being asked
- \`.gitignore\`: add \`.claude/worktrees/\`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)