### PR TITLE
docs: README cleanup — RachioFlume, LaunchJobs, NetworkCheck, dead-code notices

### DIFF
--- a/GPXParser/README.md
+++ b/GPXParser/README.md
@@ -1,0 +1,5 @@
+# GPXParser
+
+> **Status: Inactive** — utility script, not actively maintained.
+
+Helper for numbering GPX track files. Single script (`append_numbered_files.py`).

--- a/GarageCheck/README.md
+++ b/GarageCheck/README.md
@@ -1,0 +1,5 @@
+# GarageCheck
+
+> **Status: Inactive** — superseded by other approaches, not actively maintained.
+
+ML-based garage door status detection using Foscam camera snapshots and TensorFlow one-shot transfer learning on ImageNet features. Classifies garage door open/closed from images.

--- a/JWTs/README.md
+++ b/JWTs/README.md
@@ -1,0 +1,5 @@
+# JWTs
+
+> **Status: Inactive** — one-off utility, not actively maintained.
+
+Extracts JWT tokens from HAR (HTTP Archive) files for debugging authenticated API calls. Single script (`extract_har_tokens_simple.py`).

--- a/LaunchJobs/README.md
+++ b/LaunchJobs/README.md
@@ -60,3 +60,18 @@ Schedule, log paths configured under `launch_jobs.whatsapp_summary` in
   than templated XML.
 - Each `JobSpec` is frozen and self-describing; CLI commands operate purely
   on the registry, no per-job switch statements.
+
+## When to use launchd vs Claude routines
+
+Launchd jobs are appropriate for:
+- Fixed-schedule tasks that run reliably without intervention (daily summaries, periodic backups)
+- Tasks that must survive reboots and user logouts
+- Simple scripts with deterministic behavior
+
+**Claude routines** (via `pi -p` or similar) may be a better fit for:
+- Tasks that benefit from AI judgment or adaptive behavior
+- Interactive workflows that need human-in-the-loop decisions
+- Complex multi-step processes where the steps depend on runtime conditions
+- Tasks that are easier to express as natural language instructions than as shell scripts
+
+Example: The `whatsapp-summary` job currently runs a fixed `pi -p` command daily. If the summary logic becomes more complex (e.g., filtering by conversation type, adapting to user preferences), it might be better implemented as a Claude routine that can reason about the data rather than a rigid launchd script.

--- a/NetworkCheck/README.md
+++ b/NetworkCheck/README.md
@@ -1,0 +1,50 @@
+# NetworkCheck
+
+Network uplink monitoring — speed tests and external IP tracking for the home network ("Eden"). Reports via email and Pushover.
+
+## Components
+
+### `test_uplink.py` — Speed test
+
+Runs `speedtest-cli` and classifies the link:
+
+| Status | Condition |
+|--------|-----------|
+| **Good** | DL ≥ `min_dl_bw` AND UL ≥ `min_ul_bw` |
+| **Degraded** | DL ≥ 80% threshold AND UL ≥ 80% threshold |
+| **Bad** | Below 80% of either threshold |
+
+Supports `--max_retries N` (waits 60s between attempts) and `--always_email` to force email delivery.
+
+Thresholds configured in `config/default.yaml` → `network_check`:
+```yaml
+network_check:
+  min_dl_bw: 150  # Mbps
+  min_ul_bw: 4    # Mbps
+```
+
+### `external_ip_reporter.py` — IP change monitor
+
+Fetches the current external IP from a cascade of services (ipify → icanhazip → checkip) and reports via email + Pushover. Useful for detecting dynamic IP changes.
+
+## Notifications
+
+Both scripts use:
+- **Email** via `lib.Mailer`
+- **Pushover** via the `NetworkCheck` app token (`config/local.yaml` → `pushover.tokens.NetworkCheck`)
+
+## Usage
+
+```bash
+# Speed test (single attempt)
+uv run python -m NetworkCheck.test_uplink
+
+# Speed test with 3 retries
+uv run python -m NetworkCheck.test_uplink --max_retries 3
+
+# Speed test with email
+uv run python -m NetworkCheck.test_uplink --always_email
+
+# External IP report
+uv run python -m NetworkCheck.external_ip_reporter
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ make lint-fix        # Fix all linting issues
 
 # Run specific services (see individual folder READMEs for details)
 uv run python Tesla/manage_power_clean.py
-uv run python RachioFlume/main.py
+uv run python RachioFlume/rfmanager.py
 ```
 
 ## Project Components

--- a/RachioFlume/README.md
+++ b/RachioFlume/README.md
@@ -7,7 +7,10 @@ A Python integration that connects Rachio irrigation controllers with Flume wate
 - **Rachio Integration**: Monitor active zones and watering events
 - **Flume Integration**: Track real-time water consumption across all devices
 - **Data Correlation**: Match watering events with water usage patterns
