### PR TITLE
chore: add clasp config files, gitignore .clasp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ config/samsung_upload_history.json
 
 # Claude Code worktrees
 .claude/worktrees/
+
+# clasp (Google Apps Script CLI) — script ID is local, not shared
+PersonalCalSync/.clasp.json

--- a/PersonalCalSync/appsscript.json
+++ b/PersonalCalSync/appsscript.json
@@ -1,0 +1,7 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "dependencies": {
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}


### PR DESCRIPTION
## Why

`clasp clone` created `Code.js` (a download of the old Apps Script file) and `appsscript.json` alongside `calendar-sync.gs`. `Code.js` was redundant and caused Apps Script to run two script files simultaneously.

## Changes

- Add `PersonalCalSync/appsscript.json` — required by clasp for `clasp push` to work
- Add `PersonalCalSync/.clasp.json` to `.gitignore` — contains the script ID, local-only
- Delete `Code.js` locally and re-push via clasp so Apps Script only runs `calendar-sync.gs`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)