### PR TITLE
Fix speedtest path detection and remove pyenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,21 +10,14 @@ WHITE  := $(shell tput -Txterm setaf 7)
 CYAN   := $(shell tput -Txterm setaf 6)
 RESET  := $(shell tput -Txterm sgr0)
 
-PYTHON_VERSION ?= 3.13.7
-
 all: help
 
 ## Environment setup:
 setup:
-	@echo "🚀 Setting up the development environment with python $(PYTHON_VERSION)"
-	@pyenv install $(PYTHON_VERSION) -s && pyenv local $(PYTHON_VERSION)  || (echo "🔴 Failed to run pyenv. Please review the README.md for setup instructions" && exit 1);
-	@if [ "$$(python3 -V)" != "Python $(PYTHON_VERSION)" ]; then \
-	    echo "Found python version: $$(python3 -V)"; \
-		echo "${RED}Recommended python version not in path${RESET}\n${YELLOW}Please review the README.md for setup instructions${RESET}" && exit 1; \
-	fi
+	@echo "🚀 Setting up the development environment"
 	@brew upgrade
 	@brew install libomp pre-commit yamllint -q
-	@echo "📥 Installing project dependencies for $(PYTHON_VERSION)..."
+	@echo "📥 Installing project dependencies..."
 	@uv sync --extra dev
 	@echo "📦 Initializing Git submodules..."
 	@git submodule update --init --recursive

--- a/NetworkCheck/README.md
+++ b/NetworkCheck/README.md
@@ -33,6 +33,32 @@ Both scripts use:
 - **Email** via `lib.Mailer`
 - **Pushover** via the `NetworkCheck` app token (`config/local.yaml` → `pushover.tokens.NetworkCheck`)
 
+## Prerequisites
+
+### Speedtest CLI
+
+The uplink test requires the [Speedtest CLI by Ookla](https://www.speedtest.net/apps/cli). It is auto-detected via `PATH`.
+
+**macOS:**
+```bash
+brew install speedtest
+```
+
+**Linux (Debian/Ubuntu):**
+```bash
+sudo apt-get install speedtest
+```
+
+**Linux (Raspberry Pi / snap):**
+```bash
+sudo snap install speedtest
+```
+
+Verify with:
+```bash
+speedtest --version
+```
+
 ## Usage
 
 ```bash

--- a/NetworkCheck/test_uplink.py
+++ b/NetworkCheck/test_uplink.py
@@ -8,6 +8,7 @@ via email and pushover notifications. Supports retry logic for unreliable connec
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 import time
@@ -23,7 +24,7 @@ logger = SystemLogger.get_logger(__name__)
 pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["NetworkCheck"])
 
 # Constants
-SPEEDTEST_CMD = "/usr/bin/speedtest"
+SPEEDTEST_CMD = shutil.which("speedtest") or "/usr/bin/speedtest"
 SPEEDTEST_TIMEOUT = 600
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A comprehensive home automation and monitoring system with Python-based IoT inte
 ## Quick Start
 
 ### Prerequisites
-- Python 3.13+ (managed via pyenv)
+- Python 3.13+
 - [uv](https://docs.astral.sh/uv/) - Fast Python package manager
 - [pre-commit](https://pre-commit.com/) - Git hooks for code quality
 
@@ -20,11 +20,10 @@ A comprehensive home automation and monitoring system with Python-based IoT inte
 git clone https://github.com/DeviationLabs/homely-vibes.git
 cd homely-vibes
 
-# Setup development environment (installs Python 3.13.7, dependencies, and git hooks)
+# Setup development environment (installs dependencies and git hooks)
 make setup
 
 # Or manual setup:
-pyenv install 3.13.7 && pyenv local 3.13.7
 uv sync --extra dev
 pre-commit install
 ```


### PR DESCRIPTION
## Why
The uplink test was failing on AIBO because the speedtest binary path was hardcoded to `/usr/bin/speedtest`, but on AIBO it's installed via snap at `/snap/bin/speedtest`. Additionally, the project no longer uses pyenv for Python version management.

## Impact
The uplink test now auto-detects the speedtest binary via `PATH`, making it work across macOS, Linux, and Raspberry Pi without manual path configuration.

## Changes
- Auto-detect speedtest binary via `shutil.which()` with fallback to `/usr/bin/speedtest`
- Remove pyenv from `make setup` and `PYTHON_VERSION` variable
- Add speedtest installation instructions to NetworkCheck README (macOS, Linux, Raspberry Pi)
- Update main README to remove pyenv references

## Testing
Verified on AIBO (Raspberry Pi) — speedtest now executes successfully:
```
Link bad (<80%): [73.15.191.112] DL: 290.2 Mbps UL: 264.1 Mbps
```
(Note: "Link bad" is expected — AIBO's thresholds are 400/400 Mbps but actual speeds are 290/264 Mbps. This is a threshold config issue, not a code bug.)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)