### PR TITLE
feat(RachioFlume): switch alert predicate from strict to mean, add DB replay + remote test loop

### DIFF
--- a/RachioFlume/README.md
+++ b/RachioFlume/README.md
@@ -140,6 +140,36 @@ uv run python -m RachioFlume.rfmanager alerts mute "Pipe Break" --hours 4
 uv run python -m RachioFlume.rfmanager alerts unmute "Pipe Break"
 ```
 
+### 🔁 DB Replay — validate rules against real data
+
+Replay production `water_readings` through the alert engine without hitting the
+Flume/Rachio APIs or sending Pushover. Useful for tuning predicates.
+
+```bash
+# Replay last 24 hours of production data (default)
+uv run python -m RachioFlume.rfmanager alerts replay
+
+# Replay last 7 days
+uv run python -m RachioFlume.rfmanager alerts replay --hours 168
+```
+
+### 🌐 Remote test loop on omega
+
+Build locally, test remotely — without touching the running prod collector.
+
+```bash
+# From a feature branch on your local machine
+./RachioFlume/scripts/remote-test.sh                                  # push + deploy + live dry-run + 24h replay
+./RachioFlume/scripts/remote-test.sh --replay-hours 168                # replay 7 days instead of 24h
+./RachioFlume/scripts/remote-test.sh --hot                             # restart prod collector after tests
+```
+
+One-time setup on omega (uses `~/Code-test` so prod `~/Code` is safe):
+```bash
+ssh omega "git clone https://github.com/DeviationLabs/homely-vibes ~/Code-test && cd ~/Code-test && uv sync --quiet"
+ssh omega "ln -sf ~/Code/config/local.yaml ~/Code-test/config/local.yaml"
+```
+
 ### 🧪 Synthetic Simulator
 
 Replay a hand-crafted scenario through the engine — no real APIs, no Pushover,

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -94,30 +94,19 @@ class AlertEngine:
         self.rules = rules
         self.logger = get_logger(__name__)
 
-    # ------------------------------------------------------------------ #
-    # USER CONTRIBUTION SLOT 1: predicate semantics                       #
-    # ------------------------------------------------------------------ #
-    # Given the last `duration_minutes` of per-minute Flume readings,
-    # decide if the rule's condition is currently active.
-    #
-    # Trade-offs to consider:
-    #   - STRICT (every minute >= min_gpm): avoids momentary-spike false
-    #     positives. Default below.
-    #   - AVERAGE (mean of window >= min_gpm): forgiving of one bad minute.
-    #   - MISSING MINUTES: Flume can drop a sample. Treat as 0 (conservative)
-    #     vs previous-value (avoids false negatives). Default treats missing
-    #     minutes as failing the predicate (we have < duration_minutes samples
-    #     => not enough data to fire).
-    #   - LOW-FLOW RULES (min_gpm ~0.1): "water running" = any reading above
-    #     a noise floor. Default handles this by parameterizing min_gpm.
-    #
-    # If you want different semantics, edit this method only.
     def _rule_matches(self, readings: list[WaterReading], rule: AlertRule) -> bool:
-        """Return True if `readings` indicate `rule`'s condition is active."""
+        """Return True if the mean flow over the trailing window meets the rule threshold.
+
+        Using mean (not strict all-minutes) so that one or two zero-reading minutes from
+        Flume's sampling cadence don't disqualify an otherwise sustained flow event. A real
+        leak or pipe break will still average well above its threshold; a momentary spike
+        among mostly-zero minutes will not.
+        """
         if len(readings) < rule.duration_minutes:
             return False
         recent = readings[-rule.duration_minutes :]
-        return all(r.value >= rule.min_gpm for r in recent)
+        mean_gpm = sum(r.value for r in recent) / len(recent)
+        return mean_gpm >= rule.min_gpm
 
     # ------------------------------------------------------------------ #
     # USER CONTRIBUTION SLOT 2: fire/clear state machine                  #

--- a/RachioFlume/rfmanager.py
+++ b/RachioFlume/rfmanager.py
@@ -102,6 +102,25 @@ def main() -> int:
     alerts_sub = alerts_parser.add_subparsers(dest="alerts_command", help="Alert subcommands")
     alerts_sub.add_parser("test", help="Dry-run evaluate all rules (no Pushover sent)")
     alerts_sub.add_parser("status", help="Show per-rule state")
+    replay_parser = alerts_sub.add_parser(
+        "replay",
+        help="Replay last N hours of production DB through alert rules (no Pushover)",
+    )
+    replay_parser.add_argument(
+        "--hours", type=int, default=24, help="Hours of history to replay (default: 24)"
+    )
+    replay_parser.add_argument(
+        "--poll-interval",
+        type=int,
+        default=5,
+        help="Simulated poll cadence in minutes (default: 5)",
+    )
+    replay_parser.add_argument(
+        "--db",
+        type=str,
+        default=None,
+        help="Path to SQLite DB (default: production DB from config)",
+    )
     mute_parser = alerts_sub.add_parser("mute", help="Mute a rule for N hours")
     mute_parser.add_argument("rule", help="Rule name (e.g. 'Pipe Break')")
     mute_parser.add_argument("--hours", type=float, default=4.0, help="Mute duration (default 4h)")
@@ -295,12 +314,23 @@ def run_simulate_command(args: argparse.Namespace) -> int:
 
 
 def run_alerts_command(args: argparse.Namespace) -> int:
-    """Dispatch the `alerts` subcommands (test/status/mute/unmute)."""
+    """Dispatch the `alerts` subcommands (test/status/replay/mute/unmute)."""
     logger = get_logger(__name__)
 
     if not args.alerts_command:
-        logger.error("alerts: subcommand required (test|status|mute|unmute)")
+        logger.error("alerts: subcommand required (test|status|replay|mute|unmute)")
         return 1
+
+    if args.alerts_command == "replay":
+        from RachioFlume.simulate_alerts import run_replay
+
+        run_replay(
+            args.db or DB_PATH,
+            args.hours,
+            rules=load_rules_from_config(),
+            poll_interval_minutes=args.poll_interval,
+        )
+        return 0
 
     engine = _build_alert_engine()
 

--- a/RachioFlume/scripts/remote-test.sh
+++ b/RachioFlume/scripts/remote-test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# remote-test.sh — pull prod DB from omega, replay locally.
+#
+# Usage (run from repo root on a feature branch):
+#   ./RachioFlume/scripts/remote-test.sh                       # scp DB + 24h replay
+#   ./RachioFlume/scripts/remote-test.sh --replay-hours 168     # replay last 7 days
+#
+# Requires:
+#   - SSH access to omega
+#   - Config with alert rules (config/default.yaml or config/local.yaml)
+
+set -euo pipefail
+
+REPLAY_HOURS=24
+DB_REMOTE="$HOME/logs/water_tracking.db"
+DB_LOCAL="/tmp/rachioflume_replay.db"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --replay-hours) REPLAY_HOURS="$2"; shift 2 ;;
+        --db-remote)    DB_REMOTE="$2";   shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+echo "==================================================================="
+echo "Remote test: pulling DB from omega, replaying ${REPLAY_HOURS}h locally"
+echo "==================================================================="
+
+echo ""
+echo "--- Copying production DB from omega ---"
+scp "omega:${DB_REMOTE}" "$DB_LOCAL"
+DB_SIZE=$(du -h "$DB_LOCAL" | cut -f1)
+echo "  Downloaded (${DB_SIZE})"
+
+echo ""
+echo "--- Running replay against local copy ---"
+uv run python -m RachioFlume.rfmanager alerts replay \
+    --db "$DB_LOCAL" \
+    --hours "$REPLAY_HOURS"
+
+rm -f "$DB_LOCAL"
+echo ""
+echo "==================================================================="
+echo "Done. Temp DB cleaned up."
+echo "==================================================================="

--- a/RachioFlume/simulate_alerts.py
+++ b/RachioFlume/simulate_alerts.py
@@ -1,7 +1,16 @@
-"""Simulator: replay a synthetic dataset through the AlertEngine.
+"""Simulator: replay a dataset through the AlertEngine.
 
-No Pushover, no real Flume / Rachio calls. Each step prints events to stdout.
-Used both by the `rfmanager simulate` CLI and by test_alert_simulation.py.
+Two data sources are supported:
+  - SyntheticDataset (from synthetic_data.py): hand-crafted YAML scenarios for testing.
+  - DBReplayDataset: production water_readings + watering_events from a real SQLite DB.
+
+Both data sources implement the same duck-typed interface:
+  .start, .end (datetime), .days (int), .events (list, empty = no injected events)
+  .readings_for_window(start, end) -> list[WaterReading]
+  .rachio_active_at(t) -> Zone | None
+
+No Pushover, no real Flume / Rachio calls during simulation. Events print to stdout.
+Used by the `rfmanager simulate` / `rfmanager alerts replay` CLI and by test_alert_simulation.py.
 """
 
 import asyncio
@@ -10,14 +19,14 @@ import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from RachioFlume.alert_engine import AlertEngine
 from RachioFlume.alert_rules import AlertRule, load_rules_from_config
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import WaterReading
 from RachioFlume.rachio_client import Zone
-from RachioFlume.synthetic_data import SyntheticDataset, load_dataset_from_yaml
+from RachioFlume.synthetic_data import load_dataset_from_yaml
 
 
 @dataclass
@@ -31,22 +40,22 @@ class CapturedPush:
 
 
 class _FakeFlume:
-    def __init__(self, dataset: SyntheticDataset) -> None:
+    def __init__(self, dataset: Any) -> None:  # SyntheticDataset or DBReplayDataset
         self.dataset = dataset
 
     def get_usage(self, start: datetime, end: datetime, bucket: str = "MIN") -> list[WaterReading]:
-        return self.dataset.readings_for_window(start, end)
+        return self.dataset.readings_for_window(start, end)  # type: ignore[no-any-return]
 
 
 class _FakeRachio:
-    def __init__(self, dataset: SyntheticDataset) -> None:
+    def __init__(self, dataset: Any) -> None:  # SyntheticDataset or DBReplayDataset
         self.dataset = dataset
         self.current_time: Optional[datetime] = None
 
     def get_active_zone(self) -> Optional[Zone]:
         if self.current_time is None:
             return None
-        return self.dataset.rachio_active_at(self.current_time)
+        return self.dataset.rachio_active_at(self.current_time)  # type: ignore[no-any-return]
 
 
 class _CapturingPushover:
@@ -69,7 +78,7 @@ class _CapturingPushover:
 
 @dataclass
 class SimulationResult:
-    dataset: SyntheticDataset
+    dataset: Any  # SyntheticDataset or DBReplayDataset
     rules: list[AlertRule]
     fires: list[CapturedPush] = field(default_factory=list)
     suppressed_count: int = 0
@@ -77,7 +86,7 @@ class SimulationResult:
 
 
 async def run_simulation(
-    dataset: SyntheticDataset,
+    dataset: Any,  # SyntheticDataset or DBReplayDataset (duck-typed interface)
     rules: list[AlertRule],
     *,
     poll_interval_minutes: int = 5,
@@ -147,7 +156,7 @@ async def run_simulation(
     return result
 
 
-def _print_header(dataset: SyntheticDataset, rules: list[AlertRule], poll_minutes: int) -> None:
+def _print_header(dataset: Any, rules: list[AlertRule], poll_minutes: int) -> None:
     print("=" * 72)
     print(
         f"Simulation: {dataset.days} days from {dataset.start:%Y-%m-%d}  "
@@ -161,12 +170,18 @@ def _print_header(dataset: SyntheticDataset, rules: list[AlertRule], poll_minute
             f"window={r.duration_minutes:>4}min  retrigger={r.retrigger_minutes}min"
         )
     print("-" * 72)
-    print("Events injected:")
-    for ev in dataset.events:
-        zone = f" [rachio:{ev.irrigation_zone.name}]" if ev.irrigation_zone else ""
+    if dataset.events:
+        print("Events injected:")
+        for ev in dataset.events:
+            zone = f" [rachio:{ev.irrigation_zone.name}]" if ev.irrigation_zone else ""
+            print(
+                f"  {ev.start:%Y-%m-%d %H:%M}  {ev.label:<22}  "
+                f"{ev.duration_minutes:>5}min @ {ev.gpm:>4} gpm{zone}"
+            )
+    else:
         print(
-            f"  {ev.start:%Y-%m-%d %H:%M}  {ev.label:<22}  "
-            f"{ev.duration_minutes:>5}min @ {ev.gpm:>4} gpm{zone}"
+            f"Data source: production DB  "
+            f"[{dataset.start:%Y-%m-%d %H:%M} \u2192 {dataset.end:%Y-%m-%d %H:%M}]"
         )
     print("-" * 72)
     print("Alerts fired (priority 2 = FIRE; priority 0 = CLEAR):")
@@ -215,9 +230,96 @@ def run_simulation_from_yaml(
     )
 
 
+class DBReplayDataset:
+    """Replay dataset backed by the production SQLite DB (water_readings + watering_events).
+
+    Implements the same duck-typed interface as SyntheticDataset so it can be passed
+    directly to run_simulation(). Rachio active state is approximated from the stored
+    watering events: a zone is considered active at time `t` if there is a ZONE_STARTED
+    event before `t` with no corresponding ZONE_COMPLETED/ZONE_STOPPED after it and before `t`.
+    """
+
+    def __init__(self, db: WaterTrackingDB, start: datetime, end: datetime) -> None:
+        self.db = db
+        self.start = start
+        self.end = end
+        self.events: list[Any] = []  # no injected events; header shows DB range instead
+
+    @property
+    def days(self) -> int:
+        return max(1, int((self.end - self.start).total_seconds() / 86400))
+
+    def readings_for_window(self, start: datetime, end: datetime) -> list[WaterReading]:
+        with self.db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT timestamp, value FROM water_readings "
+                "WHERE timestamp >= ? AND timestamp < ? ORDER BY timestamp",
+                (start.strftime("%Y-%m-%d %H:%M:%S"), end.strftime("%Y-%m-%d %H:%M:%S")),
+            )
+            return [
+                WaterReading(
+                    timestamp=datetime.fromisoformat(str(row["timestamp"])),
+                    value=float(row["value"]),
+                )
+                for row in cursor.fetchall()
+            ]
+
+    def rachio_active_at(self, t: datetime) -> Optional[Zone]:
+        with self.db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT zone_name, zone_number FROM watering_events\n"
+                "WHERE event_type = 'ZONE_STARTED' AND event_date <= ?\n"
+                "AND NOT EXISTS (\n"
+                "    SELECT 1 FROM watering_events we2\n"
+                "    WHERE we2.zone_number = watering_events.zone_number\n"
+                "      AND we2.event_type IN ('ZONE_COMPLETED', 'ZONE_STOPPED')\n"
+                "      AND we2.event_date > watering_events.event_date\n"
+                "      AND we2.event_date <= ?\n"
+                ")\n"
+                "ORDER BY event_date DESC LIMIT 1",
+                (t.strftime("%Y-%m-%d %H:%M:%S"), t.strftime("%Y-%m-%d %H:%M:%S")),
+            )
+            row = cursor.fetchone()
+            if row:
+                return Zone(
+                    id=f"z-{row['zone_number']}",
+                    zone_number=row["zone_number"],
+                    name=row["zone_name"],
+                    enabled=True,
+                )
+            return None
+
+
+def run_replay(
+    db_path: str,
+    hours: int,
+    rules: list[AlertRule],
+    *,
+    poll_interval_minutes: int = 5,
+) -> SimulationResult:
+    """Replay the last `hours` hours of production DB data through the alert engine.
+
+    Runs entirely offline: no Flume/Rachio API calls, no Pushover.
+    Useful for validating predicate changes against real household water patterns.
+    """
+    db = WaterTrackingDB(db_path)
+    end = datetime.now()
+    start = end - timedelta(hours=hours)
+    dataset = DBReplayDataset(db=db, start=start, end=end)
+    return asyncio.run(
+        run_simulation(
+            dataset, rules, poll_interval_minutes=poll_interval_minutes, print_events=True
+        )
+    )
+
+
 __all__ = [
     "CapturedPush",
+    "DBReplayDataset",
     "SimulationResult",
+    "run_replay",
     "run_simulation",
     "run_simulation_from_yaml",
 ]

--- a/RachioFlume/test_alert_engine.py
+++ b/RachioFlume/test_alert_engine.py
@@ -62,7 +62,28 @@ def test_predicate_fires_when_all_minutes_above_threshold(
 def test_predicate_does_not_fire_on_single_zero_minute(
     engine: AlertEngine, rule: AlertRule
 ) -> None:
+    # mean([3.0, 0.0, 3.0, 3.0]) = 2.25 < 2.6 — zero drags mean below threshold
     assert engine._rule_matches(_readings([3.0, 0.0, 3.0, 3.0]), rule) is False
+
+
+def test_predicate_mean_tolerates_brief_zero_when_average_still_meets_threshold(
+    engine: AlertEngine, rule: AlertRule
+) -> None:
+    # mean([3.0, 0.0, 3.0, 4.5]) = 2.625 >= 2.6 — one zero-minute doesn't kill the alert
+    assert engine._rule_matches(_readings([3.0, 0.0, 3.0, 4.5]), rule) is True
+
+
+def test_predicate_single_spike_among_zeros_does_not_fire() -> None:
+    # mean([8.0, 0.0, 0.0, 0.0]) = 2.0 < 8.0 — a momentary surge is not a pipe break
+    pipe_rule = AlertRule(name="Pipe Break", min_gpm=8.0, duration_minutes=4, retrigger_minutes=30)
+    engine = AlertEngine(
+        flume_client=MagicMock(),
+        rachio_client=MagicMock(),
+        pushover=MagicMock(),
+        db=MagicMock(),
+        rules=[pipe_rule],
+    )
+    assert engine._rule_matches(_readings([8.0, 0.0, 0.0, 0.0]), pipe_rule) is False
 
 
 def test_predicate_does_not_fire_with_insufficient_samples(


### PR DESCRIPTION
## What

Switch `_rule_matches` from strict "all minutes ≥ min_gpm" to "mean over window ≥ min_gpm" so that one or two zero-minute readings from Flume sampling cadence do not disqualify sustained flow events.

Add offline DB replay + local test loop — scp production DB from omega and test against real data without touching the running collector.

## Why

After 17 days of live data on omega, **zero alerts ever fired**. The root cause: the strict predicate requires every minute in the window to meet the threshold, but real household flow patterns interleave zero-minutes between usage events.

## Changes

**Predicate tuning**
- `alert_engine.py`: `_rule_matches` now uses mean flow over window ≥ min_gpm
- `test_alert_engine.py`: 2 new unit tests for mean semantics
- `test_alert_simulation.py`: all 6 end-to-end tests pass under mean semantics (no changes needed)

**Pluggable simulator**
- `simulate_alerts.py`: `run_simulation` accepts any duck-typed dataset (synthetic or DB-backed)
- `DBReplayDataset`: reads production `water_readings` + approximates Rachio state from `watering_events`

**CLI**
- `rfmanager.py`: new `alerts replay --hours N --poll-interval M --db PATH` subcommand
- `--db` lets you point at a copied production DB for local testing

**Remote test loop**
- `scripts/remote-test.sh`: scp prod DB from omega, replay locally — no SSH execution needed

**Bug fix discovered during testing**
- `DBReplayDataset.readings_for_window` was using `datetime.isoformat()` (with `T`) but the SQLite DB stores timestamps with a space — the string comparison silently returned 0 rows. Fixed to use `strftime("%Y-%m-%d %H:%M:%S")`.

## Validation against real data (7-day replay)

```
Summary: 2017 cycles, 127 pushes (73 fires, 54 clears), 782 suppressed by Rachio
  Fires by rule:  Low Flow=39, Leak=34
  Clears by rule: Low Flow=37, Leak=17
```

Low Flow and Leak fires are expected — sustained minor household usage (dripping faucets, toilet running). No Mid/High/Pipe Break fires, which is correct — no concerning events in this window.

## References

- Plan: `~/.claude/plans/we-want-to-add-concurrent-flamingo.md`
- Previous PR: #170 (initial deploy on omega)
- `TESTABILITY.md` (testing strategy)