### PR TITLE
feat(NoShorts): All Subscriptions landing, top shortcut bar, video auto-landscape

### DIFF
--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -84,8 +84,6 @@ final class WebViewModel {
     @ObservationIgnored let webView: WKWebView
     @ObservationIgnored private let proxy = LocalProxy()
     var isLoading = false
-    var canGoBack = false
-    var canGoForward = false
 
     init() {
         let config = WKWebViewConfiguration()
@@ -121,11 +119,9 @@ final class WebViewModel {
     }
 
     func goHome() { load("https://www.youtube.com/feed/channels") }
-
-    func search(_ query: String) {
-        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
-        load("https://www.youtube.com/results?search_query=\(encoded)")
-    }
+    func goPlaylists() { load("https://www.youtube.com/feed/playlists") }
+    func goLiked() { load("https://www.youtube.com/playlist?list=LL") }
+    func goAccount() { load("https://www.youtube.com/account") }
 }
 
 struct YouTubeWebView: UIViewRepresentable {
@@ -193,8 +189,6 @@ struct YouTubeWebView: UIViewRepresentable {
         func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
             webView.evaluateJavaScript(shortsBlockScript)
             model.isLoading = false
-            model.canGoBack = webView.canGoBack
-            model.canGoForward = webView.canGoForward
         }
 
         func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) { model.isLoading = false }
@@ -205,15 +199,12 @@ struct ContentView: View {
     @State private var model = WebViewModel()
     @State private var remaining: TimeInterval = sessionDuration
     @State private var timer: Timer?
-    @State private var searchText = ""
-    @State private var isSearching = false
-    @FocusState private var searchFocused: Bool
 
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
-                YouTubeWebView(model: model)
                 toolbar
+                YouTubeWebView(model: model)
             }
 
             if model.isLoading {
@@ -221,7 +212,7 @@ struct ContentView: View {
                     .progressViewStyle(.linear)
                     .tint(.red)
                     .frame(maxWidth: .infinity)
-                    .padding(.top, 4)
+                    .padding(.top, 52)
             }
 
             countdownBadge
@@ -235,50 +226,14 @@ struct ContentView: View {
 
     private var toolbar: some View {
         HStack(spacing: 0) {
-            if isSearching {
-                // Expanded search bar
-                HStack(spacing: 8) {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundStyle(.secondary)
-                        .padding(.leading, 12)
-                    TextField("Search YouTube", text: $searchText)
-                        .focused($searchFocused)
-                        .submitLabel(.search)
-                        .onSubmit {
-                            if !searchText.isEmpty { model.search(searchText) }
-                            isSearching = false
-                            searchText = ""
-                        }
-                    Button {
-                        isSearching = false
-                        searchText = ""
-                        searchFocused = false
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                            .padding(.trailing, 12)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .frame(height: 36)
-                .background(Color(.secondarySystemBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .padding(.horizontal, 12)
-            } else {
-                toolbarButton("chevron.left", enabled: model.canGoBack) { model.webView.goBack() }
-                toolbarButton("chevron.right", enabled: model.canGoForward) { model.webView.goForward() }
-                toolbarButton("magnifyingglass", enabled: true) {
-                    isSearching = true
-                    searchFocused = true
-                }
-                toolbarButton("house.fill", enabled: true) { model.goHome() }
-                toolbarButton("arrow.clockwise", enabled: true) { model.webView.reload() }
-            }
+            toolbarButton("play.square.stack.fill") { model.goPlaylists() }
+            toolbarButton("hand.thumbsup.fill") { model.goLiked() }
+            toolbarButton("square.grid.3x3.fill") { model.goHome() }
+            toolbarButton("person.crop.circle.fill") { model.goAccount() }
         }
         .frame(height: 52)
         .background(.bar)
-        .overlay(alignment: .top) { Divider() }
-        .animation(.easeInOut(duration: 0.2), value: isSearching)
+        .overlay(alignment: .bottom) { Divider() }
     }
 
     private var countdownBadge: some View {
@@ -302,16 +257,15 @@ struct ContentView: View {
         }
     }
 
-    private func toolbarButton(_ icon: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+    private func toolbarButton(_ icon: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.system(size: 18, weight: .medium))
-                .foregroundStyle(enabled ? Color.red : Color.secondary.opacity(0.4))
+                .foregroundStyle(Color.red)
                 .frame(maxWidth: .infinity)
                 .frame(height: 52)
                 .contentShape(Rectangle())
         }
-        .disabled(!enabled)
     }
 }
 

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -154,8 +154,12 @@ struct YouTubeWebView: UIViewRepresentable {
             // does NOT fire for these, so YouTube's in-app Home tab tap can sneak past.
             urlObservation = model.webView.observe(\.url, options: [.new]) { [weak self] _, change in
                 guard let self, let url = change.newValue ?? nil else { return }
-                if Self.isYouTubeHome(url) {
-                    Task { @MainActor in self.model.goHome() }
+                let isHome = Self.isYouTubeHome(url)
+                let isWatch = Self.isWatchPage(url)
+                Task { @MainActor in
+                    if isHome { self.model.goHome() }
+                    if isWatch { Self.setOrientation(.landscape) }
+                    else if !isHome { Self.setOrientation(.allButUpsideDown) }
                 }
             }
         }
@@ -164,6 +168,17 @@ struct YouTubeWebView: UIViewRepresentable {
 
         nonisolated static func isYouTubeHome(_ url: URL) -> Bool {
             (url.host?.hasSuffix("youtube.com") == true) && (url.path.isEmpty || url.path == "/")
+        }
+
+        nonisolated static func isWatchPage(_ url: URL) -> Bool {
+            (url.host?.hasSuffix("youtube.com") == true) && url.path.hasPrefix("/watch")
+        }
+
+        @MainActor
+        static func setOrientation(_ mask: UIInterfaceOrientationMask) {
+            for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
+                scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask))
+            }
         }
 
         func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction) async -> WKNavigationActionPolicy {

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -25,6 +25,7 @@ private let earlyScript = """
         ytm-rich-section-renderer:has(ytm-shorts-lockup-view-model),
         ytm-rich-item-renderer:has(ytm-shorts-lockup-view-model) { display:none!important; }
         ytd-reel-shelf-renderer, ytd-rich-shelf-renderer[is-shorts] { display:none!important; }
+        ytm-pivot-bar-renderer { display:none!important; }
     `;
     (document.head || document.documentElement).appendChild(s);
 

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -38,12 +38,19 @@ private let earlyScript = """
         return Promise.reject(new DOMException('Autoplay blocked', 'NotAllowedError'));
     };
 
-    // Block SPA navigation to /shorts
+    // Block SPA navigation: /shorts -> drop, / (home) -> rewrite to subscriptions
     const _push = history.pushState.bind(history);
     const _replace = history.replaceState.bind(history);
+    const SUBS = '/feed/subscriptions';
     const isShorts = (u) => u && String(u).startsWith('/shorts');
-    history.pushState = (s,t,u) => { if (!isShorts(u)) _push(s,t,u); };
-    history.replaceState = (s,t,u) => { if (!isShorts(u)) _replace(s,t,u); };
+    const isHome = (u) => {
+        if (!u) return false;
+        const s = String(u);
+        return s === '/' || s === '' || s === window.location.origin || s === window.location.origin + '/';
+    };
+    const rewrite = (u) => isHome(u) ? SUBS : u;
+    history.pushState = (s,t,u) => { if (isShorts(u)) return; _push(s,t,rewrite(u)); };
+    history.replaceState = (s,t,u) => { if (isShorts(u)) return; _replace(s,t,rewrite(u)); };
 })();
 """
 
@@ -119,7 +126,7 @@ final class WebViewModel {
         webView.load(URLRequest(url: url))
     }
 
-    func goHome() { load("https://www.youtube.com") }
+    func goHome() { load("https://www.youtube.com/feed/subscriptions") }
 
     func search(_ query: String) {
         let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
@@ -149,6 +156,12 @@ struct YouTubeWebView: UIViewRepresentable {
         func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction) async -> WKNavigationActionPolicy {
             guard let url = action.request.url else { return .allow }
             if url.path.hasPrefix("/shorts") { model.goHome(); return .cancel }
+            // Block YouTube home: redirect / and empty path to subscriptions feed.
+            if url.host?.hasSuffix("youtube.com") == true,
+               url.path.isEmpty || url.path == "/" {
+                model.goHome()
+                return .cancel
+            }
             return .allow
         }
 

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -38,19 +38,13 @@ private let earlyScript = """
         return Promise.reject(new DOMException('Autoplay blocked', 'NotAllowedError'));
     };
 
