### PR TITLE
feat(RachioFlume): escalate report failures to Pushover + irrigation P0 status

### DIFF
--- a/NoShorts/NoShorts.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/NoShorts/NoShorts.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/RachioFlume/README.md
+++ b/RachioFlume/README.md
@@ -123,10 +123,12 @@ and live in `config/default.yaml` under `rachio_flume.alerts` — override per-h
 in `config/local.yaml`.
 
 Key behaviors:
-- **All alerts at Pushover priority 2** (emergency — retries until you ack)
+- **Fire alerts at Pushover priority 2** (emergency — retries until you ack)
+- **Irrigation status at priority 0** — while Rachio is irrigating, a P0 notification is sent each cycle with the active zone name and current flow rate (informational, not an alert)
 - **Re-trigger every 30 min** while the condition holds, unless muted
 - **Priority-0 "all clear" notification** on the cycle the condition transitions active → clear
 - **Suppression while Rachio irrigates** (plus a 10-min slack after the zone completes, to cover the trailing flow window in the predicate's lookback)
+- **Report failures escalate to Pushover** — if the weekly email report fails (e.g. Gmail auth error), a priority-2 Pushover notification is sent so you know immediately
 
 ```bash
 # Dry-run all rules against live Flume / Rachio (no Pushover sent)
@@ -229,9 +231,9 @@ kill <process_id>
 
 6. **AlertEngine** (`alert_engine.py`) + **AlertRule** (`alert_rules.py`)
    - Runs at the end of each collector cycle
-   - Evaluates each rule's predicate against trailing per-minute Flume readings
+   - Evaluates each rule's predicate against trailing per-minute Flume readings (mean over window, not strict per-minute)
    - State machine: first-fire / retrigger / clear / muted
-   - Suppresses during (and just after) Rachio irrigation
+   - Suppresses during (and just after) Rachio irrigation — sends P0 status with zone + GPM instead
    - Per-rule state persisted as JSON in the existing `collection_metadata` table
 
 7. **SyntheticDataset** (`synthetic_data.py`) + **Simulator** (`simulate_alerts.py`)

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -223,6 +223,17 @@ class AlertEngine:
             self.logger.info(
                 f"Rachio zone '{rachio_active.name}' is irrigating; suppressing all rule evaluation."
             )
+            if not dry_run:
+                try:
+                    gpm = self.flume.get_current_usage_rate()
+                    gpm_str = f"{gpm:.1f} GPM" if gpm is not None else "N/A"
+                except Exception:
+                    gpm_str = "N/A"
+                self.pushover.send_message(
+                    f"Zone: {rachio_active.name}\nFlow: {gpm_str}",
+                    title="RachioFlume: Irrigating",
+                    priority=0,
+                )
 
         for rule in self.rules:
             entry: dict = {"rule": rule.name, "action": AlertAction.NOTHING.value}

--- a/RachioFlume/rfmanager.py
+++ b/RachioFlume/rfmanager.py
@@ -260,6 +260,11 @@ def generate_report(args: argparse.Namespace) -> int:
 
     except Exception as e:
         logger.error(f"Error generating report: {e}")
+        pushover.send_message(
+            f"Error generating report: {e}",
+            title="RachioFlume Report Error",
+            priority=2,
+        )
         return 1
 
 
@@ -277,6 +282,11 @@ def generate_summary_report(_args: argparse.Namespace) -> int:
 
     except Exception as e:
         logger.error(f"Error generating summary report: {e}")
+        pushover.send_message(
+            f"Error generating summary report: {e}",
+            title="RachioFlume Report Error",
+            priority=2,
+        )
         return 1
 
 
@@ -294,6 +304,11 @@ def generate_raw_report(args: argparse.Namespace) -> int:
 
     except Exception as e:
         logger.error(f"Error generating raw report: {e}")
+        pushover.send_message(
+            f"Error generating raw report: {e}",
+            title="RachioFlume Report Error",
+            priority=2,
+        )
         return 1
 
 

--- a/RachioFlume/test_alert_engine.py
+++ b/RachioFlume/test_alert_engine.py
@@ -191,7 +191,11 @@ async def test_evaluate_suppressed_by_active_rachio_zone(
 
     assert results[0]["action"] == AlertAction.NOTHING.value
     assert "suppressed_by" in results[0]
-    engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
+    # P0 irrigation notification sent (no alert fire/clear)
+    engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
+    call_args, call_kwargs = engine.pushover.send_message.call_args  # type: ignore[attr-defined]
+    assert call_kwargs["priority"] == 0
+    assert "Front Yard" in call_args[0]
     # State unchanged (no spurious "clear" later)
     assert engine._load_state(rule).last_state is None
 


### PR DESCRIPTION
## What

1. **Report → Pushover escalation**: All three report generators (weekly, summary, raw) send a Pushover priority-2 notification when report generation fails — e.g. Gmail SMTP auth errors. Previously failures were silently logged only.

2. **Irrigation P0 status**: When Rachio is actively irrigating (the suppression window), send a Pushover priority-0 notification each cycle with the active zone name and current flow rate. Replaces the silent suppression with informational visibility — mirrors the Flume app's 'Do Not Alert Schedules' pattern.

3. **README updated**: Reflects the mean-based predicate, irrigation P0 status, and report error escalation.

## Why

The weekly water report cron job was silently failing since the Gmail app password expired. Without Pushover escalation, nobody gets notified.

During irrigation, all alerts are suppressed. Previously this was completely silent. Now you get a P0 status update so you know which zone is running and at what rate.

## Changes

| File | Change |
|---|---|
| `alert_engine.py` | `evaluate()` → P0 Pushover when `rachio_active` and not dry-run |
| `rfmanager.py` | report generators → Pushover priority-2 on error |
| `test_alert_engine.py` | Updated suppression test to expect the P0 notification |
| `README.md` | Updated key behaviors and Architecture sections |

## References

- Related: PR #179 (mean-based predicate + DB replay)

Co-Authored-By: Claude <noreply@anthropic.com>