### PR TITLE
Remove config/tokens from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ sidebar-notes.md
 
 # Xcode / iOS build artifacts (NoShorts unsigned IPA output)
 build/
+config/tokens

--- a/config/tokens
+++ b/config/tokens
@@ -1,1 +1,0 @@
-/Users/abutala/bin/Common-configs/tokens


### PR DESCRIPTION
## Why
config/tokens contains sensitive credentials and should not be tracked in git.

## Impact
Prevents accidental commits of token files to the repository.

## Changes
- Remove config/tokens from git tracking (file remains locally)
- Add config/tokens to .gitignore

🤖 Generated with [Claude Code](https://claude.ai/claude-code)