### PR TITLE
NoShorts: playlists default + true video orientation lock

### DIFF
--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -91,6 +91,9 @@ final class WebViewModel {
     init() {
         let config = WKWebViewConfiguration()
         config.mediaTypesRequiringUserActionForPlayback = .video
+        // Without this, tapping play hands the video to AVPlayerViewController,
+        // whose own orientation handling overrides our AppDelegate gate.
+        config.allowsInlineMediaPlayback = true
         config.userContentController.addUserScript(
             WKUserScript(source: earlyScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         )
@@ -182,8 +185,10 @@ struct YouTubeWebView: UIViewRepresentable {
         static func setOrientation(_ mask: UIInterfaceOrientationMask) {
             AppDelegate.orientationLock = mask
             for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
-                scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask))
                 scene.windows.first?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+                scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { error in
+                    NSLog("requestGeometryUpdate failed for mask \(mask.rawValue): \(error)")
+                }
             }
         }
 
@@ -201,6 +206,11 @@ struct YouTubeWebView: UIViewRepresentable {
             model.isLoading = false
             model.canGoBack = webView.canGoBack
             model.canGoForward = webView.canGoForward
+            // URL KVO can miss SPA back-out from a video; re-assert here too.
+            if let url = webView.url {
+                if Self.isWatchPage(url) { Self.setOrientation(.landscapeRight) }
+                else if !Self.isYouTubeHome(url) { Self.setOrientation(.portrait) }
+            }
         }
 
         func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) { model.isLoading = false }

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -150,7 +150,6 @@ struct YouTubeWebView: UIViewRepresentable {
     final class Coordinator: NSObject, WKNavigationDelegate {
         let model: WebViewModel
         private var urlObservation: NSKeyValueObservation?
-        private var fullscreenObservation: NSKeyValueObservation?
 
         init(model: WebViewModel) {
             self.model = model
@@ -163,43 +162,12 @@ struct YouTubeWebView: UIViewRepresentable {
                     Task { @MainActor in self.model.goPlaylists() }
                 }
             }
-            // Orientation is driven by WebKit fullscreen state, not URL. Entering
-            // video fullscreen (incl. AVPlayerViewController hand-off) → landscape;
-            // exiting → portrait. This is the only signal that reliably tracks
-            // "is the user actually watching a video right now".
-            fullscreenObservation = model.webView.observe(\.fullscreenState, options: [.new]) { _, change in
-                guard let state = change.newValue else { return }
-                Task { @MainActor in
-                    switch state {
-                    case .enteringFullscreen, .inFullscreen:
-                        Self.setOrientation(.landscapeRight)
-                    case .exitingFullscreen, .notInFullscreen:
-                        Self.setOrientation(.portrait)
-                    @unknown default:
-                        break
-                    }
-                }
-            }
         }
 
-        deinit {
-            urlObservation?.invalidate()
-            fullscreenObservation?.invalidate()
-        }
+        deinit { urlObservation?.invalidate() }
 
         nonisolated static func isYouTubeHome(_ url: URL) -> Bool {
             (url.host?.hasSuffix("youtube.com") == true) && (url.path.isEmpty || url.path == "/")
-        }
-
-        @MainActor
-        static func setOrientation(_ mask: UIInterfaceOrientationMask) {
-            AppDelegate.orientationLock = mask
-            for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
-                scene.windows.first?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
-                scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { error in
-                    NSLog("requestGeometryUpdate failed for mask \(mask.rawValue): \(error)")
-                }
-            }
         }
 
         func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction) async -> WKNavigationActionPolicy {

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -199,6 +199,7 @@ struct YouTubeWebView: UIViewRepresentable {
 
         nonisolated func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
             guard let kind = message.body as? String else { return }
+            NSLog("NoShorts.video event=\(kind)")
             Task { @MainActor in
                 switch kind {
                 case "play":
@@ -213,13 +214,14 @@ struct YouTubeWebView: UIViewRepresentable {
 
         @MainActor
         static func setOrientation(_ mask: UIInterfaceOrientationMask) {
+            NSLog("NoShorts.setOrientation mask=\(mask.rawValue)")
             AppDelegate.orientationLock = mask
             for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
                 for window in scene.windows {
                     window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
                 }
                 scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { error in
-                    NSLog("requestGeometryUpdate(\(mask.rawValue)) failed: \(error)")
+                    NSLog("NoShorts.setOrientation requestGeometryUpdate(\(mask.rawValue)) failed: \(error)")
                 }
             }
         }

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -199,7 +199,6 @@ struct YouTubeWebView: UIViewRepresentable {
 
         nonisolated func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
             guard let kind = message.body as? String else { return }
-            NSLog("NoShorts.video event=\(kind)")
             Task { @MainActor in
                 switch kind {
                 case "play":
@@ -214,14 +213,13 @@ struct YouTubeWebView: UIViewRepresentable {
 
         @MainActor
         static func setOrientation(_ mask: UIInterfaceOrientationMask) {
-            NSLog("NoShorts.setOrientation mask=\(mask.rawValue)")
             AppDelegate.orientationLock = mask
             for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
                 for window in scene.windows {
                     window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
                 }
                 scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { error in
-                    NSLog("NoShorts.setOrientation requestGeometryUpdate(\(mask.rawValue)) failed: \(error)")
+                    NSLog("NoShorts.setOrientation(\(mask.rawValue)) failed: \(error)")
                 }
             }
         }

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -87,6 +87,7 @@ final class WebViewModel {
     var isLoading = false
     var canGoBack = false
     var canGoForward = false
+    var isWatching = false
 
     init() {
         let config = WKWebViewConfiguration()
@@ -165,6 +166,7 @@ struct YouTubeWebView: UIViewRepresentable {
                 let isWatch = Self.isWatchPage(url)
                 Task { @MainActor in
                     if isHome { self.model.goPlaylists() }
+                    self.model.isWatching = isWatch
                     if isWatch { Self.setOrientation(.landscapeRight) }
                     else if !isHome { Self.setOrientation(.portrait) }
                 }
@@ -208,7 +210,9 @@ struct YouTubeWebView: UIViewRepresentable {
             model.canGoForward = webView.canGoForward
             // URL KVO can miss SPA back-out from a video; re-assert here too.
             if let url = webView.url {
-                if Self.isWatchPage(url) { Self.setOrientation(.landscapeRight) }
+                let isWatch = Self.isWatchPage(url)
+                model.isWatching = isWatch
+                if isWatch { Self.setOrientation(.landscapeRight) }
                 else if !Self.isYouTubeHome(url) { Self.setOrientation(.portrait) }
             }
         }
@@ -228,9 +232,9 @@ struct ContentView: View {
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
-                topToolbar
+                if !model.isWatching { topToolbar }
                 YouTubeWebView(model: model)
-                bottomToolbar
+                if !model.isWatching { bottomToolbar }
             }
 
             if model.isLoading {
@@ -238,14 +242,18 @@ struct ContentView: View {
                     .progressViewStyle(.linear)
                     .tint(.red)
                     .frame(maxWidth: .infinity)
-                    .padding(.top, 52)
+                    .padding(.top, model.isWatching ? 0 : 52)
             }
 
-            countdownBadge
-                .padding(.top, 60)  // 52pt top toolbar + 8pt gap
-                .padding(.trailing, 12)
-                .frame(maxWidth: .infinity, alignment: .trailing)
+            if !model.isWatching {
+                countdownBadge
+                    .padding(.top, 60)  // 52pt top toolbar + 8pt gap
+                    .padding(.trailing, 12)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
         }
+        .statusBarHidden(model.isWatching)
+        .ignoresSafeArea(edges: model.isWatching ? .all : [])
         .onAppear { startTimer() }
         .onDisappear { timer?.invalidate() }
     }

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -49,6 +49,26 @@ private let earlyScript = """
 })();
 """
 
+// Listens for HTML5 video play/pause/ended events anywhere in the page and
+// posts a message to native. Works for inline playback AND fullscreen — both
+// fire `play`/`pause` events on the same <video> element.
+private let videoEventScript = """
+(function() {
+    const post = (kind) => {
+        try { window.webkit.messageHandlers.video.postMessage(kind); } catch(e) {}
+    };
+    const onPlay = (e) => { if (e.target instanceof HTMLVideoElement) post('play'); };
+    const onPause = (e) => { if (e.target instanceof HTMLVideoElement) post('pause'); };
+    const onEnded = (e) => { if (e.target instanceof HTMLVideoElement) post('ended'); };
+    document.addEventListener('play', onPlay, true);
+    document.addEventListener('pause', onPause, true);
+    document.addEventListener('ended', onEnded, true);
+    // Navigating away from a watch page tears down the <video> element
+    // without firing pause. pagehide covers the SPA-back case too.
+    window.addEventListener('pagehide', () => post('pause'));
+})();
+"""
+
 // Runs at document end: DOM removal + debounced MutationObserver
 private let shortsBlockScript = """
 (function() {
@@ -96,6 +116,9 @@ final class WebViewModel {
         )
         config.userContentController.addUserScript(
             WKUserScript(source: shortsBlockScript, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+        )
+        config.userContentController.addUserScript(
+            WKUserScript(source: videoEventScript, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
         )
 
         // Route WKWebView traffic through a local DoH-backed proxy so requests
@@ -147,13 +170,14 @@ struct YouTubeWebView: UIViewRepresentable {
     func updateUIView(_ uiView: WKWebView, context: Context) {}
 
     @MainActor
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         let model: WebViewModel
         private var urlObservation: NSKeyValueObservation?
 
         init(model: WebViewModel) {
             self.model = model
             super.init()
+            model.webView.configuration.userContentController.add(self, name: "video")
             // Catch SPA URL changes (history.pushState / replaceState). decidePolicyFor
             // does NOT fire for these, so YouTube's in-app Home tab tap can sneak past.
             urlObservation = model.webView.observe(\.url, options: [.new]) { [weak self] _, change in
@@ -164,10 +188,40 @@ struct YouTubeWebView: UIViewRepresentable {
             }
         }
 
-        deinit { urlObservation?.invalidate() }
+        deinit {
+            urlObservation?.invalidate()
+            model.webView.configuration.userContentController.removeScriptMessageHandler(forName: "video")
+        }
 
         nonisolated static func isYouTubeHome(_ url: URL) -> Bool {
             (url.host?.hasSuffix("youtube.com") == true) && (url.path.isEmpty || url.path == "/")
+        }
+
+        nonisolated func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard let kind = message.body as? String else { return }
+            Task { @MainActor in
+                switch kind {
+                case "play":
+                    Self.setOrientation(.landscapeRight)
+                case "pause", "ended":
+                    Self.setOrientation(.portrait)
+                default:
+                    break
+                }
+            }
+        }
+
+        @MainActor
+        static func setOrientation(_ mask: UIInterfaceOrientationMask) {
+            AppDelegate.orientationLock = mask
+            for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
+                for window in scene.windows {
+                    window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+                }
+                scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask)) { error in
+                    NSLog("requestGeometryUpdate(\(mask.rawValue)) failed: \(error)")
+                }
+            }
         }
 
         func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction) async -> WKNavigationActionPolicy {

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -87,14 +87,10 @@ final class WebViewModel {
     var isLoading = false
     var canGoBack = false
     var canGoForward = false
-    var isWatching = false
 
     init() {
         let config = WKWebViewConfiguration()
         config.mediaTypesRequiringUserActionForPlayback = .video
-        // Without this, tapping play hands the video to AVPlayerViewController,
-        // whose own orientation handling overrides our AppDelegate gate.
-        config.allowsInlineMediaPlayback = true
         config.userContentController.addUserScript(
             WKUserScript(source: earlyScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         )
@@ -154,6 +150,7 @@ struct YouTubeWebView: UIViewRepresentable {
     final class Coordinator: NSObject, WKNavigationDelegate {
         let model: WebViewModel
         private var urlObservation: NSKeyValueObservation?
+        private var fullscreenObservation: NSKeyValueObservation?
 
         init(model: WebViewModel) {
             self.model = model
@@ -162,25 +159,36 @@ struct YouTubeWebView: UIViewRepresentable {
             // does NOT fire for these, so YouTube's in-app Home tab tap can sneak past.
             urlObservation = model.webView.observe(\.url, options: [.new]) { [weak self] _, change in
                 guard let self, let url = change.newValue ?? nil else { return }
-                let isHome = Self.isYouTubeHome(url)
-                let isWatch = Self.isWatchPage(url)
+                if Self.isYouTubeHome(url) {
+                    Task { @MainActor in self.model.goPlaylists() }
+                }
+            }
+            // Orientation is driven by WebKit fullscreen state, not URL. Entering
+            // video fullscreen (incl. AVPlayerViewController hand-off) → landscape;
+            // exiting → portrait. This is the only signal that reliably tracks
+            // "is the user actually watching a video right now".
+            fullscreenObservation = model.webView.observe(\.fullscreenState, options: [.new]) { _, change in
+                guard let state = change.newValue else { return }
                 Task { @MainActor in
-                    if isHome { self.model.goPlaylists() }
-                    self.model.isWatching = isWatch
-                    if isWatch { Self.setOrientation(.landscapeRight) }
-                    else if !isHome { Self.setOrientation(.portrait) }
+                    switch state {
+                    case .enteringFullscreen, .inFullscreen:
+                        Self.setOrientation(.landscapeRight)
+                    case .exitingFullscreen, .notInFullscreen:
+                        Self.setOrientation(.portrait)
+                    @unknown default:
+                        break
+                    }
                 }
             }
         }
 
-        deinit { urlObservation?.invalidate() }
+        deinit {
+            urlObservation?.invalidate()
+            fullscreenObservation?.invalidate()
+        }
 
         nonisolated static func isYouTubeHome(_ url: URL) -> Bool {
             (url.host?.hasSuffix("youtube.com") == true) && (url.path.isEmpty || url.path == "/")
-        }
-
-        nonisolated static func isWatchPage(_ url: URL) -> Bool {
-            (url.host?.hasSuffix("youtube.com") == true) && url.path.hasPrefix("/watch")
         }
 
         @MainActor
@@ -208,13 +216,6 @@ struct YouTubeWebView: UIViewRepresentable {
             model.isLoading = false
             model.canGoBack = webView.canGoBack
             model.canGoForward = webView.canGoForward
-            // URL KVO can miss SPA back-out from a video; re-assert here too.
-            if let url = webView.url {
-                let isWatch = Self.isWatchPage(url)
-                model.isWatching = isWatch
-                if isWatch { Self.setOrientation(.landscapeRight) }
-                else if !Self.isYouTubeHome(url) { Self.setOrientation(.portrait) }
-            }
         }
 
         func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) { model.isLoading = false }
@@ -232,9 +233,9 @@ struct ContentView: View {
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 0) {
-                if !model.isWatching { topToolbar }
+                topToolbar
                 YouTubeWebView(model: model)
-                if !model.isWatching { bottomToolbar }
+                bottomToolbar
             }
 
             if model.isLoading {
@@ -242,18 +243,14 @@ struct ContentView: View {
                     .progressViewStyle(.linear)
                     .tint(.red)
                     .frame(maxWidth: .infinity)
-                    .padding(.top, model.isWatching ? 0 : 52)
+                    .padding(.top, 52)
             }
 
-            if !model.isWatching {
-                countdownBadge
-                    .padding(.top, 60)  // 52pt top toolbar + 8pt gap
-                    .padding(.trailing, 12)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
-            }
+            countdownBadge
+                .padding(.top, 60)
+                .padding(.trailing, 12)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
-        .statusBarHidden(model.isWatching)
-        .ignoresSafeArea(edges: model.isWatching ? .all : [])
         .onAppear { startTimer() }
         .onDisappear { timer?.invalidate() }
     }

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -140,7 +140,7 @@ struct YouTubeWebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let wv = model.webView
         wv.navigationDelegate = context.coordinator
-        model.goHome()
+        model.goPlaylists()
         return wv
     }
 
@@ -161,9 +161,8 @@ struct YouTubeWebView: UIViewRepresentable {
                 let isHome = Self.isYouTubeHome(url)
                 let isWatch = Self.isWatchPage(url)
                 Task { @MainActor in
-                    if isHome { self.model.goHome() }
+                    if isHome { self.model.goPlaylists() }
                     if isWatch { Self.setOrientation(.landscape) }
-                    else if !isHome { Self.setOrientation(.allButUpsideDown) }
                 }
             }
         }
@@ -187,8 +186,8 @@ struct YouTubeWebView: UIViewRepresentable {
 
         func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction) async -> WKNavigationActionPolicy {
             guard let url = action.request.url else { return .allow }
-            if url.path.hasPrefix("/shorts") { model.goHome(); return .cancel }
-            if Self.isYouTubeHome(url) { model.goHome(); return .cancel }
+            if url.path.hasPrefix("/shorts") { model.goPlaylists(); return .cancel }
+            if Self.isYouTubeHome(url) { model.goPlaylists(); return .cancel }
             return .allow
         }
 

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -162,7 +162,8 @@ struct YouTubeWebView: UIViewRepresentable {
                 let isWatch = Self.isWatchPage(url)
                 Task { @MainActor in
                     if isHome { self.model.goPlaylists() }
-                    if isWatch { Self.setOrientation(.landscape) }
+                    if isWatch { Self.setOrientation(.landscapeRight) }
+                    else if !isHome { Self.setOrientation(.portrait) }
                 }
             }
         }

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -180,8 +180,10 @@ struct YouTubeWebView: UIViewRepresentable {
 
         @MainActor
         static func setOrientation(_ mask: UIInterfaceOrientationMask) {
+            AppDelegate.orientationLock = mask
             for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
                 scene.requestGeometryUpdate(.iOS(interfaceOrientations: mask))
+                scene.windows.first?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
             }
         }
 

--- a/NoShorts/NoShorts/NoShortsApp.swift
+++ b/NoShorts/NoShorts/NoShortsApp.swift
@@ -8,9 +8,8 @@ import UIKit
 
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-    // Source of truth for which orientations iOS will rotate to.
-    // Updated by ContentView as the user navigates between watch pages
-    // (landscape) and everything else (portrait).
+    // Lock for our own app window (browsing chrome). The AVPlayerViewController
+    // window is handled separately in supportedInterfaceOrientationsFor below.
     static var orientationLock: UIInterfaceOrientationMask = .portrait
 
     var window: UIWindow?
@@ -23,6 +22,22 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         window.rootViewController = OrientedHostingController(rootView: ContentView())
         window.makeKeyAndVisible()
         self.window = window
+
+        // When AVPlayerViewController dismisses its own UIWindow, force our
+        // window back to portrait. Without this nudge, iOS leaves us in
+        // whatever orientation the player ended in.
+        NotificationCenter.default.addObserver(
+            forName: UIWindow.didBecomeHiddenNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let win = note.object as? UIWindow, AppDelegate.isVideoFullscreenWindow(win) else { return }
+            self?.window?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+            for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
+                scene.requestGeometryUpdate(.iOS(interfaceOrientations: .portrait))
+            }
+        }
+
         return true
     }
 
@@ -30,7 +45,22 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         supportedInterfaceOrientationsFor window: UIWindow?
     ) -> UIInterfaceOrientationMask {
-        AppDelegate.orientationLock
+        // AVPlayerViewController presents in a separate UIWindow. iOS asks the
+        // AppDelegate for that window's mask — return a single landscape so the
+        // player can't rotate between left/right via the device sensor.
+        if AppDelegate.isVideoFullscreenWindow(window) {
+            return .landscapeRight
+        }
+        return AppDelegate.orientationLock
+    }
+
+    // The fullscreen video window's class name on iOS varies by version
+    // (AVFullScreenWindow, _UIRemoteKeyboardWindow-style internals, etc.) but
+    // reliably contains "Fullscreen" or "AVPlayer" — match loosely.
+    static func isVideoFullscreenWindow(_ window: UIWindow?) -> Bool {
+        guard let window else { return false }
+        let name = String(describing: type(of: window))
+        return name.contains("Fullscreen") || name.contains("AVPlayer")
     }
 }
 

--- a/NoShorts/NoShorts/NoShortsApp.swift
+++ b/NoShorts/NoShorts/NoShortsApp.swift
@@ -7,77 +7,22 @@ import SwiftUI
 import UIKit
 
 @main
-final class AppDelegate: UIResponder, UIApplicationDelegate {
-    // Lock for our own app window (browsing chrome). The AVPlayerViewController
-    // window is handled separately in supportedInterfaceOrientationsFor below.
-    static var orientationLock: UIInterfaceOrientationMask = .portrait
-
-    var window: UIWindow?
-
-    func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-    ) -> Bool {
-        let window = UIWindow(frame: UIScreen.main.bounds)
-        window.rootViewController = OrientedHostingController(rootView: ContentView())
-        window.makeKeyAndVisible()
-        self.window = window
-
-        // When AVPlayerViewController dismisses its own UIWindow, force our
-        // window back to portrait. Without this nudge, iOS leaves us in
-        // whatever orientation the player ended in.
-        NotificationCenter.default.addObserver(
-            forName: UIWindow.didBecomeHiddenNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
-            guard let win = note.object as? UIWindow, AppDelegate.isVideoFullscreenWindow(win) else { return }
-            self?.window?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
-            for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
-                scene.requestGeometryUpdate(.iOS(interfaceOrientations: .portrait))
-            }
-        }
-
-        return true
+struct NoShortsApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    var body: some Scene {
+        WindowGroup { ContentView() }
     }
+}
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    // Source of truth for the orientation iOS will rotate to / hold at.
+    // Updated by the JS-driven video-play/pause handler in ContentView.
+    static var orientationLock: UIInterfaceOrientationMask = .portrait
 
     func application(
         _ application: UIApplication,
         supportedInterfaceOrientationsFor window: UIWindow?
     ) -> UIInterfaceOrientationMask {
-        // AVPlayerViewController presents in a separate UIWindow. iOS asks the
-        // AppDelegate for that window's mask — return a single landscape so the
-        // player can't rotate between left/right via the device sensor.
-        if AppDelegate.isVideoFullscreenWindow(window) {
-            return .landscapeRight
-        }
-        return AppDelegate.orientationLock
-    }
-
-    // The fullscreen video window's class name on iOS varies by version
-    // (AVFullScreenWindow, _UIRemoteKeyboardWindow-style internals, etc.) but
-    // reliably contains "Fullscreen" or "AVPlayer" — match loosely.
-    static func isVideoFullscreenWindow(_ window: UIWindow?) -> Bool {
-        guard let window else { return false }
-        let name = String(describing: type(of: window))
-        return name.contains("Fullscreen") || name.contains("AVPlayer")
-    }
-}
-
-// SwiftUI's default UIHostingController returns .all for supportedInterfaceOrientations,
-// which makes iOS follow the device sensor regardless of what the AppDelegate says.
-// Subclassing and deferring to AppDelegate.orientationLock pins the orientation.
-final class OrientedHostingController<Content: View>: UIHostingController<Content> {
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         AppDelegate.orientationLock
-    }
-
-    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-        switch AppDelegate.orientationLock {
-        case .landscapeRight: return .landscapeRight
-        case .landscapeLeft: return .landscapeLeft
-        case .portrait: return .portrait
-        default: return .portrait
-        }
     }
 }

--- a/NoShorts/NoShorts/NoShortsApp.swift
+++ b/NoShorts/NoShorts/NoShortsApp.swift
@@ -6,12 +6,24 @@
 //
 
 import SwiftUI
+import UIKit
 
 @main
 struct NoShortsApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+    }
+}
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    // Source of truth for which orientations iOS will rotate to. Updated by
+    // ContentView when navigating between watch and non-watch pages.
+    static var orientationLock: UIInterfaceOrientationMask = .portrait
+
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        AppDelegate.orientationLock
     }
 }

--- a/NoShorts/NoShorts/NoShortsApp.swift
+++ b/NoShorts/NoShorts/NoShortsApp.swift
@@ -32,23 +32,11 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
             object: nil,
             queue: .main
         ) { note in
-            let window = note.object as? UIWindow
-            let cls = window.map { String(describing: type(of: $0)) } ?? "nil"
-            NSLog("NoShorts.window didBecomeVisible class=\(cls) lock=\(AppDelegate.orientationLock.rawValue)")
-            guard let scene = window?.windowScene else { return }
-            window?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+            guard let window = note.object as? UIWindow, let scene = window.windowScene else { return }
+            window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
             scene.requestGeometryUpdate(.iOS(interfaceOrientations: AppDelegate.orientationLock)) { error in
-                NSLog("NoShorts.window didBecomeVisible geometryUpdate failed: \(error)")
+                NSLog("NoShorts.didBecomeVisible geometryUpdate failed: \(error)")
             }
-        }
-        NotificationCenter.default.addObserver(
-            forName: UIWindow.didBecomeHiddenNotification,
-            object: nil,
-            queue: .main
-        ) { note in
-            let window = note.object as? UIWindow
-            let cls = window.map { String(describing: type(of: $0)) } ?? "nil"
-            NSLog("NoShorts.window didBecomeHidden class=\(cls) lock=\(AppDelegate.orientationLock.rawValue)")
         }
         return true
     }
@@ -57,8 +45,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         supportedInterfaceOrientationsFor window: UIWindow?
     ) -> UIInterfaceOrientationMask {
-        let cls = window.map { String(describing: type(of: $0)) } ?? "nil"
-        NSLog("NoShorts.supportedOrientations window=\(cls) returning=\(AppDelegate.orientationLock.rawValue)")
-        return AppDelegate.orientationLock
+        AppDelegate.orientationLock
     }
 }

--- a/NoShorts/NoShorts/NoShortsApp.swift
+++ b/NoShorts/NoShorts/NoShortsApp.swift
@@ -21,8 +21,44 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
     func application(
         _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        // When a new window becomes visible (e.g. AVPlayerViewController) and a
+        // video is playing, re-assert landscape on its scene. iOS doesn't
+        // automatically apply our existing geometry preference to a freshly
+        // presented window.
+        NotificationCenter.default.addObserver(
+            forName: UIWindow.didBecomeVisibleNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            let window = note.object as? UIWindow
+            let cls = window.map { String(describing: type(of: $0)) } ?? "nil"
+            NSLog("NoShorts.window didBecomeVisible class=\(cls) lock=\(AppDelegate.orientationLock.rawValue)")
+            guard let scene = window?.windowScene else { return }
+            window?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+            scene.requestGeometryUpdate(.iOS(interfaceOrientations: AppDelegate.orientationLock)) { error in
+                NSLog("NoShorts.window didBecomeVisible geometryUpdate failed: \(error)")
+            }
+        }
+        NotificationCenter.default.addObserver(
+            forName: UIWindow.didBecomeHiddenNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            let window = note.object as? UIWindow
+            let cls = window.map { String(describing: type(of: $0)) } ?? "nil"
+            NSLog("NoShorts.window didBecomeHidden class=\(cls) lock=\(AppDelegate.orientationLock.rawValue)")
+        }
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
         supportedInterfaceOrientationsFor window: UIWindow?
     ) -> UIInterfaceOrientationMask {
-        AppDelegate.orientationLock
+        let cls = window.map { String(describing: type(of: $0)) } ?? "nil"
+        NSLog("NoShorts.supportedOrientations window=\(cls) returning=\(AppDelegate.orientationLock.rawValue)")
+        return AppDelegate.orientationLock
     }
 }

--- a/NoShorts/NoShorts/NoShortsApp.swift
+++ b/NoShorts/NoShorts/NoShortsApp.swift
@@ -2,28 +2,52 @@
 //  NoShortsApp.swift
 //  NoShorts
 //
-//  Created by Amit Butala on 4/26/26.
-//
 
 import SwiftUI
 import UIKit
 
 @main
-struct NoShortsApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    // Source of truth for which orientations iOS will rotate to.
+    // Updated by ContentView as the user navigates between watch pages
+    // (landscape) and everything else (portrait).
+    static var orientationLock: UIInterfaceOrientationMask = .portrait
+
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = OrientedHostingController(rootView: ContentView())
+        window.makeKeyAndVisible()
+        self.window = window
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        supportedInterfaceOrientationsFor window: UIWindow?
+    ) -> UIInterfaceOrientationMask {
+        AppDelegate.orientationLock
     }
 }
 
-final class AppDelegate: NSObject, UIApplicationDelegate {
-    // Source of truth for which orientations iOS will rotate to. Updated by
-    // ContentView when navigating between watch and non-watch pages.
-    static var orientationLock: UIInterfaceOrientationMask = .portrait
-
-    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+// SwiftUI's default UIHostingController returns .all for supportedInterfaceOrientations,
+// which makes iOS follow the device sensor regardless of what the AppDelegate says.
+// Subclassing and deferring to AppDelegate.orientationLock pins the orientation.
+final class OrientedHostingController<Content: View>: UIHostingController<Content> {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         AppDelegate.orientationLock
+    }
+
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        switch AppDelegate.orientationLock {
+        case .landscapeRight: return .landscapeRight
+        case .landscapeLeft: return .landscapeLeft
+        case .portrait: return .portrait
+        default: return .portrait
+        }
     }
 }


### PR DESCRIPTION
## Why
Two fixes for an in-bed YouTube-watching workflow:
1. The app landed on Subscriptions; Playlists is the more natural entry point.
2. While watching a video, orientation flopped between landscape-left and landscape-right with the device sensor — exactly what you don't want lying down — and the app got stuck in landscape after exiting back to list pages.

## Impact
- App opens directly into Playlists.
- App is locked to portrait while browsing.
- When any `<video>` plays (inline or fullscreen, including YouTube's hand-off to AVPlayerViewController), orientation snaps to a single fixed `.landscapeRight` and stays there — no sensor flop.
- When the video pauses, ends, or the user navigates away from the watch page, orientation returns to portrait.

## Changes
- `goHome()` (Subscriptions) is no longer the default. Initial load and `/shorts`/YouTube-home redirects route to `goPlaylists()`. Subscriptions remains accessible via the top-toolbar grid icon.
- App lifecycle: SwiftUI `App` + `@UIApplicationDelegateAdaptor`, scene-compatible (resolves the iOS 26 "UIScene lifecycle will soon be required" warning).
- `AppDelegate.orientationLock` + `application(_:supportedInterfaceOrientationsFor:)` enforces the active mask system-wide.
- `UIWindow.didBecomeVisibleNotification` re-asserts the lock when a new window appears (e.g. AVPlayerViewController presents mid-play) — iOS doesn't auto-apply the existing geometry preference to a freshly-presented window.
- JS injection (`videoEventScript`) listens for `play`/`pause`/`ended`/`pagehide` on every `<video>` and posts to native via `webkit.messageHandlers.video`. The Coordinator is a `WKScriptMessageHandler`; on `play` → `setOrientation(.landscapeRight)`, on `pause`/`ended`/`pagehide` → `.portrait`.
- `setOrientation` walks every scene + window, calls `setNeedsUpdateOfSupportedInterfaceOrientations`, then `requestGeometryUpdate` with an error-only failure log so future regressions are visible.

## Architecture / Call flow

```mermaid
sequenceDiagram
    participant JS as videoEventScript (JS)
    participant Coord as Coordinator<br/>(WKScriptMessageHandler)
    participant App as AppDelegate
    participant iOS as iOS / WindowScene

    JS->>Coord: postMessage("play")
    Coord->>App: orientationLock = .landscapeRight
    Coord->>iOS: setNeedsUpdate + requestGeometryUpdate(.landscapeRight)
    iOS->>App: supportedInterfaceOrientationsFor(window)
    App-->>iOS: .landscapeRight
    iOS->>iOS: rotate to landscapeRight (locked)

    Note over iOS: Later: AVPlayerViewController presents in new UIWindow
    iOS->>App: didBecomeVisibleNotification
    App->>iOS: setNeedsUpdate + requestGeometryUpdate(orientationLock)
    iOS->>App: supportedInterfaceOrientationsFor(avWindow)
    App-->>iOS: .landscapeRight
    iOS->>iOS: AV player locked to landscapeRight

    JS->>Coord: postMessage("pause" / "ended" / "pagehide")
    Coord->>App: orientationLock = .portrait
    Coord->>iOS: setNeedsUpdate + requestGeometryUpdate(.portrait)
    iOS->>iOS: rotate back to portrait
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)