### PR TITLE
fix(rachioflume): report each zone cycle with cycle count

### DIFF
--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -111,7 +111,7 @@ def _load_count_map(db: WaterTrackingDB, key: str) -> dict[str, int]:
     blob = db.get_metadata(key)
     if not blob:
         return {}
-    return json.loads(blob)
+    return json.loads(blob)  # type: ignore[no-any-return]
 
 
 def _save_count_map(db: WaterTrackingDB, key: str, d: dict[str, int]) -> None:

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -152,7 +152,9 @@ class AlertEngine:
             d.get("last_zone_number"),
         )
 
-    def _save_rachio_state(self, at: datetime, zone_name: str, zone_number: int) -> None:
+    def _save_rachio_state(
+        self, at: datetime, zone_name: Optional[str], zone_number: Optional[int]
+    ) -> None:
         self.db.set_metadata(
             _RACHIO_STATE_KEY,
             json.dumps(

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -1,8 +1,9 @@
 """Zone-end reporting for RachioFlume.
 
 Runs at the end of every collector cycle. Detects when a Rachio zone finishes
-irrigating and — after a slack window — sends exactly **one** P1 notification
-per zone per day reporting:
+irrigating — either because a new zone started (zone transition) or because
+Rachio went fully idle — and sends exactly **one** P-1 notification per zone
+per day reporting:
   • Zone name
   • Runtime (minutes)
   • Average flow rate (GPM, computed from per-minute Flume readings)
@@ -26,14 +27,27 @@ from RachioFlume.flume_client import FlumeClient, WaterReading
 from RachioFlume.rachio_client import RachioClient
 
 # Minutes to wait after Rachio reports inactive before sending the zone-end
-# report. Covers the gap between the last poll where the zone was still active
-# and when it actually stopped, plus time for the collector cycle to persist
-# the session data.
+# report. Covers the gap for the collector cycle to persist session data.
+# Only applies when Rachio goes fully idle (not zone transitions, which are
+# detected immediately).
 RACHIO_POST_ACTIVE_SLACK_MINUTES = 10
 
 _RACHIO_STATE_KEY = "alert::__rachio__::last_active"
 _REPORTED_ZONES_KEY = "reported::zones::{date}"
 _REPORTED_RULES_KEY = "reported::rules::{date}"
+
+
+def _zone_name_matches(session_name: str, lookup_name: str) -> bool:
+    """Check if session zone name matches lookup name (handles partial names).
+
+    Session data uses short names from event summaries (e.g., "Z2 FS"),
+    while active zone API returns full names (e.g., "Z2 FS - Sergio Inner").
+    This function handles both exact matches and prefix matches.
+    """
+    if session_name == lookup_name:
+        return True
+    # Check if one is a prefix of the other
+    return lookup_name.startswith(session_name) or session_name.startswith(lookup_name)
 
 
 class AlertAction(str, Enum):
@@ -93,6 +107,17 @@ def _save_set(db: WaterTrackingDB, key: str, s: set[str]) -> None:
     db.set_metadata(key, json.dumps(sorted(s)))
 
 
+def _load_count_map(db: WaterTrackingDB, key: str) -> dict[str, int]:
+    blob = db.get_metadata(key)
+    if not blob:
+        return {}
+    return json.loads(blob)
+
+
+def _save_count_map(db: WaterTrackingDB, key: str, d: dict[str, int]) -> None:
+    db.set_metadata(key, json.dumps(d))
+
+
 class AlertEngine:
     """Zone-end reporting + rule-based anomaly detection."""
 
@@ -115,83 +140,103 @@ class AlertEngine:
     # Zone-end reporting                                                  #
     # ------------------------------------------------------------------ #
 
-    def _load_rachio_state(self) -> tuple[Optional[datetime], Optional[str]]:
+    def _load_rachio_state(self) -> tuple[Optional[datetime], Optional[str], Optional[int]]:
         blob = self.db.get_metadata(_RACHIO_STATE_KEY)
         if not blob:
-            return None, None
+            return None, None, None
         d = json.loads(blob)
         at_iso = d.get("last_active_at")
         return (
             datetime.fromisoformat(at_iso) if at_iso else None,
             d.get("last_zone"),
+            d.get("last_zone_number"),
         )
 
-    def _save_rachio_state(self, at: datetime, zone_name: str) -> None:
+    def _save_rachio_state(self, at: datetime, zone_name: str, zone_number: int) -> None:
         self.db.set_metadata(
             _RACHIO_STATE_KEY,
-            json.dumps({"last_active_at": at.isoformat(), "last_zone": zone_name}),
+            json.dumps(
+                {
+                    "last_active_at": at.isoformat(),
+                    "last_zone": zone_name,
+                    "last_zone_number": zone_number,
+                }
+            ),
         )
 
+    def _clear_rachio_state(self) -> None:
+        self.db.delete_metadata(_RACHIO_STATE_KEY)
+
+    def _find_zone_session(
+        self, zone_name: str, zone_number: Optional[int], now: datetime
+    ) -> Optional[dict]:
+        """Find the most recent session for a zone, using zone_number if available."""
+        sessions = self.db.get_zone_sessions(now - timedelta(days=1), now)
+
+        # Try matching by zone_number first (more reliable)
+        if zone_number is not None:
+            zone_sessions = [s for s in sessions if s.get("zone_number") == zone_number]
+        else:
+            # Fallback to name matching (handles partial names)
+            zone_sessions = [s for s in sessions if _zone_name_matches(s["zone_name"], zone_name)]
+
+        if not zone_sessions:
+            return None
+
+        # Return most recent session
+        return sorted(
+            zone_sessions,
+            key=lambda s: s.get("end_time") or s.get("start_time") or datetime.min,
+            reverse=True,
+        )[0]
+
     def _send_zone_report(
-        self, zone_name: str, runtime_min: float, avg_gpm: float, total_gal: float
+        self, zone_name: str, runtime_min: float, avg_gpm: float, total_gal: float, cycle: int
     ) -> None:
+        cycle_label = f" (Cycle {cycle})" if cycle > 1 else ""
         msg = (
-            f"Zone '{zone_name}' completed.\n"
+            f"Zone '{zone_name}' completed{cycle_label}.\n"
             f"Runtime: {runtime_min:.0f} min\n"
             f"Avg flow: {avg_gpm:.2f} GPM\n"
             f"Total: {total_gal:.1f} gal"
         )
         self.pushover.send_message(msg, title="RachioFlume: Zone Report", priority=-1)
         self.logger.info(
-            f"Zone-end report sent for '{zone_name}': {runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
+            f"Zone-end report sent for '{zone_name}'{cycle_label}: {runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
         )
 
     def _check_zone_end_report(
         self,
-        rachio_active: Optional[object],
-        last_rachio_active_at: Optional[datetime],
-        last_rachio_zone: Optional[str],
+        zone_name: str,
+        zone_number: Optional[int],
+        last_active_at: Optional[datetime],
         now: datetime,
         dry_run: bool,
     ) -> bool:
-        """Check if a zone just ended and send the one-per-day report.
+        """Send a P-1 report for a zone that just ended.
+
+        Reports every cycle (no per-day dedup). Includes cycle count in message
+        so repeated runs of the same zone are distinguishable.
 
         Returns True if a report was sent (or would be sent in dry-run).
         """
-        reported = _load_set(self.db, _today_key(_REPORTED_ZONES_KEY, now))
-
-        # Zone was active last cycle but not now → it just ended
-        if rachio_active or last_rachio_active_at is None or last_rachio_zone is None:
-            return False
-
-        slack_cutoff = last_rachio_active_at + timedelta(minutes=RACHIO_POST_ACTIVE_SLACK_MINUTES)
-        if now < slack_cutoff:
-            return False  # still waiting for data to settle
-
-        if last_rachio_zone in reported:
-            self.logger.debug(f"Zone '{last_rachio_zone}' already reported today, skipping")
-            return False
+        counts = _load_count_map(self.db, _today_key(_REPORTED_ZONES_KEY, now))
+        cycle = counts.get(zone_name, 0) + 1
 
         # Look up the session data for this zone
-        sessions = self.db.get_zone_sessions(now - timedelta(days=1), now)
-        zone_sessions = [s for s in sessions if s["zone_name"] == last_rachio_zone]
+        session = self._find_zone_session(zone_name, zone_number, now)
 
-        if zone_sessions:
-            # Most recent session for this zone
-            session = sorted(
-                zone_sessions,
-                key=lambda s: s.get("end_time") or s.get("start_time") or datetime.min,
-                reverse=True,
-            )[0]
+        if session:
             runtime_min = (session.get("duration_seconds") or 0) / 60.0
             avg_gpm = session.get("average_flow_rate") or 0.0
             total_gal = session.get("total_water_used") or 0.0
         else:
             # Fallback: estimate from Flume readings over the irrigation window
             self.logger.warning(
-                f"No session found for zone '{last_rachio_zone}', estimating from Flume readings"
+                f"No session found for zone '{zone_name}' (cycle {cycle}), estimating from Flume readings"
             )
-            readings = self.flume.get_usage(last_rachio_active_at, now, bucket="MIN")
+            window_start = last_active_at or (now - timedelta(hours=1))
+            readings = self.flume.get_usage(window_start, now, bucket="MIN")
             active_readings = [r for r in readings if r.value > 0.05]  # threshold to filter noise
             if active_readings:
                 runtime_min = len(active_readings)
@@ -206,12 +251,12 @@ class AlertEngine:
 
         if not dry_run:
             if runtime_min > 0:
-                self._send_zone_report(last_rachio_zone, runtime_min, avg_gpm, total_gal)
-            reported.add(last_rachio_zone)
-            _save_set(self.db, _today_key(_REPORTED_ZONES_KEY, now), reported)
+                self._send_zone_report(zone_name, runtime_min, avg_gpm, total_gal, cycle)
+            counts[zone_name] = cycle
+            _save_count_map(self.db, _today_key(_REPORTED_ZONES_KEY, now), counts)
         else:
             self.logger.info(
-                f"[DRY RUN] Would report zone '{last_rachio_zone}': {runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
+                f"[DRY RUN] Would report zone '{zone_name}' (cycle {cycle}): {runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
             )
 
         return True
@@ -314,21 +359,44 @@ class AlertEngine:
             now = datetime.now()
         results: list[dict] = []
 
-        # Single Rachio check per cycle.
+        # --- Rachio zone tracking ---
+        # Load previous state BEFORE saving so we can detect transitions.
+        last_rachio_active_at, last_rachio_zone, last_rachio_zone_number = self._load_rachio_state()
         rachio_active = self.rachio.get_active_zone()
-        if rachio_active and not dry_run:
-            self._save_rachio_state(now, rachio_active.name)
-        last_rachio_active_at, last_rachio_zone = self._load_rachio_state()
+        current_zone_name = rachio_active.name if rachio_active else None
+
+        # Detect zone end: zone changed (transition) or Rachio went idle.
+        zone_to_report: Optional[str] = None
+        zone_to_report_number: Optional[int] = None
+        zone_last_active_at: Optional[datetime] = None
+        if last_rachio_zone is not None and current_zone_name != last_rachio_zone:
+            zone_to_report = last_rachio_zone
+            zone_to_report_number = last_rachio_zone_number
+            zone_last_active_at = last_rachio_active_at
+
+        # Persist current state for next cycle.
+        if not dry_run:
+            if rachio_active:
+                self._save_rachio_state(now, rachio_active.name, rachio_active.zone_number)
+            else:
+                self._clear_rachio_state()
+
+        # Effective values for rule-suppression logic below
         if rachio_active:
             last_rachio_active_at = now
             last_rachio_zone = rachio_active.name
 
-        # --- Zone-end report (one per zone per day, after slack) ---
-        zone_reported = self._check_zone_end_report(
-            rachio_active, last_rachio_active_at, last_rachio_zone, now, dry_run
-        )
-        if zone_reported:
-            results.append({"zone_report": True, "zone": last_rachio_zone})
+        # --- Zone-end report (one per zone per day) ---
+        if zone_to_report is not None:
+            zone_reported = self._check_zone_end_report(
+                zone_to_report,
+                zone_to_report_number,
+                zone_last_active_at,
+                now,
+                dry_run,
+            )
+            if zone_reported:
+                results.append({"zone_report": True, "zone": zone_to_report})
 
         # --- Suppress rule evaluation while irrigating or within slack ---
         suppressed_by: Optional[str] = None

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -164,9 +164,6 @@ class AlertEngine:
             ),
         )
 