-    // Block SPA navigation: /shorts -> drop, / (home) -> rewrite to subscriptions
+    // Block SPA navigation to /shorts. Home (/) is handled in Swift via KVO on
+    // webView.url so we catch it regardless of who triggered the URL change.
     const _push = history.pushState.bind(history);
     const _replace = history.replaceState.bind(history);
-    const SUBS = '/feed/subscriptions';
     const isShorts = (u) => u && String(u).startsWith('/shorts');
-    const isHome = (u) => {
-        if (!u) return false;
-        const s = String(u);
-        return s === '/' || s === '' || s === window.location.origin || s === window.location.origin + '/';
-    };
-    const rewrite = (u) => isHome(u) ? SUBS : u;
-    history.pushState = (s,t,u) => { if (isShorts(u)) return; _push(s,t,rewrite(u)); };
-    history.replaceState = (s,t,u) => { if (isShorts(u)) return; _replace(s,t,rewrite(u)); };
+    history.pushState = (s,t,u) => { if (!isShorts(u)) _push(s,t,u); };
+    history.replaceState = (s,t,u) => { if (!isShorts(u)) _replace(s,t,u); };
 })();
 """
 
@@ -126,7 +120,7 @@ final class WebViewModel {
         webView.load(URLRequest(url: url))
     }
 
-    func goHome() { load("https://www.youtube.com/feed/subscriptions") }
+    func goHome() { load("https://www.youtube.com/feed/channels") }
 
     func search(_ query: String) {
         let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
@@ -151,17 +145,31 @@ struct YouTubeWebView: UIViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate {
         let model: WebViewModel
-        init(model: WebViewModel) { self.model = model }
+        private var urlObservation: NSKeyValueObservation?
+
+        init(model: WebViewModel) {
+            self.model = model
+            super.init()
+            // Catch SPA URL changes (history.pushState / replaceState). decidePolicyFor
+            // does NOT fire for these, so YouTube's in-app Home tab tap can sneak past.
+            urlObservation = model.webView.observe(\.url, options: [.new]) { [weak self] _, change in
+                guard let self, let url = change.newValue ?? nil else { return }
+                if Self.isYouTubeHome(url) {
+                    Task { @MainActor in self.model.goHome() }
+                }
+            }
+        }
+
+        deinit { urlObservation?.invalidate() }
+
+        static func isYouTubeHome(_ url: URL) -> Bool {
+            (url.host?.hasSuffix("youtube.com") == true) && (url.path.isEmpty || url.path == "/")
+        }
 
         func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction) async -> WKNavigationActionPolicy {
             guard let url = action.request.url else { return .allow }
             if url.path.hasPrefix("/shorts") { model.goHome(); return .cancel }
-            // Block YouTube home: redirect / and empty path to subscriptions feed.
-            if url.host?.hasSuffix("youtube.com") == true,
-               url.path.isEmpty || url.path == "/" {
-                model.goHome()
-                return .cancel
-            }
+            if Self.isYouTubeHome(url) { model.goHome(); return .cancel }
             return .allow
         }
 

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -162,7 +162,7 @@ struct YouTubeWebView: UIViewRepresentable {
 
         deinit { urlObservation?.invalidate() }
 
-        static func isYouTubeHome(_ url: URL) -> Bool {
+        nonisolated static func isYouTubeHome(_ url: URL) -> Bool {
             (url.host?.hasSuffix("youtube.com") == true) && (url.path.isEmpty || url.path == "/")
         }
 

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -84,6 +84,8 @@ final class WebViewModel {
     @ObservationIgnored let webView: WKWebView
     @ObservationIgnored private let proxy = LocalProxy()
     var isLoading = false
+    var canGoBack = false
+    var canGoForward = false
 
     init() {
         let config = WKWebViewConfiguration()
@@ -122,6 +124,11 @@ final class WebViewModel {
     func goPlaylists() { load("https://www.youtube.com/feed/playlists") }
     func goLiked() { load("https://www.youtube.com/playlist?list=LL") }
     func goAccount() { load("https://www.youtube.com/account") }
+
+    func search(_ query: String) {
+        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        load("https://www.youtube.com/results?search_query=\(encoded)")
+    }
 }
 
 struct YouTubeWebView: UIViewRepresentable {
@@ -189,6 +196,8 @@ struct YouTubeWebView: UIViewRepresentable {
         func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
             webView.evaluateJavaScript(shortsBlockScript)
             model.isLoading = false
+            model.canGoBack = webView.canGoBack
+            model.canGoForward = webView.canGoForward
         }
 
         func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) { model.isLoading = false }
@@ -199,12 +208,16 @@ struct ContentView: View {
     @State private var model = WebViewModel()
     @State private var remaining: TimeInterval = sessionDuration
     @State private var timer: Timer?
+    @State private var searchText = ""
+    @State private var isSearching = false
+    @FocusState private var searchFocused: Bool
 
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
-                toolbar
+                topToolbar
                 YouTubeWebView(model: model)
+                bottomToolbar
             }
 
             if model.isLoading {
@@ -224,16 +237,63 @@ struct ContentView: View {
         .onDisappear { timer?.invalidate() }
     }
 
-    private var toolbar: some View {
+    private var topToolbar: some View {
         HStack(spacing: 0) {
-            toolbarButton("play.square.stack.fill") { model.goPlaylists() }
-            toolbarButton("hand.thumbsup.fill") { model.goLiked() }
-            toolbarButton("square.grid.3x3.fill") { model.goHome() }
-            toolbarButton("person.crop.circle.fill") { model.goAccount() }
+            toolbarButton("play.square.stack.fill", enabled: true) { model.goPlaylists() }
+            toolbarButton("hand.thumbsup.fill", enabled: true) { model.goLiked() }
+            toolbarButton("square.grid.3x3.fill", enabled: true) { model.goHome() }
+            toolbarButton("person.crop.circle.fill", enabled: true) { model.goAccount() }
         }
         .frame(height: 52)
         .background(.bar)
         .overlay(alignment: .bottom) { Divider() }
+    }
+
+    private var bottomToolbar: some View {
+        HStack(spacing: 0) {
+            if isSearching {
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, 12)
+                    TextField("Search YouTube", text: $searchText)
+                        .focused($searchFocused)
+                        .submitLabel(.search)
+                        .onSubmit {
+                            if !searchText.isEmpty { model.search(searchText) }
+                            isSearching = false
+                            searchText = ""
+                        }
+                    Button {
+                        isSearching = false
+                        searchText = ""
+                        searchFocused = false
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                            .padding(.trailing, 12)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 36)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .padding(.horizontal, 12)
+            } else {
+                toolbarButton("chevron.left", enabled: model.canGoBack) { model.webView.goBack() }
+                toolbarButton("chevron.right", enabled: model.canGoForward) { model.webView.goForward() }
+                toolbarButton("magnifyingglass", enabled: true) {
+                    isSearching = true
+                    searchFocused = true
+                }
+                toolbarButton("house.fill", enabled: true) { model.goHome() }
+                toolbarButton("arrow.clockwise", enabled: true) { model.webView.reload() }
+            }
+        }
+        .frame(height: 52)
+        .background(.bar)
+        .overlay(alignment: .top) { Divider() }
+        .animation(.easeInOut(duration: 0.2), value: isSearching)
     }
 
     private var countdownBadge: some View {
@@ -257,15 +317,16 @@ struct ContentView: View {
         }
     }
 
-    private func toolbarButton(_ icon: String, action: @escaping () -> Void) -> some View {
+    private func toolbarButton(_ icon: String, enabled: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.system(size: 18, weight: .medium))
-                .foregroundStyle(Color.red)
+                .foregroundStyle(enabled ? Color.red : Color.secondary.opacity(0.4))
                 .frame(maxWidth: .infinity)
                 .frame(height: 52)
                 .contentShape(Rectangle())
         }
+        .disabled(!enabled)
     }
 }
 

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -229,7 +229,7 @@ struct ContentView: View {
             }
 
             countdownBadge
-                .padding(.top, 8)
+                .padding(.top, 60)  // 52pt top toolbar + 8pt gap
                 .padding(.trailing, 12)
                 .frame(maxWidth: .infinity, alignment: .trailing)
         }

--- a/NoShorts/README.md
+++ b/NoShorts/README.md
@@ -10,8 +10,7 @@ An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navig
 - **Autoplay blocked**: JS interceptor only allows `video.play()` within 1.5s of a user tap
 - **SPA navigation guard**: intercepts `pushState`/`replaceState` to drop `/shorts` navigations
 - **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0
-- **Search bar**: tap the magnifying glass to expand an animated inline search field
-- **Toolbar**: back, forward, search, home (→ All Subscriptions), reload
+- **Top toolbar**: 4 shortcuts (Playlists, Liked Videos, All Subscriptions, Account/Login) — pinned above the WebView. YouTube's own header and bottom pivot bar handle search and back/forward; we don't duplicate them.
 - **Google sign-in**: works natively in-app (no Safari handoff required)
 - **DNS bypass**: in-app DoH proxy lets WKWebView reach `youtube.com` even when system DNS (e.g. NextDNS) blocks it — used to block YouTube in Chrome while keeping it accessible here
 

--- a/NoShorts/README.md
+++ b/NoShorts/README.md
@@ -1,16 +1,16 @@
 # NoShorts
 
-An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navigation, feed shelves, autoplay), and lands on the Subscriptions feed instead of the algorithmic home page.
+An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navigation, feed shelves, autoplay), and lands on the **All Subscriptions** channel grid (`/feed/channels`) instead of the algorithmic home page.
 
 ## Features
 
 - **Shorts blocking**: removes Shorts tab, home feed shelf, and all `/shorts/` links from the DOM
-- **Subscriptions as default landing**: app launches into `/feed/subscriptions`. Any navigation to `/` (algorithmic home feed) — including the Home button and the YouTube logo — is rewritten back to Subscriptions, in the navigation delegate and the SPA `pushState`/`replaceState` interceptors.
+- **All Subscriptions as default landing**: app launches into `/feed/channels` (the channel grid, not the videos feed). Any navigation to `/` (algorithmic home) — including YouTube's own in-page Home tab, the YouTube logo, the toolbar Home button, post-login redirects — is caught and rewritten via KVO on `webView.url` (catches SPA `pushState`) plus `WKNavigationDelegate` (catches full-page navs).
 - **Autoplay blocked**: JS interceptor only allows `video.play()` within 1.5s of a user tap
-- **SPA navigation guard**: intercepts `pushState`/`replaceState` to prevent in-app Shorts navigation and to rewrite home → subscriptions
+- **SPA navigation guard**: intercepts `pushState`/`replaceState` to drop `/shorts` navigations
 - **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0
 - **Search bar**: tap the magnifying glass to expand an animated inline search field
-- **Toolbar**: back, forward, search, home (→ Subscriptions), reload
+- **Toolbar**: back, forward, search, home (→ All Subscriptions), reload
 - **Google sign-in**: works natively in-app (no Safari handoff required)
 - **DNS bypass**: in-app DoH proxy lets WKWebView reach `youtube.com` even when system DNS (e.g. NextDNS) blocks it — used to block YouTube in Chrome while keeping it accessible here
 
@@ -34,14 +34,16 @@ Two `WKUserScript` injections run on every page:
 **`atDocumentStart` (`earlyScript`)**:
 - Injects CSS to hide Shorts elements before first paint (`.pivot-shorts`, `ytm-shorts-lockup-view-model`, etc.)
 - Intercepts `HTMLVideoElement.prototype.play()` — blocked unless called within 1.5s of a user touch/click
-- Intercepts `history.pushState`/`replaceState` to drop any navigation to `/shorts` and rewrite navigations to `/` (home) → `/feed/subscriptions`
+- Intercepts `history.pushState`/`replaceState` to drop any navigation to `/shorts`
 - Removes `window.webkit` for `accounts.google.com` only, so Google's sign-in flow doesn't detect WKWebView
 
 **`atDocumentEnd` (`shortsBlockScript`)**:
 - DOM removal of all Shorts-related elements
 - Debounced `MutationObserver` (300ms) re-runs removal as YouTube's SPA loads new content
 
-`WKNavigationDelegate` also intercepts full-page navigations to `/shorts` (→ Subscriptions) and to `/` or empty paths on `*.youtube.com` (→ Subscriptions).
+`WKNavigationDelegate` intercepts full-page navigations to `/shorts` and to `/` (or empty path) on `*.youtube.com`, redirecting both to the All Subscriptions grid.
+
+A `KVO` observer on `webView.url` catches SPA URL changes (`history.pushState`/`replaceState` from YouTube's own Home tab) — `decidePolicyFor` does NOT fire for SPA navigations, so KVO is the catch-all. When the URL becomes `/`, the observer calls `goHome()` to force a real navigation; rewriting the URL alone wouldn't stop YouTube's home content from being rendered.
 
 ## Architecture Notes / Gotchas
 

--- a/NoShorts/README.md
+++ b/NoShorts/README.md
@@ -1,15 +1,16 @@
 # NoShorts
 
-An iOS app that wraps YouTube in a `WKWebView` and blocks all Shorts content — navigation, feed shelves, and autoplay.
+An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navigation, feed shelves, autoplay), and lands on the Subscriptions feed instead of the algorithmic home page.
 
 ## Features
 
 - **Shorts blocking**: removes Shorts tab, home feed shelf, and all `/shorts/` links from the DOM
+- **Subscriptions as default landing**: app launches into `/feed/subscriptions`. Any navigation to `/` (algorithmic home feed) — including the Home button and the YouTube logo — is rewritten back to Subscriptions, in the navigation delegate and the SPA `pushState`/`replaceState` interceptors.
 - **Autoplay blocked**: JS interceptor only allows `video.play()` within 1.5s of a user tap
-- **SPA navigation guard**: intercepts `pushState`/`replaceState` to prevent in-app Shorts navigation
+- **SPA navigation guard**: intercepts `pushState`/`replaceState` to prevent in-app Shorts navigation and to rewrite home → subscriptions
 - **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0
 - **Search bar**: tap the magnifying glass to expand an animated inline search field
-- **Toolbar**: back, forward, search, home, reload
+- **Toolbar**: back, forward, search, home (→ Subscriptions), reload
 - **Google sign-in**: works natively in-app (no Safari handoff required)
 - **DNS bypass**: in-app DoH proxy lets WKWebView reach `youtube.com` even when system DNS (e.g. NextDNS) blocks it — used to block YouTube in Chrome while keeping it accessible here
 
@@ -33,14 +34,14 @@ Two `WKUserScript` injections run on every page:
 **`atDocumentStart` (`earlyScript`)**:
 - Injects CSS to hide Shorts elements before first paint (`.pivot-shorts`, `ytm-shorts-lockup-view-model`, etc.)
 - Intercepts `HTMLVideoElement.prototype.play()` — blocked unless called within 1.5s of a user touch/click
-- Intercepts `history.pushState`/`replaceState` to drop any navigation to `/shorts`
+- Intercepts `history.pushState`/`replaceState` to drop any navigation to `/shorts` and rewrite navigations to `/` (home) → `/feed/subscriptions`
 - Removes `window.webkit` for `accounts.google.com` only, so Google's sign-in flow doesn't detect WKWebView
 
 **`atDocumentEnd` (`shortsBlockScript`)**:
 - DOM removal of all Shorts-related elements
 - Debounced `MutationObserver` (300ms) re-runs removal as YouTube's SPA loads new content
 
-`WKNavigationDelegate` also intercepts full-page navigations to `/shorts` and redirects home.
+`WKNavigationDelegate` also intercepts full-page navigations to `/shorts` (→ Subscriptions) and to `/` or empty paths on `*.youtube.com` (→ Subscriptions).
 
 ## Architecture Notes / Gotchas
 

--- a/NoShorts/README.md
+++ b/NoShorts/README.md
@@ -10,7 +10,9 @@ An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navig
 - **Autoplay blocked**: JS interceptor only allows `video.play()` within 1.5s of a user tap
 - **SPA navigation guard**: intercepts `pushState`/`replaceState` to drop `/shorts` navigations
 - **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0
-- **Top toolbar**: 4 shortcuts (Playlists, Liked Videos, All Subscriptions, Account/Login) — pinned above the WebView. YouTube's own header and bottom pivot bar handle search and back/forward; we don't duplicate them.
+- **Top toolbar**: 4 destination shortcuts — Playlists (`/feed/playlists`), Liked Videos (`/playlist?list=LL`), All Subscriptions (`/feed/channels`), Account/Login (`/account`)
+- **Bottom toolbar**: back, forward, search (expands inline), home (→ All Subscriptions), reload
+- **Search bar**: tap the magnifying glass in the bottom toolbar to expand an animated inline search field
 - **Google sign-in**: works natively in-app (no Safari handoff required)
 - **DNS bypass**: in-app DoH proxy lets WKWebView reach `youtube.com` even when system DNS (e.g. NextDNS) blocks it — used to block YouTube in Chrome while keeping it accessible here
 

--- a/NoShorts/README.md
+++ b/NoShorts/README.md
@@ -6,6 +6,7 @@ An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navig
 
 - **Shorts blocking**: removes Shorts tab, home feed shelf, and all `/shorts/` links from the DOM
 - **All Subscriptions as default landing**: app launches into `/feed/channels` (the channel grid, not the videos feed). Any navigation to `/` (algorithmic home) — including YouTube's own in-page Home tab, the YouTube logo, the toolbar Home button, post-login redirects — is caught and rewritten via KVO on `webView.url` (catches SPA `pushState`) plus `WKNavigationDelegate` (catches full-page navs).
+- **Auto-rotate to landscape on video play**: tapping a video (URL → `/watch?v=...`) calls `UIWindowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .landscape))` to force landscape immediately. Off the watch page, orientation is unlocked (`.allButUpsideDown`) so manual rotation works.
 - **Autoplay blocked**: JS interceptor only allows `video.play()` within 1.5s of a user tap
 - **SPA navigation guard**: intercepts `pushState`/`replaceState` to drop `/shorts` navigations
 - **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0


### PR DESCRIPTION
## Why

Three QoL fixes to the YouTube wrapper, evolved over device-testing iterations:

1. Algorithmic home is engagement-bait — default to **All Subscriptions** channel grid (`/feed/channels`)
2. Manually rotating the device every time a video opens is friction — auto-rotate to landscape on `/watch`
3. Frequent destinations (Playlists, Liked, Account) buried deep in YouTube's UI — pin them as a top shortcut bar

## Impact

- App opens to `/feed/channels`. Any nav to `/` (toolbar Home, YouTube's in-page Home tab, YouTube logo, post-login redirect, in-app SPA route) gets rewritten to All Subscriptions.
- Tapping any video forces landscape immediately. Off the watch page, orientation unlocks so manual rotation works.
- New top toolbar with 4 shortcuts (Playlists / Liked / All Subs / Account). YouTube's own pivot bar is hidden to avoid duplication; existing bottom toolbar (back/fwd/search/home/reload) unchanged.

## Changes

**Routing**
- `goHome()` loads `/feed/channels`
- `WebViewModel` adds `goPlaylists()` / `goLiked()` / `goAccount()` for the new shortcuts
- **KVO on `webView.url`** in the navigation Coordinator catches SPA URL transitions (which `decidePolicyFor` does NOT see):
  - URL → `/` → call `goHome()` (force real navigation; rewriting URL alone wouldn't stop YouTube rendering home content)
  - URL → `/watch...` → `UIWindowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .landscape))`
  - URL → anything else → unlock orientation to `.allButUpsideDown`
- `WKNavigationDelegate.decidePolicyFor` retained as defense-in-depth for full-page navs to `/` and `/shorts`

**UI**
- New `topToolbar` above the WebView: 4 destination shortcuts (`play.square.stack.fill`, `hand.thumbsup.fill`, `square.grid.3x3.fill`, `person.crop.circle.fill`)
- `bottomToolbar` retains the existing 5 nav buttons + inline expanding search field
- Countdown badge top-padding bumped to 60pt so it sits below the new top toolbar
- CSS adds `ytm-pivot-bar-renderer { display:none }` to hide YouTube's bottom pivot bar (was duplicating our bottom toolbar visually)

**Other**
- `earlyScript` SPA guard simplified back to just dropping `/shorts` (URL-rewriting `/` was redundant — KVO handles it)
- Info.plist orientation settings already supported portrait + landscape on iPhone, so no project setting changes
- README features list, How-It-Works, and architecture note updated

## Why KVO instead of JS URL rewrite?

YouTube renders home content based on internal state, not the URL bar. Rewriting `pushState`'s URL argument to `/feed/channels` updated the URL bar but YouTube still rendered home. Forcing a real navigation via `webView.load(...)` is the only way to actually replace the rendered content. KVO on `webView.url` is the cleanest hook because it fires for both full navs and SPA pushState — the same mechanism is reused for orientation toggling.

## Test plan

- [x] `xcodebuild -scheme NoShorts -sdk iphonesimulator build` — succeeds
- [x] Initial load lands on All Subscriptions grid
- [x] YouTube's in-page Home tab → All Subscriptions (KVO path) — verified after KVO fix
- [x] Tap any video → screen rotates to landscape immediately
- [x] Top shortcuts: Playlists / Liked / All Subs / Account all navigate correctly
- [x] YouTube's bottom pivot bar hidden — only our SwiftUI bottom toolbar visible
- [x] Countdown badge no longer overlaps top toolbar
- [ ] Back from video → can rotate to portrait manually
- [ ] Sign out / sign back in → post-login redirect lands on All Subscriptions
- [ ] Confirm Shorts blocking, autoplay, DNS bypass, session timer still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)