### PR TITLE
fix(NodeCheck): myLink recv must parse-on-receive, not wait for newline

### DIFF
--- a/NodeCheck/nodes.py
+++ b/NodeCheck/nodes.py
@@ -128,21 +128,34 @@ class SomfyMyLinkNode(GenericNode):
             + "\n"
         ).encode()
 
+        # myLink replies with one JSON object then keeps the connection open (no
+        # newline / FIN). Parse incrementally and stop on first complete object —
+        # waiting for a delimiter or EOF would block until socket timeout.
         try:
             with socket.create_connection(
                 (self.config.ip, port), timeout=self.RPC_TIMEOUT_S
             ) as sock:
                 sock.settimeout(self.RPC_TIMEOUT_S)
                 sock.sendall(request)
-                # myLink may write the payload across multiple packets; read until newline.
                 buf = b""
-                while b"\n" not in buf:
+                response: dict | None = None
+                while True:
                     chunk = sock.recv(4096)
                     if not chunk:
-                        break
+                        break  # server closed
                     buf += chunk
-            response = json.loads(buf.decode().strip())
-        except (OSError, json.JSONDecodeError) as e:
+                    try:
+                        response = json.loads(buf.decode())
+                        break  # got a complete object
+                    except json.JSONDecodeError:
+                        continue  # partial — keep reading
+            if response is None:
+                logger.warning(
+                    f"{self.name}: myLink API check failed: incomplete response ({len(buf)} bytes)"
+                )
+                self.is_online = False
+                return False
+        except OSError as e:
             logger.warning(f"{self.name}: myLink API check failed: {e!r}")
             self.is_online = False
             return False

--- a/NodeCheck/test_nodes.py
+++ b/NodeCheck/test_nodes.py
@@ -279,6 +279,61 @@ class TestSomfyMyLinkNode:
 
     @patch("NodeCheck.nodes.socket.create_connection")
     @patch("NodeCheck.nodes.NetHelpers.ping_output")
+    def test_heartbeat_success_when_server_keeps_connection_open(
+        self, mock_ping: Any, mock_conn: Any, mylink_node: SomfyMyLinkNode
+    ) -> None:
+        """Real myLink behavior: replies with JSON, no newline, doesn't close. Parse-on-receive
+        must break on the first complete object — a delimiter-wait would block until timeout."""
+        mock_ping.return_value = True
+        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"targetID": "CC113EA8"}})
+        sock = MagicMock()
+        # First recv returns the full payload; any further recv would block forever — simulate
+        # by raising timeout. If the implementation correctly breaks on parse, recv is never
+        # called a second time and the timeout never fires.
+        sock.recv.side_effect = [payload.encode(), socket.timeout("would block")]
+        sock.__enter__ = MagicMock(return_value=sock)
+        sock.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = sock
+
+        assert mylink_node.heartbeat() is True
+        assert sock.recv.call_count == 1  # second call would have blocked
+
+    @patch("NodeCheck.nodes.socket.create_connection")
+    @patch("NodeCheck.nodes.NetHelpers.ping_output")
+    def test_heartbeat_success_payload_split_across_recv_calls(
+        self, mock_ping: Any, mock_conn: Any, mylink_node: SomfyMyLinkNode
+    ) -> None:
+        """Payload arrives in two chunks -> first parse fails, second succeeds"""
+        mock_ping.return_value = True
+        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"targetID": "X"}})
+        # Split mid-object so the first chunk is unparseable JSON
+        split = len(payload) // 2
+        sock = MagicMock()
+        sock.recv.side_effect = [payload[:split].encode(), payload[split:].encode()]
+        sock.__enter__ = MagicMock(return_value=sock)
+        sock.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = sock
+
+        assert mylink_node.heartbeat() is True
+        assert sock.recv.call_count == 2
+
+    @patch("NodeCheck.nodes.socket.create_connection")
+    @patch("NodeCheck.nodes.NetHelpers.ping_output")
+    def test_heartbeat_incomplete_then_eof(
+        self, mock_ping: Any, mock_conn: Any, mylink_node: SomfyMyLinkNode
+    ) -> None:
+        """Server sends partial JSON then closes -> heartbeat returns False (no crash)"""
+        mock_ping.return_value = True
+        sock = MagicMock()
+        sock.recv.side_effect = [b'{"jsonrpc":"2.0"', b""]  # truncated, then EOF
+        sock.__enter__ = MagicMock(return_value=sock)
+        sock.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = sock
+
+        assert mylink_node.heartbeat() is False
+
+    @patch("NodeCheck.nodes.socket.create_connection")
+    @patch("NodeCheck.nodes.NetHelpers.ping_output")
     def test_heartbeat_api_error_response(
         self, mock_ping: Any, mock_conn: Any, mylink_node: SomfyMyLinkNode
     ) -> None:


### PR DESCRIPTION
## Summary

Hotfix for PR #167. The real myLink JSON-RPC server replies with one JSON object and keeps the TCP connection open — no newline terminator, no FIN. My original \`while b\"\\n\" not in buf: recv()\` loop hung on the next recv() until the 4s socket timeout fired, causing every API check to false-positive even when the device was healthy.

**Root cause confirmed via netcat against the real device**:
\`\`\`
$ echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"mylink.status.info\",\"params\":{\"auth\":\"...\"}}' | nc -w 4 192.168.1.43 44100
{\"jsonrpc\":\"2.0\",\"result\":{\"targetID\":\"CC113EA8\",\"name\":\"Eden Awning:27\",...,\"type\":\"myLink\"},\"id\":1}
\`\`\`
Response ends with \`}\` — no \`\\n\`. The server holds the socket open afterwards.

## Fix

Parse-on-receive: try \`json.loads\` after every chunk; break on first complete object. Two failure modes still handled:
- Server closes mid-response → \`recv()\` returns \`b\"\"\` → exit loop, log \"incomplete response\", return False
- Socket timeout → \`OSError\` caught, log + return False

## Test plan

- [x] Existing 6 \`TestSomfyMyLinkNode\` tests still pass
- [x] **2 new tests**:
  - \`test_heartbeat_success_when_server_keeps_connection_open\` — mocks the exact real-world behavior (first recv returns full payload, second recv would block forever). Asserts \`recv\` is called exactly once.
  - \`test_heartbeat_success_payload_split_across_recv_calls\` — payload split mid-JSON across two chunks; first parse fails, second succeeds.
- [x] \`uv run pytest NodeCheck\` → **26/26 pass**
- [x] \`make ruff\` + \`make mypy\` → clean
- [x] **Live smoke test against the real myLink** (\`--poll 30 --cooloff 60\`, 3 cycles):
  \`\`\`
  23:03:12  All nodes healthy: Somfy Awning Remote
  23:03:45  All nodes healthy: Somfy Awning Remote
  23:04:17  All nodes healthy: Somfy Awning Remote
  \`\`\`
  Zero pages, ~2.5s/cycle (ping + JSON-RPC combined). No timeouts.

## References

- Predecessor: PR #167 (introduced \`SomfyMyLinkNode\` with the buggy recv loop)
- Smoke test log: \`/tmp/heartbeat-somfy-4.log\`
- Diagnostic netcat probe: confirmed the wire-level mismatch before changing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)