-    def _clear_rachio_state(self) -> None:
-        self.db.delete_metadata(_RACHIO_STATE_KEY)
-
     def _find_zone_session(
         self, zone_name: str, zone_number: Optional[int], now: datetime
     ) -> Optional[dict]:
@@ -375,11 +372,20 @@ class AlertEngine:
             zone_last_active_at = last_rachio_active_at
 
         # Persist current state for next cycle.
+        # Only save when something changed (zone transition or active→idle).
+        # Don't refresh last_active_at on every idle cycle — that would
+        # keep the rule-suppression window open indefinitely.
         if not dry_run:
-            if rachio_active:
-                self._save_rachio_state(now, rachio_active.name, rachio_active.zone_number)
-            else:
-                self._clear_rachio_state()
+            state_changed = (zone_to_report is not None) or (
+                rachio_active and (last_rachio_zone != rachio_active.name)
+            )
+            if state_changed:
+                if rachio_active:
+                    self._save_rachio_state(now, rachio_active.name, rachio_active.zone_number)
+                else:
+                    # Active→idle transition: keep last_active_at for suppression,
+                    # clear zone to prevent re-detection.
+                    self._save_rachio_state(last_rachio_active_at or now, None, None)
 
         # Effective values for rule-suppression logic below
         if rachio_active:

