### PR TITLE
fix(alerts): remove redundant Low Flow rule

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -239,7 +239,6 @@ rachio_flume:
       - {name: "Pipe Break", min_gpm: 8.0, duration_minutes: 10}
       - {name: "High Flow",  min_gpm: 5.4, duration_minutes: 4}
       - {name: "Mid Flow",   min_gpm: 2.6, duration_minutes: 14}
-      - {name: "Low Flow",   min_gpm: 0.1, duration_minutes: 30}
       - {name: "Leak",       min_gpm: 0.1, duration_minutes: 120}
 
 # === PersonalCalSync (Google Apps Script) ===


### PR DESCRIPTION
## Why
Both "Low Flow" (0.1 gpm, 30 min) and "Leak" (0.1 gpm, 120 min) share the same threshold. When flow stays >= 0.1 gpm for 120+ min, both rules fire — duplicate Pushover alerts for the same condition.

## Impact
Eliminates duplicate notifications. Only "Leak" fires at 0.1 gpm after 120 minutes of sustained flow.

## Changes
- Removed "Low Flow" rule from `config/default.yaml`
- Same change applied to local `config/local.yaml` (gitignored)