### PR TITLE
fix: migrate old zone report set format to count map

### DIFF
--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -111,7 +111,11 @@ def _load_count_map(db: WaterTrackingDB, key: str) -> dict[str, int]:
     blob = db.get_metadata(key)
     if not blob:
         return {}
-    return json.loads(blob)  # type: ignore[no-any-return]
+    data = json.loads(blob)
+    # Migrate from old set format (list) to count map (dict)
+    if isinstance(data, list):
+        return {zone: 1 for zone in data}
+    return data  # type: ignore[no-any-return]
 
 
 def _save_count_map(db: WaterTrackingDB, key: str, d: dict[str, int]) -> None:


### PR DESCRIPTION
## Problem

After merging PR #190, the collector on Omega crashes with:
```
Error evaluating alerts: 'list' object has no attribute 'get'
```

## Root Cause

Old code stored reported zones as a JSON **array** `["Zone A", "Zone B"]` via `_save_set`. New code uses `_load_count_map` which expects a JSON **object** `{"Zone A": 1}`. The existing data in Omega's database is still in the old list format, causing `.get()` to fail on a list.

## Fix

Added migration logic in `_load_count_map` to detect old list format and convert to new dict format with count=1 per zone.