-- **Usage Alerts** (`alert_engine.py`): First-party Pushover alerts for Pipe Break / High Flow / Mid Flow / Low Flow / Leak, suppressed during Rachio irrigation, with mute support and "all clear" notifications
+- **Usage Alerts** (`alert_engine.py`):
+  - **Zone-end reports**: One P-1 Pushover notification per zone per day, sent after the zone finishes irrigating (10-min slack for data to settle). Reports runtime, precise avg GPM, and total gallons.
+  - **Anomaly rules**: Pipe Break / High Flow / Mid Flow / Low Flow / Leak — P2 (emergency), at most once per day per rule. Uses coefficient-of-variation filter to reject spiky noise on low-flow rules.
+  - Suppressed during Rachio irrigation; mute support; P0 "all clear" on active→clear transition
 - **Synthetic Simulator** (`simulate_alerts.py`): Replay a YAML-defined scenario through the alert engine without hitting real APIs or Pushover — see [TESTABILITY.md](TESTABILITY.md)
 - **Period Reports**: Generate detailed reports with:
   - Average watering rate by zone
@@ -123,11 +126,11 @@ and live in `config/default.yaml` under `rachio_flume.alerts` — override per-h
 in `config/local.yaml`.
 
 Key behaviors:
-- **Fire alerts at Pushover priority 2** (emergency — retries until you ack)
-- **Irrigation status at priority 0** — while Rachio is irrigating, a P0 notification is sent each cycle with the active zone name and current flow rate (informational, not an alert)
-- **Re-trigger every 30 min** while the condition holds, unless muted
+- **Zone-end report (P-1)** — one notification per zone per day, sent after the zone finishes irrigating (10-min slack). Reports runtime, avg GPM, and total gallons.
+- **Anomaly rules fire at P2** (emergency — retries until you ack), at most once per day per rule
+- **CV-based variance filter** — rules require both mean ≥ threshold AND low coefficient of variation. Rejects spiky noise (e.g. a few high readings among zeros) that would pass a mean-only check. Formula: `max_cv = 0.5 - 0.04 × min_gpm`, capped [0.15, 0.5].
 - **Priority-0 "all clear" notification** on the cycle the condition transitions active → clear
-- **Suppression while Rachio irrigates** (plus a 10-min slack after the zone completes, to cover the trailing flow window in the predicate's lookback)
+- **Suppression while Rachio irrigates** (plus a 10-min slack after the zone completes)
 - **Report failures escalate to Pushover** — if the weekly email report fails (e.g. Gmail auth error), a priority-2 Pushover notification is sent so you know immediately
 
 ```bash
@@ -231,10 +234,11 @@ kill <process_id>
 
 6. **AlertEngine** (`alert_engine.py`) + **AlertRule** (`alert_rules.py`)
    - Runs at the end of each collector cycle
-   - Evaluates each rule's predicate against trailing per-minute Flume readings (mean over window, not strict per-minute)
-   - State machine: first-fire / retrigger / clear / muted
-   - Suppresses during (and just after) Rachio irrigation — sends P0 status with zone + GPM instead
-   - Per-rule state persisted as JSON in the existing `collection_metadata` table
+   - **Zone-end reporting**: detects when a Rachio zone finishes, waits for slack, sends one P-1 report per zone per day with runtime, avg GPM, total gallons
+   - **Anomaly rules**: evaluates each rule's predicate against trailing per-minute Flume readings — requires mean ≥ threshold AND CV ≤ max_cv (coefficient-of-variation filter rejects spiky noise)
+   - Anomaly fires at P2 (emergency), at most once per day per rule; P0 clear on active→clear
+   - Suppressed during (and just after) Rachio irrigation
+   - Per-rule and per-zone reported-today state persisted as JSON in `collection_metadata`
 
 7. **SyntheticDataset** (`synthetic_data.py`) + **Simulator** (`simulate_alerts.py`)
    - YAML-defined scenarios with household, irrigation, leak, and pipe-break events

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -141,7 +141,7 @@ class AlertEngine:
             f"Avg flow: {avg_gpm:.2f} GPM\n"
             f"Total: {total_gal:.1f} gal"
         )
-        self.pushover.send_message(msg, title="RachioFlume: Zone Report", priority=1)
+        self.pushover.send_message(msg, title="RachioFlume: Zone Report", priority=-1)
         self.logger.info(
             f"Zone-end report sent for '{zone_name}': {runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
         )


### PR DESCRIPTION
## Summary

### RachioFlume README
- Updated features section for zone-end reporting (P-1) and anomaly rules (P2, once/day)
- Added CV-based variance filter documentation
- Removed stale 'P0 notification each cycle while irrigating' and 're-trigger every 30 min'
- Updated architecture section for AlertEngine

### Top-level README
- Fixed entry point: `rfmanager.py` not `main.py`

### LaunchJobs README
- Added 'When to use launchd vs Claude routines' section

### Backfilled missing READMEs
- **GPXParser** — dead-code notice
- **GarageCheck** — dead-code notice
- **JWTs** — dead-code notice
- **NetworkCheck** — full docs (speed test thresholds, external IP reporter, usage)

### Code fix
- Zone-end report priority corrected from P1 → P-1 in `alert_engine.py`

Co-authored-by: Claude <noreply@anthropic.com>