### PR TITLE
fix(ci): bump actions/checkout to v5 across all workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: false
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Pages
         id: pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: false
 


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` → `actions/checkout@v5` in `lint.yml`, `test.yml`, `pages.yml`.

## Why

`actions/checkout@v4` runs on Node.js 20. GitHub forces Node 24 on the runner starting 2026-06-16 and removes Node 20 entirely on 2026-09-16. Bumping now clears the deprecation warning before it becomes a hard break.

Same fix was applied in `mastrix-ai/mastrix-core` (PR #25) alongside an unrelated `jq` argv overflow fix; that repo had `agent-review.yml`, which this repo does not.

## Test plan

- [ ] Lint, Test, and Pages workflows run green on this PR.
- [ ] No Node 20 deprecation warning in any run log.

## References

- mastrix-core PR: https://github.com/mastrix-ai/mastrix-core/pull/25
- Node 20 deprecation notice: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/