--- a/RachioFlume/test_alert_engine.py
+++ b/RachioFlume/test_alert_engine.py
@@ -371,7 +371,8 @@ async def test_zone_report_each_cycle(engine: AlertEngine, rule: AlertRule) -> N
     engine.flume.get_usage.return_value = _readings([3.0, 3.0, 3.0])  # type: ignore[attr-defined]
     await engine.evaluate()
     assert engine.pushover.send_message.call_count == 1  # type: ignore[attr-defined]
-    assert "Cycle" not in engine.pushover.send_message.call_args_list[0][0][0]  # type: ignore[attr-defined] (cycle 1 has no label)
+    # cycle 1 has no label
+    assert "Cycle" not in engine.pushover.send_message.call_args_list[0][0][0]  # type: ignore[attr-defined]
 
     # Cycle 3: Zone B → Zone A → report Zone B (Cycle 1)
     engine.rachio.get_active_zone.return_value = Zone(  # type: ignore[attr-defined]

--- a/RachioFlume/test_alert_engine.py
+++ b/RachioFlume/test_alert_engine.py
@@ -288,3 +288,124 @@ async def test_muted_rule_does_not_fire_in_evaluate(engine: AlertEngine, rule: A
 
     assert results[0]["action"] == AlertAction.NOTHING.value
     engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------- #
+# Zone-end reporting — zone transitions                                  #
+# ---------------------------------------------------------------------- #
+
+
+async def test_zone_transition_reports_previous_zone(engine: AlertEngine, rule: AlertRule) -> None:
+    """When zone A transitions to zone B, zone A should be reported."""
+    # Cycle 1: Zone A is active
+    engine.rachio.get_active_zone.return_value = Zone(  # type: ignore[attr-defined]
+        id="z1", zone_number=1, name="Front Lawn", enabled=True
+    )
+    engine.flume.get_usage.return_value = _readings([5.0, 5.0, 5.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
+
+    # Cycle 2: Zone A ended, Zone B started → report Zone A
+    engine.rachio.get_active_zone.return_value = Zone(  # type: ignore[attr-defined]
+        id="z2", zone_number=2, name="Back Lawn", enabled=True
+    )
+    engine.flume.get_usage.return_value = _readings([5.0, 5.0, 5.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+
+    # Zone A should be reported
+    engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
+    call_args = engine.pushover.send_message.call_args  # type: ignore[attr-defined]
+    assert "Front Lawn" in call_args[0][0]
+    assert call_args[1]["priority"] == -1
+
+
+async def test_zone_transition_multiple_zones(engine: AlertEngine, rule: AlertRule) -> None:
+    """Multi-zone cycle: each zone gets reported when the next one starts."""
+    zones = [
+        Zone(id="z1", zone_number=1, name="Zone A", enabled=True),
+        Zone(id="z2", zone_number=2, name="Zone B", enabled=True),
+        Zone(id="z3", zone_number=3, name="Zone C", enabled=True),
+    ]
+
+    # Cycle 1: Zone A active
+    engine.rachio.get_active_zone.return_value = zones[0]  # type: ignore[attr-defined]
+    engine.flume.get_usage.return_value = _readings([4.0, 4.0, 4.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 0  # type: ignore[attr-defined]
+
+    # Cycle 2: Zone A → Zone B transition → report Zone A
+    engine.rachio.get_active_zone.return_value = zones[1]  # type: ignore[attr-defined]
+    engine.flume.get_usage.return_value = _readings([4.0, 4.0, 4.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 1  # type: ignore[attr-defined]
+    assert "Zone A" in engine.pushover.send_message.call_args_list[0][0][0]  # type: ignore[attr-defined]
+
+    # Cycle 3: Zone B → Zone C transition → report Zone B
+    engine.rachio.get_active_zone.return_value = zones[2]  # type: ignore[attr-defined]
+    engine.flume.get_usage.return_value = _readings([4.0, 4.0, 4.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 2  # type: ignore[attr-defined]
+    assert "Zone B" in engine.pushover.send_message.call_args_list[1][0][0]  # type: ignore[attr-defined]
+
+    # Cycle 4: Zone C → idle → report Zone C
+    engine.rachio.get_active_zone.return_value = None  # type: ignore[attr-defined]
+    engine.flume.get_usage.return_value = _readings([4.0, 4.0, 4.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 3  # type: ignore[attr-defined]
+    assert "Zone C" in engine.pushover.send_message.call_args_list[2][0][0]  # type: ignore[attr-defined]
+
+
+async def test_zone_report_each_cycle(engine: AlertEngine, rule: AlertRule) -> None:
+    """Each zone cycle should be reported with a cycle count."""
+    # Cycle 1: Zone A active
+    engine.rachio.get_active_zone.return_value = Zone(  # type: ignore[attr-defined]
+        id="z1", zone_number=1, name="Zone A", enabled=True
+    )
+    engine.flume.get_usage.return_value = _readings([3.0, 3.0, 3.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+
+    # Cycle 2: Zone A → Zone B → report Zone A (Cycle 1)
+    engine.rachio.get_active_zone.return_value = Zone(  # type: ignore[attr-defined]
+        id="z2", zone_number=2, name="Zone B", enabled=True
+    )
+    engine.flume.get_usage.return_value = _readings([3.0, 3.0, 3.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 1  # type: ignore[attr-defined]
+    assert "Cycle" not in engine.pushover.send_message.call_args_list[0][0][0]  # type: ignore[attr-defined] (cycle 1 has no label)
+
+    # Cycle 3: Zone B → Zone A → report Zone B (Cycle 1)
+    engine.rachio.get_active_zone.return_value = Zone(  # type: ignore[attr-defined]
+        id="z1", zone_number=1, name="Zone A", enabled=True
+    )
+    engine.flume.get_usage.return_value = _readings([3.0, 3.0, 3.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 2  # type: ignore[attr-defined]
+    assert "Zone B" in engine.pushover.send_message.call_args_list[1][0][0]  # type: ignore[attr-defined]
+
+    # Cycle 4: Zone A → Zone B → report Zone A (Cycle 2)
+    engine.rachio.get_active_zone.return_value = Zone(  # type: ignore[attr-defined]
+        id="z2", zone_number=2, name="Zone B", enabled=True
+    )
+    engine.flume.get_usage.return_value = _readings([3.0, 3.0, 3.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 3  # type: ignore[attr-defined]
+    assert "Zone A" in engine.pushover.send_message.call_args_list[2][0][0]  # type: ignore[attr-defined]
+    assert "Cycle 2" in engine.pushover.send_message.call_args_list[2][0][0]  # type: ignore[attr-defined]
+
+
+async def test_rachio_idle_reports_last_zone(engine: AlertEngine, rule: AlertRule) -> None:
+    """When Rachio goes idle, the last active zone should be reported."""
+    # Cycle 1: Zone active
+    engine.rachio.get_active_zone.return_value = Zone(  # type: ignore[attr-defined]
+        id="z1", zone_number=1, name="Front Yard", enabled=True
+    )
+    engine.flume.get_usage.return_value = _readings([6.0, 6.0, 6.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 0  # type: ignore[attr-defined]
+
+    # Cycle 2: Rachio idle → report the zone
+    engine.rachio.get_active_zone.return_value = None  # type: ignore[attr-defined]
+    engine.flume.get_usage.return_value = _readings([6.0, 6.0, 6.0])  # type: ignore[attr-defined]
+    await engine.evaluate()
+    assert engine.pushover.send_message.call_count == 1  # type: ignore[attr-defined]
+    assert "Front Yard" in engine.pushover.send_message.call_args[0][0]  # type: ignore[attr-defined]


### PR DESCRIPTION
## Problem

Only the final zone in a multi-zone Rachio schedule received a P-1 notification. Intermediate zones were silently skipped.

Additionally, when a notification was sent, the runtime was wrong (e.g., 6 min reported vs 20 min actual) due to a zone name mismatch between session data and the active zone API.

## Root Causes

1. **No zone transition detection** — `_check_zone_end_report` only fired when Rachio went fully idle. When zone A ended and zone B started, `rachio_active` was still truthy, so zone A's report was skipped.

2. **Zone name mismatch** — Session data stores short names (e.g., `"Z2 FS"`) parsed from event summaries, but the active zone API returns full names (e.g., `"Z2 FS - Sergio Inner"`). Exact match failed → fell back to Flume estimation with a too-short window.

3. **Per-day dedup** — Same zone running multiple cycles (e.g., soak-and-repeat schedules) only got reported once.

## Fixes

- **Zone transition detection**: Load rachio state BEFORE saving in `evaluate()` to detect when the active zone changes
- **Zone number tracking**: Save `zone_number` in state; use it for session lookup (with partial name match fallback)
- **Report every cycle**: Removed per-day dedup; each cycle gets its own notification with a cycle count label (`"Cycle 2"`)
- **Removed 10-min slack**: Transition detection is immediate; fallback Flume estimation covers the case where session data isn't persisted yet

## Example Notification

```
Zone 'Z2 FS - Sergio Inner' completed (Cycle 2).
Runtime: 10 min
Avg flow: 5.88 GPM
Total: 58.7 gal
```

## Tests

28 passing (4 new zone-transition tests + updated cycle counting test)

## References

- Rachio app screenshot (source of truth): Z1=20min, Z2=20min for Front Lawn schedule on Jun 18
- Previous notification showed Z2 runtime=6min (wrong) due to name mismatch fallback
