### PR TITLE
Add per-zone flow thresholds and security scrub

### DIFF
--- a/NodeCheck/test_nodes.py
+++ b/NodeCheck/test_nodes.py
@@ -16,9 +16,9 @@ class TestNode:
 
     def test_node_can_be_instantiated(self) -> None:
         """Test that GenericNode can be instantiated directly"""
-        node = GenericNode("test", NodeConfig("192.168.1.1", NodeType.GENERIC))
+        node = GenericNode("test", NodeConfig("192.0.2.1", NodeType.GENERIC))
         assert node.name == "test"
-        assert node.config.ip == "192.168.1.1"
+        assert node.config.ip == "192.0.2.1"
 
 
 class TestFoscamNode:
@@ -26,7 +26,7 @@ class TestFoscamNode:
 
     @pytest.fixture
     def foscam_config(self) -> NodeConfig:
-        return NodeConfig("192.168.1.51", NodeType.FOSCAM, "testuser", "testpass")
+        return NodeConfig("192.0.2.51", NodeType.FOSCAM, "testuser", "testpass")
 
     @pytest.fixture
     def foscam_node(self, foscam_config: NodeConfig) -> FoscamNode:
@@ -35,7 +35,7 @@ class TestFoscamNode:
     def test_init(self, foscam_node: FoscamNode, foscam_config: NodeConfig) -> None:
         """Test FoscamNode initialization"""
         assert foscam_node.name == "TestCam"
-        assert foscam_node.config.ip == "192.168.1.51"
+        assert foscam_node.config.ip == "192.0.2.51"
         assert foscam_node.config == foscam_config
         assert foscam_node.is_online is False
 
@@ -48,7 +48,7 @@ class TestFoscamNode:
 
         assert result is True
         assert foscam_node.is_online is True
-        mock_ping.assert_called_once_with(node="192.168.1.51", desired_up=True)
+        mock_ping.assert_called_once_with(node="192.0.2.51", desired_up=True)
 
     @patch("NodeCheck.nodes.NetHelpers.ping_output")
     def test_check_state_failure(self, mock_ping: Any, foscam_node: FoscamNode) -> None:
@@ -68,7 +68,9 @@ class TestFoscamNode:
 
         result = foscam_node.reboot_node()
 
-        expected_url = "http://192.168.1.51:88//cgi-bin/CGIProxy.fcgi?cmd=rebootSystem&usr=testuser&pwd=testpass"
+        expected_url = (
+            "http://192.0.2.51:88//cgi-bin/CGIProxy.fcgi?cmd=rebootSystem&usr=testuser&pwd=testpass"
+        )
         mock_http_req.assert_called_once_with(expected_url)
         assert "reboot successful" in result
 
@@ -102,7 +104,7 @@ class TestFoscamNode:
         result = foscam_node.heartbeat()
 
         assert result is False
-        mock_ping.assert_called_once_with(node="192.168.1.51", count=3, desired_up=True)
+        mock_ping.assert_called_once_with(node="192.0.2.51", count=3, desired_up=True)
 
     # Note: Removed FoscamImager tests due to import complexity during full test suite
     # These would be better suited for integration tests
@@ -113,7 +115,7 @@ class TestWindowsNode:
 
     @pytest.fixture
     def windows_config(self) -> NodeConfig:
-        return NodeConfig("192.168.1.100", NodeType.WINDOWS, "testuser", "testpass")
+        return NodeConfig("192.0.2.100", NodeType.WINDOWS, "testuser", "testpass")
 
     @pytest.fixture
     def windows_node(self, windows_config: NodeConfig) -> WindowsNode:
@@ -122,7 +124,7 @@ class TestWindowsNode:
     def test_init(self, windows_node: WindowsNode, windows_config: NodeConfig) -> None:
         """Test WindowsNode initialization"""
         assert windows_node.name == "TestPC"
-        assert windows_node.config.ip == "192.168.1.100"
+        assert windows_node.config.ip == "192.0.2.100"
         assert windows_node.config == windows_config
         assert windows_node.is_online is False
 
@@ -134,7 +136,7 @@ class TestWindowsNode:
         result = windows_node.reboot_node()
 
         expected_cmd = 'cmd /c "shutdown /r /f & ping localhost -n 3 > nul"'
-        mock_ssh_cmd.assert_called_once_with("192.168.1.100", "testuser", "testpass", expected_cmd)
+        mock_ssh_cmd.assert_called_once_with("192.0.2.100", "testuser", "testpass", expected_cmd)
         assert "reboot initiated" in result
 
     @patch("NodeCheck.nodes.NetHelpers.ping_output")
@@ -149,9 +151,9 @@ class TestWindowsNode:
         result = windows_node.heartbeat()
 
         assert result is True
-        mock_ping.assert_called_once_with(node="192.168.1.100", count=3, desired_up=True)
+        mock_ping.assert_called_once_with(node="192.0.2.100", count=3, desired_up=True)
         mock_ssh_cmd.assert_called_once_with(
-            "192.168.1.100", "testuser", "testpass", "net statistics workstation"
+            "192.0.2.100", "testuser", "testpass", "net statistics workstation"
         )
 
     @patch("NodeCheck.nodes.NetHelpers.ping_output")
@@ -182,7 +184,7 @@ class TestGenericNode:
 
     @pytest.fixture
     def generic_config(self) -> NodeConfig:
-        return NodeConfig("192.168.1.200", NodeType.GENERIC)
+        return NodeConfig("192.0.2.200", NodeType.GENERIC)
 
     @pytest.fixture
     def generic_node(self, generic_config: NodeConfig) -> GenericNode:
@@ -191,7 +193,7 @@ class TestGenericNode:
     def test_init(self, generic_node: GenericNode, generic_config: NodeConfig) -> None:
         """Test GenericNode initialization"""
         assert generic_node.name == "TestDevice"
-        assert generic_node.config.ip == "192.168.1.200"
+        assert generic_node.config.ip == "192.0.2.200"
         assert generic_node.config == generic_config
         assert generic_node.is_online is False
 
@@ -209,7 +211,7 @@ class TestGenericNode:
         result = generic_node.heartbeat()
 
         assert result is True
-        mock_ping.assert_called_once_with(node="192.168.1.200", count=3, desired_up=True)
+        mock_ping.assert_called_once_with(node="192.0.2.200", count=3, desired_up=True)
 
     @patch("NodeCheck.nodes.NetHelpers.ping_output")
     def test_heartbeat_failure(self, mock_ping: Any, generic_node: GenericNode) -> None:
@@ -219,7 +221,7 @@ class TestGenericNode:
         result = generic_node.heartbeat()
 
         assert result is False
-        mock_ping.assert_called_once_with(node="192.168.1.200", count=3, desired_up=True)
+        mock_ping.assert_called_once_with(node="192.0.2.200", count=3, desired_up=True)
 
 
 class TestSomfyMyLinkNode:
@@ -228,7 +230,7 @@ class TestSomfyMyLinkNode:
     @pytest.fixture
     def mylink_config(self) -> NodeConfig:
         return NodeConfig(
-            ip="192.168.1.43",
+            ip="192.0.2.43",
             node_type=NodeType.MYLINK,
             auth_token="test-token-abc",  # nosecret
         )
@@ -256,8 +258,8 @@ class TestSomfyMyLinkNode:
         mock_conn.return_value = self._make_sock_mock(response.encode())
 
         assert mylink_node.heartbeat() is True
-        mock_ping.assert_called_once_with(node="192.168.1.43", count=3, desired_up=True)
-        mock_conn.assert_called_once_with(("192.168.1.43", 44100), timeout=4)
+        mock_ping.assert_called_once_with(node="192.0.2.43", count=3, desired_up=True)
+        mock_conn.assert_called_once_with(("192.0.2.43", 44100), timeout=4)
 
     @patch("NodeCheck.nodes.NetHelpers.ping_output")
     def test_heartbeat_ping_failure_short_circuits(
@@ -352,7 +354,7 @@ class TestSomfyMyLinkNode:
         self, mock_ping: Any, mock_conn: Any
     ) -> None:
         """auth_token unset -> skip API call, return ping result with a warning"""
-        config = NodeConfig(ip="192.168.1.43", node_type=NodeType.MYLINK, auth_token=None)
+        config = NodeConfig(ip="192.0.2.43", node_type=NodeType.MYLINK, auth_token=None)
         node = SomfyMyLinkNode("Somfy", config)
         mock_ping.return_value = True
 
@@ -364,7 +366,7 @@ class TestSomfyMyLinkNode:
     def test_heartbeat_uses_port_override(self, mock_ping: Any, mock_conn: Any) -> None:
         """NodeConfig.port overrides the default 44100"""
         config = NodeConfig(
-            ip="192.168.1.43",
+            ip="192.0.2.43",
             node_type=NodeType.MYLINK,
             auth_token="tok",  # nosecret
             port=55555,
@@ -375,7 +377,7 @@ class TestSomfyMyLinkNode:
         mock_conn.return_value = self._make_sock_mock(response.encode())
 
         assert node.heartbeat() is True
-        mock_conn.assert_called_once_with(("192.168.1.43", 55555), timeout=4)
+        mock_conn.assert_called_once_with(("192.0.2.43", 55555), timeout=4)
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -43,6 +43,38 @@ uv run python Tesla/manage_power_clean.py
 uv run python RachioFlume/rfmanager.py
 ```
 
+## Configuration & Secrets
+
+All sensitive data (API keys, passwords, tokens, device IPs) must be stored in `config/local.yaml`, which is **gitignored** and never committed to the repository.
+
+### Setup
+
+1. Copy the template and fill in your values:
+   ```bash
+   cp config/local.yaml.example config/local.yaml
+   # Edit config/local.yaml with your actual credentials and device IPs
+   ```
+
+2. The `config/default.yaml` file contains safe placeholder values and is committed to git.
+
+3. **Never hardcode secrets or device IPs in source code or tests.** Always read from config:
+   ```python
+   from lib.config import get_config
+   cfg = get_config()
+   api_key = cfg.rachio.api_key  # ✅ Good
+   # api_key = "abc123..."        # ❌ Never do this
+   ```
+
+### What goes in local.yaml
+
+- API credentials (Rachio, Flume, Tesla, August, etc.)
+- Device IP addresses
+- Email/SMTP passwords
+- Pushover tokens
+- Any other sensitive data
+
+See `config/default.yaml` for the full structure and `config/local.yaml.example` for a template.
+
 ## Project Components
 
 | Component | Description | Documentation |

--- a/RachioFlume/README.md
+++ b/RachioFlume/README.md
@@ -9,6 +9,7 @@ A Python integration that connects Rachio irrigation controllers with Flume wate
 - **Data Correlation**: Match watering events with water usage patterns
 - **Usage Alerts** (`alert_engine.py`):
   - **Zone-end reports**: One P-1 Pushover notification per zone per day, sent after the zone finishes irrigating (10-min slack for data to settle). Reports runtime, precise avg GPM, and total gallons.
+  - **Zone anomaly detection**: Per-zone flow thresholds (adaptive: `avg + max(0.5 GPM, 10% of avg)`). P2 emergency alert when zone-end flow exceeds threshold. Unknown zones default to 0.5 GPM threshold.
   - **Anomaly rules**: Pipe Break / High Flow / Mid Flow / Low Flow / Leak — P2 (emergency), at most once per day per rule. Uses coefficient-of-variation filter to reject spiky noise on low-flow rules.
   - Suppressed during Rachio irrigation; mute support; P0 "all clear" on active→clear transition
 - **Synthetic Simulator** (`simulate_alerts.py`): Replay a YAML-defined scenario through the alert engine without hitting real APIs or Pushover — see [TESTABILITY.md](TESTABILITY.md)
@@ -235,6 +236,7 @@ kill <process_id>
 6. **AlertEngine** (`alert_engine.py`) + **AlertRule** (`alert_rules.py`)
    - Runs at the end of each collector cycle
    - **Zone-end reporting**: detects when a Rachio zone finishes, waits for slack, sends one P-1 report per zone per day with runtime, avg GPM, total gallons
+   - **Zone anomaly detection**: checks zone-end flow against per-zone thresholds (configured in `config/default.yaml` under `rachio_flume.alerts.zone_thresholds`). Alerts at P2 when flow exceeds `avg + max(0.5 GPM, 10% of avg)`. Unknown zones default to 0.5 GPM threshold.
    - **Anomaly rules**: evaluates each rule's predicate against trailing per-minute Flume readings — requires mean ≥ threshold AND CV ≤ max_cv (coefficient-of-variation filter rejects spiky noise)
    - Anomaly fires at P2 (emergency), at most once per day per rule; P0 clear on active→clear
    - Suppressed during (and just after) Rachio irrigation
@@ -312,9 +314,48 @@ uv run python -m pytest RachioFlume/test_alert_engine.py -v
 # Synthetic scenario assertions
 uv run python -m pytest RachioFlume/test_alert_simulation.py -v
 
+# Zone threshold integration test (fetches DB from Aibo)
+uv run python -m pytest RachioFlume/test_zone_thresholds.py -v
+# Or standalone:
+python RachioFlume/test_zone_thresholds.py
+
 # Visual playback of a scenario (events to screen, no Pushover)
 uv run python -m RachioFlume.rfmanager simulate
 ```
+
+### Zone Threshold Integration Test
+
+The `test_zone_thresholds.py` integration test validates the zone anomaly detection logic against production data:
+
+1. **Fetches the production database** from Aibo (`192.168.1.200`) via SCP
+2. **Loads zone thresholds** from config (12 zones with per-zone avg GPM)
+3. **Tests threshold computation** for known/unknown zones
+4. **Simulates zone-end scenarios** with real historical data
+5. **Checks for threshold violations** in recent production sessions
+
+**Threshold formula** (adaptive mode):
+```
+threshold = avg_gpm + max(absolute_gpm, percent_above/100 × avg_gpm)
+```
+
+| Zone | Avg GPM | Threshold |
+|------|---------|-----------|
+| Z1   | 5.00    | 5.50      |
+| Z2   | 6.50    | 7.15      |
+| Z3   | 2.00    | 2.50      |
+| Z4   | 3.00    | 3.50      |
+| Z5   | 3.50    | 4.00      |
+| Z6   | 4.50    | 5.00      |
+| Z7   | 2.50    | 3.00      |
+| Z8   | 3.00    | 3.50      |
+| Z9   | 1.50    | 2.00      |
+| Z10  | 7.00    | 7.70      |
+| Z11  | 6.00    | 6.60      |
+| Z12  | 0.75    | 1.25      |
+
+**Unknown zones** (not in config) default to `avg_gpm=0`, yielding a 0.5 GPM threshold — any flow triggers an alert.
+
+**Requirements**: SSH access to Aibo (`ssh abutala@aibo`) must work without password prompt (key-based auth).
 
 ## Development
 

--- a/RachioFlume/README.md
+++ b/RachioFlume/README.md
@@ -314,7 +314,7 @@ uv run python -m pytest RachioFlume/test_alert_engine.py -v
 # Synthetic scenario assertions
 uv run python -m pytest RachioFlume/test_alert_simulation.py -v
 
-# Zone threshold integration test (fetches DB from Aibo)
+# Zone threshold integration test (fetches DB from prod controller)
 uv run python -m pytest RachioFlume/test_zone_thresholds.py -v
 # Or standalone:
 python RachioFlume/test_zone_thresholds.py
@@ -327,7 +327,7 @@ uv run python -m RachioFlume.rfmanager simulate
 
 The `test_zone_thresholds.py` integration test validates the zone anomaly detection logic against production data:
 
-1. **Fetches the production database** from Aibo (`192.168.1.200`) via SCP
+1. **Fetches the production database** from prod controller via SCP
 2. **Loads zone thresholds** from config (12 zones with per-zone avg GPM)
 3. **Tests threshold computation** for known/unknown zones
 4. **Simulates zone-end scenarios** with real historical data
@@ -355,7 +355,7 @@ threshold = avg_gpm + max(absolute_gpm, percent_above/100 × avg_gpm)
 
 **Unknown zones** (not in config) default to `avg_gpm=0`, yielding a 0.5 GPM threshold — any flow triggers an alert.
 
-**Requirements**: SSH access to Aibo (`ssh abutala@aibo`) must work without password prompt (key-based auth).
+**Requirements**: SSH access to prod controller (configured in `config/local.yaml`) must work without password prompt (key-based auth).
 
 ## Development
 

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
-from RachioFlume.alert_rules import AlertRule
+from RachioFlume.alert_rules import AlertRule, ZoneThreshold
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import FlumeClient, WaterReading
 from RachioFlume.rachio_client import RachioClient
@@ -132,13 +132,85 @@ class AlertEngine:
         pushover: Pushover,
         db: WaterTrackingDB,
         rules: list[AlertRule],
+        zone_thresholds: Optional[dict[int, ZoneThreshold]] = None,
+        absolute_gpm: float = 0.5,
+        percent_above: float = 10.0,
+        min_runtime_minutes: int = 5,
     ) -> None:
         self.flume = flume_client
         self.rachio = rachio_client
         self.pushover = pushover
         self.db = db
         self.rules = rules
+        self.zone_thresholds = zone_thresholds or {}
+        self.absolute_gpm = absolute_gpm
+        self.percent_above = percent_above
+        self.min_runtime_minutes = min_runtime_minutes
         self.logger = get_logger(__name__)
+
+    # ------------------------------------------------------------------ #
+    # Zone threshold checking                                             #
+    # ------------------------------------------------------------------ #
+
+    def _get_zone_threshold(self, zone_number: Optional[int]) -> tuple[float, float]:
+        """Get threshold for a zone.
+
+        Returns:
+            (threshold_gpm, avg_gpm) tuple
+        """
+        if zone_number is None or zone_number not in self.zone_thresholds:
+            # Unknown zone: default to avg_gpm=0, threshold=0.5
+            return self.absolute_gpm, 0.0
+
+        zt = self.zone_thresholds[zone_number]
+        threshold = zt.compute_threshold(self.absolute_gpm, self.percent_above)
+        return threshold, zt.avg_gpm
+
+    def _check_zone_threshold(
+        self,
+        zone_name: str,
+        zone_number: Optional[int],
+        avg_gpm: float,
+        runtime_min: float,
+        now: datetime,
+        dry_run: bool,
+    ) -> bool:
+        """Check if zone flow exceeds threshold and send alert if so.
+
+        Only fires if runtime_min > self.min_runtime_minutes (short runs
+        are excluded to avoid false positives from test cycles or glitches).
+
+        Returns True if alert was sent (or would be sent in dry-run).
+        """
+        if runtime_min <= self.min_runtime_minutes:
+            return False
+
+        threshold, expected_avg = self._get_zone_threshold(zone_number)
+
+        if avg_gpm <= threshold:
+            return False
+
+        # Alert: zone flow exceeds threshold
+        deviation = avg_gpm - expected_avg
+        deviation_pct = (deviation / expected_avg * 100) if expected_avg > 0 else 0
+
+        msg = (
+            f"Zone '{zone_name}' flow anomaly detected.\n"
+            f"Avg flow: {avg_gpm:.2f} GPM (threshold: {threshold:.2f} GPM)\n"
+            f"Deviation: +{deviation:.2f} GPM ({deviation_pct:.0f}%)"
+        )
+
+        if not dry_run:
+            self.pushover.send_message(msg, title="RachioFlume: Zone Anomaly", priority=2)
+            self.logger.warning(
+                f"Zone anomaly alert sent for '{zone_name}': {avg_gpm:.2f} GPM > {threshold:.2f} GPM"
+            )
+        else:
+            self.logger.info(
+                f"[DRY RUN] Would alert zone anomaly for '{zone_name}': {avg_gpm:.2f} GPM > {threshold:.2f} GPM"
+            )
+
+        return True
 
     # ------------------------------------------------------------------ #
     # Zone-end reporting                                                  #
@@ -255,12 +327,20 @@ class AlertEngine:
         if not dry_run:
             if runtime_min > 0:
                 self._send_zone_report(zone_name, runtime_min, avg_gpm, total_gal, cycle)
+                # Check if flow exceeds zone threshold
+                self._check_zone_threshold(
+                    zone_name, zone_number, avg_gpm, runtime_min, now, dry_run
+                )
             counts[zone_name] = cycle
             _save_count_map(self.db, _today_key(_REPORTED_ZONES_KEY, now), counts)
         else:
             self.logger.info(
                 f"[DRY RUN] Would report zone '{zone_name}' (cycle {cycle}): {runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
             )
+            if runtime_min > 0:
+                self._check_zone_threshold(
+                    zone_name, zone_number, avg_gpm, runtime_min, now, dry_run
+                )
 
         return True
 

--- a/RachioFlume/alert_rules.py
+++ b/RachioFlume/alert_rules.py
@@ -24,6 +24,22 @@ class AlertRule(BaseModel):
     )
 
 
+class ZoneThreshold(BaseModel):
+    """Per-zone flow threshold for anomaly detection."""
+
+    zone_number: int
+    name: str
+    avg_gpm: float
+
+    def compute_threshold(self, absolute_gpm: float, percent_above: float) -> float:
+        """Compute effective alert threshold.
+
+        threshold = avg_gpm + max(absolute_gpm, percent_above/100 * avg_gpm)
+        """
+        deviation = max(absolute_gpm, percent_above / 100.0 * self.avg_gpm)
+        return self.avg_gpm + deviation
+
+
 def load_rules_from_config() -> list[AlertRule]:
     """Build AlertRule list from `cfg.rachio_flume.alerts`."""
     cfg = get_config()
@@ -38,3 +54,17 @@ def load_rules_from_config() -> list[AlertRule]:
         )
         for r in alerts_cfg.rules
     ]
+
+
+def load_zone_thresholds_from_config() -> dict[int, ZoneThreshold]:
+    """Build zone threshold map from cfg.rachio_flume.alerts.zone_thresholds."""
+    cfg = get_config()
+    alerts_cfg = cfg.rachio_flume.alerts
+    thresholds = {}
+    for zone_num, zt_cfg in alerts_cfg.zone_thresholds.items():
+        thresholds[zone_num] = ZoneThreshold(
+            zone_number=zone_num,
+            name=zt_cfg.name,
+            avg_gpm=zt_cfg.avg_gpm,
+        )
+    return thresholds

--- a/RachioFlume/rfmanager.py
+++ b/RachioFlume/rfmanager.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from time import sleep
 from RachioFlume.alert_engine import AlertEngine
-from RachioFlume.alert_rules import load_rules_from_config
+from RachioFlume.alert_rules import load_rules_from_config, load_zone_thresholds_from_config
 from RachioFlume.collector import WaterTrackingCollector
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import FlumeClient
@@ -154,12 +154,18 @@ def main() -> int:
 def _build_alert_engine() -> AlertEngine:
     """Construct an AlertEngine sharing the rfmanager-level Pushover instance."""
     rules = load_rules_from_config()
+    zone_thresholds = load_zone_thresholds_from_config()
+    alerts_cfg = cfg.rachio_flume.alerts
     return AlertEngine(
         flume_client=FlumeClient(),
         rachio_client=RachioClient(),
         pushover=pushover,
         db=WaterTrackingDB(DB_PATH),
         rules=rules,
+        zone_thresholds=zone_thresholds,
+        absolute_gpm=alerts_cfg.absolute_gpm,
+        percent_above=alerts_cfg.percent_above,
+        min_runtime_minutes=alerts_cfg.min_runtime_minutes,
     )
 
 

--- a/RachioFlume/test_alert_engine.py
+++ b/RachioFlume/test_alert_engine.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from RachioFlume.alert_engine import AlertAction, AlertEngine, AlertState
-from RachioFlume.alert_rules import AlertRule
+from RachioFlume.alert_rules import AlertRule, ZoneThreshold
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import WaterReading
 from RachioFlume.rachio_client import Zone
@@ -39,12 +39,19 @@ def engine(db: WaterTrackingDB, rule: AlertRule) -> AlertEngine:
     rachio.get_active_zone.return_value = None
     pushover = MagicMock()
     pushover.send_message.return_value = True
+    # Provide zone thresholds high enough that test flow rates don't trigger anomalies
+    zone_thresholds = {
+        1: ZoneThreshold(zone_number=1, name="Z1*", avg_gpm=10.0),
+        2: ZoneThreshold(zone_number=2, name="Z2*", avg_gpm=10.0),
+        3: ZoneThreshold(zone_number=3, name="Z3*", avg_gpm=10.0),
+    }
     return AlertEngine(
         flume_client=flume,
         rachio_client=rachio,
         pushover=pushover,
         db=db,
         rules=[rule],
+        zone_thresholds=zone_thresholds,
     )
 
 

--- a/RachioFlume/test_zone_thresholds.py
+++ b/RachioFlume/test_zone_thresholds.py
@@ -333,14 +333,14 @@ def main() -> int:
     print("\n  Checking for threshold violations in recent data:")
     violations = 0
     for session in sessions:
-        zone_num: int | None = session.get("zone_number")
+        session_zone_num: int | None = session.get("zone_number")
         avg_gpm = session.get("average_flow_rate") or 0
-        if avg_gpm > 0 and zone_num:
-            threshold, expected = engine._get_zone_threshold(zone_num)
+        if avg_gpm > 0 and session_zone_num:
+            threshold, expected = engine._get_zone_threshold(session_zone_num)
             if avg_gpm > threshold:
-                zone_name = session.get("zone_name", f"Zone {zone_num}")
+                zone_name = session.get("zone_name", f"Zone {session_zone_num}")
                 print(
-                    f"    ⚠ Zone {zone_num} ({zone_name}): {avg_gpm:.2f} GPM > {threshold:.2f} GPM threshold"
+                    f"    ⚠ Zone {session_zone_num} ({zone_name}): {avg_gpm:.2f} GPM > {threshold:.2f} GPM threshold"
                 )
                 violations += 1
 

--- a/RachioFlume/test_zone_thresholds.py
+++ b/RachioFlume/test_zone_thresholds.py
@@ -1,0 +1,359 @@
+"""Integration test for zone threshold checking with real Aibo database.
+
+This test validates the zone threshold logic by:
+1. Fetching the production database from Aibo (configured in config/local.yaml)
+2. Testing threshold computation for all configured zones
+3. Simulating zone-end scenarios with actual historical data
+4. Verifying alert behavior for known/unknown zones
+
+Run with: python -m pytest RachioFlume/test_zone_thresholds.py -v
+Or standalone: python RachioFlume/test_zone_thresholds.py
+"""
+
+import subprocess
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from RachioFlume.alert_engine import AlertEngine
+from RachioFlume.alert_rules import ZoneThreshold, load_zone_thresholds_from_config
+from RachioFlume.data_storage import WaterTrackingDB
+from lib.config import get_config, reset_config
+
+
+def _get_aibo_config():
+    """Load Aibo SSH config from config/local.yaml."""
+    cfg = get_config()
+    return cfg.aibo.ssh_host, cfg.aibo.db_path
+
+
+@pytest.fixture(scope="module")
+def aibo_db_path() -> str:
+    """Fetch the production database from Aibo for testing."""
+    aibo_host, aibo_db = _get_aibo_config()
+    if not aibo_host or not aibo_db:
+        pytest.skip("Aibo SSH config not set in config/local.yaml")
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        subprocess.run(
+            ["scp", f"{aibo_host}:{aibo_db}", tmp_path],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        yield tmp_path
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        pytest.skip(f"Could not fetch DB from Aibo: {e}")
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+@pytest.fixture
+def zone_thresholds() -> dict[int, ZoneThreshold]:
+    """Load zone thresholds from config."""
+    reset_config()
+    return load_zone_thresholds_from_config()
+
+
+@pytest.fixture
+def mock_engine(aibo_db_path: str, zone_thresholds: dict[int, ZoneThreshold]) -> AlertEngine:
+    """Create an AlertEngine with real DB and mocked clients."""
+    db = WaterTrackingDB(aibo_db_path)
+    flume = MagicMock()
+    rachio = MagicMock()
+    rachio.get_active_zone.return_value = None
+    pushover = MagicMock()
+
+    cfg = get_config()
+    alerts_cfg = cfg.rachio_flume.alerts
+
+    return AlertEngine(
+        flume_client=flume,
+        rachio_client=rachio,
+        pushover=pushover,
+        db=db,
+        rules=[],
+        zone_thresholds=zone_thresholds,
+        absolute_gpm=alerts_cfg.absolute_gpm,
+        percent_above=alerts_cfg.percent_above,
+        min_runtime_minutes=alerts_cfg.min_runtime_minutes,
+    )
+
+
+class TestZoneThresholdComputation:
+    """Test threshold computation logic."""
+
+    def test_known_zone_threshold(self, zone_thresholds: dict[int, ZoneThreshold]):
+        """Verify threshold computation for known zones."""
+        # Zone 10: avg=7.0, threshold = 7.0 + max(0.5, 0.10*7.0) = 7.0 + 0.7 = 7.7
+        zt = zone_thresholds.get(10)
+        assert zt is not None
+        assert zt.avg_gpm == 7.0
+
+        threshold = zt.compute_threshold(absolute_gpm=0.5, percent_above=10.0)
+        assert threshold == pytest.approx(7.7, rel=0.01)
+
+    def test_small_zone_threshold(self, zone_thresholds: dict[int, ZoneThreshold]):
+        """Verify threshold for small zones uses absolute_gpm floor."""
+        # Zone 12: avg=0.75, threshold = 0.75 + max(0.5, 0.10*0.75) = 0.75 + 0.5 = 1.25
+        zt = zone_thresholds.get(12)
+        assert zt is not None
+        assert zt.avg_gpm == 0.75
+
+        threshold = zt.compute_threshold(absolute_gpm=0.5, percent_above=10.0)
+        assert threshold == pytest.approx(1.25, rel=0.01)
+
+    def test_all_zones_configured(self, zone_thresholds: dict[int, ZoneThreshold]):
+        """Verify all 12 enabled zones have thresholds."""
+        assert len(zone_thresholds) == 12
+        for zone_num in range(1, 13):
+            assert zone_num in zone_thresholds, f"Zone {zone_num} missing from config"
+
+
+class TestZoneThresholdChecking:
+    """Test zone threshold checking with real database."""
+
+    def test_get_zone_threshold_known_zone(self, mock_engine: AlertEngine):
+        """Test threshold lookup for known zone."""
+        threshold, avg_gpm = mock_engine._get_zone_threshold(zone_number=10)
+        assert avg_gpm == 7.0
+        assert threshold == pytest.approx(7.7, rel=0.01)
+
+    def test_get_zone_threshold_unknown_zone(self, mock_engine: AlertEngine):
+        """Test threshold lookup for unknown zone defaults to 0.5 GPM."""
+        threshold, avg_gpm = mock_engine._get_zone_threshold(zone_number=99)
+        assert avg_gpm == 0.0
+        assert threshold == 0.5  # absolute_gpm default
+
+    def test_get_zone_threshold_none_zone_number(self, mock_engine: AlertEngine):
+        """Test threshold lookup with None zone_number."""
+        threshold, avg_gpm = mock_engine._get_zone_threshold(zone_number=None)
+        assert avg_gpm == 0.0
+        assert threshold == 0.5
+
+    def test_check_zone_threshold_no_alert(self, mock_engine: AlertEngine):
+        """Test that normal flow doesn't trigger alert."""
+        now = datetime.now()
+        # Zone 10 threshold is 7.7 GPM, send 7.0 GPM (below threshold)
+        alerted = mock_engine._check_zone_threshold(
+            zone_name="Z10 BB - Redwoods",
+            zone_number=10,
+            avg_gpm=7.0,
+            runtime_min=10.0,
+            now=now,
+            dry_run=False,
+        )
+        assert alerted is False
+        mock_engine.pushover.send_message.assert_not_called()
+
+    def test_check_zone_threshold_alert_triggered(self, mock_engine: AlertEngine):
+        """Test that excessive flow triggers alert."""
+        now = datetime.now()
+        # Zone 10 threshold is 7.7 GPM, send 8.5 GPM (above threshold)
+        alerted = mock_engine._check_zone_threshold(
+            zone_name="Z10 BB - Redwoods",
+            zone_number=10,
+            avg_gpm=8.5,
+            runtime_min=10.0,
+            now=now,
+            dry_run=False,
+        )
+        assert alerted is True
+        mock_engine.pushover.send_message.assert_called_once()
+        call_args = mock_engine.pushover.send_message.call_args
+        assert "anomaly" in call_args[1]["title"].lower() or "anomaly" in call_args[0][0].lower()
+        assert call_args[1]["priority"] == 2  # P2 emergency
+
+    def test_check_zone_threshold_unknown_zone_alerts(self, mock_engine: AlertEngine):
+        """Test that unknown zone with any flow triggers alert."""
+        now = datetime.now()
+        # Unknown zone threshold is 0.5 GPM, send 0.6 GPM
+        alerted = mock_engine._check_zone_threshold(
+            zone_name="Unknown Zone",
+            zone_number=99,
+            avg_gpm=0.6,
+            runtime_min=10.0,
+            now=now,
+            dry_run=False,
+        )
+        assert alerted is True
+        mock_engine.pushover.send_message.assert_called_once()
+
+    def test_check_zone_threshold_dry_run(self, mock_engine: AlertEngine):
+        """Test dry run doesn't send actual alert."""
+        now = datetime.now()
+        alerted = mock_engine._check_zone_threshold(
+            zone_name="Z10 BB - Redwoods",
+            zone_number=10,
+            avg_gpm=8.5,
+            runtime_min=10.0,
+            now=now,
+            dry_run=True,
+        )
+        assert alerted is True
+        mock_engine.pushover.send_message.assert_not_called()
+
+    def test_check_zone_threshold_short_run_skipped(self, mock_engine: AlertEngine):
+        """Test that short runs (<= min_runtime_minutes) don't trigger alerts."""
+        now = datetime.now()
+        # Zone 10 threshold is 7.7 GPM, send 8.5 GPM (above threshold) but short runtime
+        alerted = mock_engine._check_zone_threshold(
+            zone_name="Z10 BB - Redwoods",
+            zone_number=10,
+            avg_gpm=8.5,
+            runtime_min=3.0,  # less than min_runtime_minutes (5)
+            now=now,
+            dry_run=False,
+        )
+        assert alerted is False
+        mock_engine.pushover.send_message.assert_not_called()
+
+
+class TestRealZoneData:
+    """Test with actual zone data from production database."""
+
+    def test_recent_zone_sessions_exist(self, aibo_db_path: str):
+        """Verify the fetched DB has recent zone session data."""
+        db = WaterTrackingDB(aibo_db_path)
+        now = datetime.now()
+        sessions = db.get_zone_sessions(now - timedelta(days=7), now)
+        assert len(sessions) > 0, "No zone sessions found in last 7 days"
+
+    def test_zone_sessions_have_flow_data(self, aibo_db_path: str):
+        """Verify zone sessions have flow rate data."""
+        db = WaterTrackingDB(aibo_db_path)
+        now = datetime.now()
+        sessions = db.get_zone_sessions(now - timedelta(days=7), now)
+
+        zones_with_flow = [s for s in sessions if (s.get("average_flow_rate") or 0) > 0]
+        assert len(zones_with_flow) > 0, "No zones with flow data found"
+
+
+def main():
+    """Standalone test runner for manual execution."""
+    print("=" * 70)
+    print("Zone Threshold Integration Test")
+    print("=" * 70)
+
+    # Load Aibo config
+    aibo_host, aibo_db = _get_aibo_config()
+    if not aibo_host or not aibo_db:
+        print("  ✗ Aibo SSH config not set in config/local.yaml")
+        return 1
+
+    # Fetch DB from Aibo
+    print("\n[1/4] Fetching database from Aibo...")
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        subprocess.run(
+            ["scp", f"{aibo_host}:{aibo_db}", tmp_path],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        print(f"  ✓ Database fetched to {tmp_path}")
+    except Exception as e:
+        print(f"  ✗ Failed to fetch DB: {e}")
+        return 1
+
+    # Load config and thresholds
+    print("\n[2/4] Loading zone thresholds from config...")
+    reset_config()
+    zone_thresholds = load_zone_thresholds_from_config()
+    print(f"  ✓ Loaded {len(zone_thresholds)} zone thresholds")
+    for zone_num in sorted(zone_thresholds.keys()):
+        zt = zone_thresholds[zone_num]
+        cfg = get_config()
+        threshold = zt.compute_threshold(
+            cfg.rachio_flume.alerts.absolute_gpm, cfg.rachio_flume.alerts.percent_above
+        )
+        print(f"    Zone {zone_num:2d}: avg={zt.avg_gpm:5.2f} GPM, threshold={threshold:5.2f} GPM")
+
+    # Test threshold checking
+    print("\n[3/4] Testing threshold checking logic...")
+    db = WaterTrackingDB(tmp_path)
+    flume = MagicMock()
+    rachio = MagicMock()
+    rachio.get_active_zone.return_value = None
+    pushover = MagicMock()
+
+    cfg = get_config()
+    alerts_cfg = cfg.rachio_flume.alerts
+
+    engine = AlertEngine(
+        flume_client=flume,
+        rachio_client=rachio,
+        pushover=pushover,
+        db=db,
+        rules=[],
+        zone_thresholds=zone_thresholds,
+        absolute_gpm=alerts_cfg.absolute_gpm,
+        percent_above=alerts_cfg.percent_above,
+        min_runtime_minutes=alerts_cfg.min_runtime_minutes,
+    )
+
+    # Test known zone
+    threshold, avg = engine._get_zone_threshold(10)
+    print(f"  ✓ Zone 10: avg={avg:.2f}, threshold={threshold:.2f}")
+
+    # Test unknown zone
+    threshold, avg = engine._get_zone_threshold(99)
+    print(f"  ✓ Zone 99 (unknown): avg={avg:.2f}, threshold={threshold:.2f}")
+
+    # Test alert triggering
+    now = datetime.now()
+    alerted = engine._check_zone_threshold("Z10 BB", 10, 8.5, 10.0, now, dry_run=True)
+    print(f"  ✓ Zone 10 @ 8.5 GPM: alert={'YES' if alerted else 'NO'} (expected: YES)")
+
+    alerted = engine._check_zone_threshold("Z10 BB", 10, 7.0, 10.0, now, dry_run=True)
+    print(f"  ✓ Zone 10 @ 7.0 GPM: alert={'YES' if alerted else 'NO'} (expected: NO)")
+
+    alerted = engine._check_zone_threshold("Unknown", 99, 0.6, 10.0, now, dry_run=True)
+    print(f"  ✓ Zone 99 @ 0.6 GPM: alert={'YES' if alerted else 'NO'} (expected: YES)")
+
+    # Check real data
+    print("\n[4/4] Checking real zone data from production...")
+    sessions = db.get_zone_sessions(now - timedelta(days=7), now)
+    print(f"  ✓ Found {len(sessions)} zone sessions in last 7 days")
+
+    zones_with_flow = [s for s in sessions if (s.get("average_flow_rate") or 0) > 0]
+    print(f"  ✓ {len(zones_with_flow)} zones with flow data")
+
+    # Check if any real sessions would trigger alerts
+    print("\n  Checking for threshold violations in recent data:")
+    violations = 0
+    for session in sessions:
+        zone_num = session.get("zone_number")
+        avg_gpm = session.get("average_flow_rate") or 0
+        if avg_gpm > 0 and zone_num:
+            threshold, expected = engine._get_zone_threshold(zone_num)
+            if avg_gpm > threshold:
+                zone_name = session.get("zone_name", f"Zone {zone_num}")
+                print(
+                    f"    ⚠ Zone {zone_num} ({zone_name}): {avg_gpm:.2f} GPM > {threshold:.2f} GPM threshold"
+                )
+                violations += 1
+
+    if violations == 0:
+        print("    ✓ No threshold violations detected")
+    else:
+        print(f"    ⚠ {violations} threshold violations detected")
+
+    print("\n" + "=" * 70)
+    print("All tests passed!")
+    print("=" * 70)
+
+    Path(tmp_path).unlink(missing_ok=True)
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/RachioFlume/test_zone_thresholds.py
+++ b/RachioFlume/test_zone_thresholds.py
@@ -1,7 +1,7 @@
-"""Integration test for zone threshold checking with real Aibo database.
+"""Integration test for zone threshold checking with production database.
 
 This test validates the zone threshold logic by:
-1. Fetching the production database from Aibo (configured in config/local.yaml)
+1. Fetching the production database from prod controller (configured in config/local.yaml)
 2. Testing threshold computation for all configured zones
 3. Simulating zone-end scenarios with actual historical data
 4. Verifying alert behavior for known/unknown zones
@@ -12,8 +12,10 @@ Or standalone: python RachioFlume/test_zone_thresholds.py
 
 import subprocess
 import tempfile
+from collections.abc import Generator
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,32 +26,32 @@ from RachioFlume.data_storage import WaterTrackingDB
 from lib.config import get_config, reset_config
 
 
-def _get_aibo_config():
-    """Load Aibo SSH config from config/local.yaml."""
+def _get_prod_controller_config() -> tuple[str, str]:
+    """Load prod controller SSH config from config/local.yaml."""
     cfg = get_config()
-    return cfg.aibo.ssh_host, cfg.aibo.db_path
+    return cfg.prod_controller.ssh_host, cfg.prod_controller.db_path
 
 
 @pytest.fixture(scope="module")
-def aibo_db_path() -> str:
-    """Fetch the production database from Aibo for testing."""
-    aibo_host, aibo_db = _get_aibo_config()
-    if not aibo_host or not aibo_db:
-        pytest.skip("Aibo SSH config not set in config/local.yaml")
+def prod_db_path() -> Generator[str, None, None]:
+    """Fetch the production database from prod controller for testing."""
+    host, db_path = _get_prod_controller_config()
+    if not host or not db_path:
+        pytest.skip("Prod controller SSH config not set in config/local.yaml")
 
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
         tmp_path = tmp.name
 
     try:
         subprocess.run(
-            ["scp", f"{aibo_host}:{aibo_db}", tmp_path],
+            ["scp", f"{host}:{db_path}", tmp_path],
             check=True,
             capture_output=True,
             timeout=30,
         )
         yield tmp_path
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-        pytest.skip(f"Could not fetch DB from Aibo: {e}")
+        pytest.skip(f"Could not fetch DB from prod controller: {e}")
     finally:
         Path(tmp_path).unlink(missing_ok=True)
 
@@ -62,9 +64,9 @@ def zone_thresholds() -> dict[int, ZoneThreshold]:
 
 
 @pytest.fixture
-def mock_engine(aibo_db_path: str, zone_thresholds: dict[int, ZoneThreshold]) -> AlertEngine:
+def mock_engine(prod_db_path: str, zone_thresholds: dict[int, ZoneThreshold]) -> AlertEngine:
     """Create an AlertEngine with real DB and mocked clients."""
-    db = WaterTrackingDB(aibo_db_path)
+    db = WaterTrackingDB(prod_db_path)
     flume = MagicMock()
     rachio = MagicMock()
     rachio.get_active_zone.return_value = None
@@ -89,7 +91,7 @@ def mock_engine(aibo_db_path: str, zone_thresholds: dict[int, ZoneThreshold]) ->
 class TestZoneThresholdComputation:
     """Test threshold computation logic."""
 
-    def test_known_zone_threshold(self, zone_thresholds: dict[int, ZoneThreshold]):
+    def test_known_zone_threshold(self, zone_thresholds: dict[int, ZoneThreshold]) -> None:
         """Verify threshold computation for known zones."""
         # Zone 10: avg=7.0, threshold = 7.0 + max(0.5, 0.10*7.0) = 7.0 + 0.7 = 7.7
         zt = zone_thresholds.get(10)
@@ -99,7 +101,7 @@ class TestZoneThresholdComputation:
         threshold = zt.compute_threshold(absolute_gpm=0.5, percent_above=10.0)
         assert threshold == pytest.approx(7.7, rel=0.01)
 
-    def test_small_zone_threshold(self, zone_thresholds: dict[int, ZoneThreshold]):
+    def test_small_zone_threshold(self, zone_thresholds: dict[int, ZoneThreshold]) -> None:
         """Verify threshold for small zones uses absolute_gpm floor."""
         # Zone 12: avg=0.75, threshold = 0.75 + max(0.5, 0.10*0.75) = 0.75 + 0.5 = 1.25
         zt = zone_thresholds.get(12)
@@ -109,7 +111,7 @@ class TestZoneThresholdComputation:
         threshold = zt.compute_threshold(absolute_gpm=0.5, percent_above=10.0)
         assert threshold == pytest.approx(1.25, rel=0.01)
 
-    def test_all_zones_configured(self, zone_thresholds: dict[int, ZoneThreshold]):
+    def test_all_zones_configured(self, zone_thresholds: dict[int, ZoneThreshold]) -> None:
         """Verify all 12 enabled zones have thresholds."""
         assert len(zone_thresholds) == 12
         for zone_num in range(1, 13):
@@ -119,25 +121,25 @@ class TestZoneThresholdComputation:
 class TestZoneThresholdChecking:
     """Test zone threshold checking with real database."""
 
-    def test_get_zone_threshold_known_zone(self, mock_engine: AlertEngine):
+    def test_get_zone_threshold_known_zone(self, mock_engine: AlertEngine) -> None:
         """Test threshold lookup for known zone."""
         threshold, avg_gpm = mock_engine._get_zone_threshold(zone_number=10)
         assert avg_gpm == 7.0
         assert threshold == pytest.approx(7.7, rel=0.01)
 
-    def test_get_zone_threshold_unknown_zone(self, mock_engine: AlertEngine):
+    def test_get_zone_threshold_unknown_zone(self, mock_engine: AlertEngine) -> None:
         """Test threshold lookup for unknown zone defaults to 0.5 GPM."""
         threshold, avg_gpm = mock_engine._get_zone_threshold(zone_number=99)
         assert avg_gpm == 0.0
         assert threshold == 0.5  # absolute_gpm default
 
-    def test_get_zone_threshold_none_zone_number(self, mock_engine: AlertEngine):
+    def test_get_zone_threshold_none_zone_number(self, mock_engine: AlertEngine) -> None:
         """Test threshold lookup with None zone_number."""
         threshold, avg_gpm = mock_engine._get_zone_threshold(zone_number=None)
         assert avg_gpm == 0.0
         assert threshold == 0.5
 
-    def test_check_zone_threshold_no_alert(self, mock_engine: AlertEngine):
+    def test_check_zone_threshold_no_alert(self, mock_engine: AlertEngine) -> None:
         """Test that normal flow doesn't trigger alert."""
         now = datetime.now()
         # Zone 10 threshold is 7.7 GPM, send 7.0 GPM (below threshold)
@@ -150,9 +152,9 @@ class TestZoneThresholdChecking:
             dry_run=False,
         )
         assert alerted is False
-        mock_engine.pushover.send_message.assert_not_called()
+        mock_engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
 
-    def test_check_zone_threshold_alert_triggered(self, mock_engine: AlertEngine):
+    def test_check_zone_threshold_alert_triggered(self, mock_engine: AlertEngine) -> None:
         """Test that excessive flow triggers alert."""
         now = datetime.now()
         # Zone 10 threshold is 7.7 GPM, send 8.5 GPM (above threshold)
@@ -165,12 +167,12 @@ class TestZoneThresholdChecking:
             dry_run=False,
         )
         assert alerted is True
-        mock_engine.pushover.send_message.assert_called_once()
-        call_args = mock_engine.pushover.send_message.call_args
+        mock_engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
+        call_args: Any = mock_engine.pushover.send_message.call_args  # type: ignore[attr-defined]
         assert "anomaly" in call_args[1]["title"].lower() or "anomaly" in call_args[0][0].lower()
         assert call_args[1]["priority"] == 2  # P2 emergency
 
-    def test_check_zone_threshold_unknown_zone_alerts(self, mock_engine: AlertEngine):
+    def test_check_zone_threshold_unknown_zone_alerts(self, mock_engine: AlertEngine) -> None:
         """Test that unknown zone with any flow triggers alert."""
         now = datetime.now()
         # Unknown zone threshold is 0.5 GPM, send 0.6 GPM
@@ -183,9 +185,9 @@ class TestZoneThresholdChecking:
             dry_run=False,
         )
         assert alerted is True
-        mock_engine.pushover.send_message.assert_called_once()
+        mock_engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
 
-    def test_check_zone_threshold_dry_run(self, mock_engine: AlertEngine):
+    def test_check_zone_threshold_dry_run(self, mock_engine: AlertEngine) -> None:
         """Test dry run doesn't send actual alert."""
         now = datetime.now()
         alerted = mock_engine._check_zone_threshold(
@@ -197,9 +199,9 @@ class TestZoneThresholdChecking:
             dry_run=True,
         )
         assert alerted is True
-        mock_engine.pushover.send_message.assert_not_called()
+        mock_engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
 
-    def test_check_zone_threshold_short_run_skipped(self, mock_engine: AlertEngine):
+    def test_check_zone_threshold_short_run_skipped(self, mock_engine: AlertEngine) -> None:
         """Test that short runs (<= min_runtime_minutes) don't trigger alerts."""
         now = datetime.now()
         # Zone 10 threshold is 7.7 GPM, send 8.5 GPM (above threshold) but short runtime
@@ -212,22 +214,22 @@ class TestZoneThresholdChecking:
             dry_run=False,
         )
         assert alerted is False
-        mock_engine.pushover.send_message.assert_not_called()
+        mock_engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
 
 
 class TestRealZoneData:
     """Test with actual zone data from production database."""
 
-    def test_recent_zone_sessions_exist(self, aibo_db_path: str):
+    def test_recent_zone_sessions_exist(self, prod_db_path: str) -> None:
         """Verify the fetched DB has recent zone session data."""
-        db = WaterTrackingDB(aibo_db_path)
+        db = WaterTrackingDB(prod_db_path)
         now = datetime.now()
         sessions = db.get_zone_sessions(now - timedelta(days=7), now)
         assert len(sessions) > 0, "No zone sessions found in last 7 days"
 
-    def test_zone_sessions_have_flow_data(self, aibo_db_path: str):
+    def test_zone_sessions_have_flow_data(self, prod_db_path: str) -> None:
         """Verify zone sessions have flow rate data."""
-        db = WaterTrackingDB(aibo_db_path)
+        db = WaterTrackingDB(prod_db_path)
         now = datetime.now()
         sessions = db.get_zone_sessions(now - timedelta(days=7), now)
 
@@ -235,26 +237,26 @@ class TestRealZoneData:
         assert len(zones_with_flow) > 0, "No zones with flow data found"
 
 
-def main():
+def main() -> int:
     """Standalone test runner for manual execution."""
     print("=" * 70)
     print("Zone Threshold Integration Test")
     print("=" * 70)
 
-    # Load Aibo config
-    aibo_host, aibo_db = _get_aibo_config()
-    if not aibo_host or not aibo_db:
-        print("  ✗ Aibo SSH config not set in config/local.yaml")
+    # Load prod controller config
+    host, db_path = _get_prod_controller_config()
+    if not host or not db_path:
+        print("  ✗ Prod controller SSH config not set in config/local.yaml")
         return 1
 
-    # Fetch DB from Aibo
-    print("\n[1/4] Fetching database from Aibo...")
+    # Fetch DB from prod controller
+    print("\n[1/4] Fetching database from prod controller...")
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
         tmp_path = tmp.name
 
     try:
         subprocess.run(
-            ["scp", f"{aibo_host}:{aibo_db}", tmp_path],
+            ["scp", f"{host}:{db_path}", tmp_path],
             check=True,
             capture_output=True,
             timeout=30,
@@ -331,7 +333,7 @@ def main():
     print("\n  Checking for threshold violations in recent data:")
     violations = 0
     for session in sessions:
-        zone_num = session.get("zone_number")
+        zone_num: int | None = session.get("zone_number")
         avg_gpm = session.get("average_flow_rate") or 0
         if avg_gpm > 0 and zone_num:
             threshold, expected = engine._get_zone_threshold(zone_num)

--- a/SamsungFrame/test_manage_samsung.py
+++ b/SamsungFrame/test_manage_samsung.py
@@ -12,7 +12,7 @@ class TestRebootTvHandler:
     def test_connect_fails_returns_1(self, mock_cls: Mock) -> None:
         mock_client = MagicMock()
         mock_client.__enter__ = Mock(
-            side_effect=ConnectionError("Failed to get TV ready at 192.168.1.4")
+            side_effect=ConnectionError("Failed to get TV ready at 192.0.2.4")
         )
         mock_client.__exit__ = Mock(return_value=False)
         mock_cls.return_value = mock_client
@@ -54,7 +54,7 @@ class TestShowStatusHandler:
     def test_connect_fails_returns_1(self, mock_cls: Mock) -> None:
         mock_client = MagicMock()
         mock_client.__enter__ = Mock(
-            side_effect=ConnectionError("Failed to get TV ready at 192.168.1.4")
+            side_effect=ConnectionError("Failed to get TV ready at 192.0.2.4")
         )
         mock_client.__exit__ = Mock(return_value=False)
         mock_cls.return_value = mock_client

--- a/SamsungFrame/test_samsung_client.py
+++ b/SamsungFrame/test_samsung_client.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch, MagicMock
 
 from SamsungFrame.samsung_client import SamsungFrameClient
 
-TV_HOST = "192.168.1.4"
+TV_HOST = "192.0.2.4"
 TOKEN_FILE = "/tmp/token.txt"
 
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -285,9 +285,9 @@ launch_jobs:
     stdout_path: ${paths.home}/bin/knowledge/personal/wa_summary.out.log
     stderr_path: ${paths.home}/bin/knowledge/personal/wa_summary.err.log
 
-# === Aibo (remote DB host for integration tests) ===
-aibo:
-  ssh_host: ""          # e.g. "abutala@aibo"
+# === Prod Controller (remote DB host for integration tests) ===
+prod_controller:
+  ssh_host: ""          # e.g. "user@host"
   db_path: ""           # e.g. "~/logs/water_tracking.db"
 
 # === Constants ===

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -235,11 +235,33 @@ rachio_flume:
   alerts:
     enabled: true
     default_retrigger_minutes: 30
+    # Zone-end anomaly threshold: alert when flow exceeds zone avg by the
+    # greater of absolute_gpm or (percent_above / 100 * avg_gpm).
+    # "adaptive" = max(absolute_gpm, percent_above/100 * avg_gpm)
+    threshold_mode: adaptive
+    absolute_gpm: 0.5        # min deviation above average (GPM)
+    percent_above: 10        # min deviation above average (%)
+    min_runtime_minutes: 5   # zone must run this long (min) before threshold alert fires
     rules:
       - {name: "Pipe Break", min_gpm: 8.0, duration_minutes: 10}
       - {name: "High Flow",  min_gpm: 5.4, duration_minutes: 4}
       - {name: "Mid Flow",   min_gpm: 2.6, duration_minutes: 14}
       - {name: "Leak",       min_gpm: 0.1, duration_minutes: 120}
+    # Per-zone average flow rates (GPM) from historical data.
+    # Alert fires when zone-end flow > avg + max(absolute_gpm, percent_above/100 * avg).
+    zone_thresholds:
+      1:  {name: "Z1*",  avg_gpm: 5.0}
+      2:  {name: "Z2*",  avg_gpm: 6.5}
+      3:  {name: "Z3*",  avg_gpm: 2.0}
+      4:  {name: "Z4*",  avg_gpm: 3.0}
+      5:  {name: "Z5*",  avg_gpm: 3.5}
+      6:  {name: "Z6*",  avg_gpm: 4.5}
+      7:  {name: "Z7*",  avg_gpm: 2.5}
+      8:  {name: "Z8*",  avg_gpm: 3.0}
+      9:  {name: "Z9*",  avg_gpm: 1.5}
+      10: {name: "Z10*", avg_gpm: 7.0}
+      11: {name: "Z11*", avg_gpm: 6.0}
+      12: {name: "Z12*", avg_gpm: 0.75}
 
 # === PersonalCalSync (Google Apps Script) ===
 personal_cal_sync:
@@ -262,6 +284,11 @@ launch_jobs:
     minute: 30
     stdout_path: ${paths.home}/bin/knowledge/personal/wa_summary.out.log
     stderr_path: ${paths.home}/bin/knowledge/personal/wa_summary.err.log
+
+# === Aibo (remote DB host for integration tests) ===
+aibo:
+  ssh_host: ""          # e.g. "abutala@aibo"
+  db_path: ""           # e.g. "~/logs/water_tracking.db"
 
 # === Constants ===
 my_external_ip: "hoiboi.tplinkdns.com"

--- a/lib/config.py
+++ b/lib/config.py
@@ -319,8 +319,8 @@ class VoiceNotesConfig:
 
 
 @dataclass
-class AiboConfig:
-    """Aibo remote DB host configuration"""
+class ProdControllerConfig:
+    """Prod controller remote DB host configuration"""
 
     ssh_host: str
     db_path: str
@@ -346,7 +346,7 @@ class Config:
     browser_alert: BrowserAlertConfig
     personal_cal_sync: PersonalCalSyncConfig
     voice_notes: VoiceNotesConfig
-    aibo: AiboConfig
+    prod_controller: ProdControllerConfig
     launch_jobs: LaunchJobsConfig
     my_external_ip: str
     seconds_in_day: int

--- a/lib/config.py
+++ b/lib/config.py
@@ -233,12 +233,25 @@ class AlertRuleConfig:
 
 
 @dataclass
+class ZoneThresholdConfig:
+    """Per-zone flow threshold for anomaly detection"""
+
+    name: str
+    avg_gpm: float
+
+
+@dataclass
 class RachioFlumeAlertsConfig:
     """Usage alert configuration for RachioFlume"""
 
     enabled: bool
     default_retrigger_minutes: int
+    threshold_mode: str  # "adaptive", "absolute", or "percent"
+    absolute_gpm: float  # min deviation above average (GPM)
+    percent_above: float  # min deviation above average (%)
+    min_runtime_minutes: int  # zone must run this long before threshold alert fires
     rules: list[AlertRuleConfig]
+    zone_thresholds: Dict[int, ZoneThresholdConfig]  # zone_number -> threshold
 
 
 @dataclass
@@ -306,6 +319,14 @@ class VoiceNotesConfig:
 
 
 @dataclass
+class AiboConfig:
+    """Aibo remote DB host configuration"""
+
+    ssh_host: str
+    db_path: str
+
+
+@dataclass
 class Config:
     """Root configuration for homely-vibes"""
 
@@ -325,6 +346,7 @@ class Config:
     browser_alert: BrowserAlertConfig
     personal_cal_sync: PersonalCalSyncConfig
     voice_notes: VoiceNotesConfig
+    aibo: AiboConfig
     launch_jobs: LaunchJobsConfig
     my_external_ip: str
     seconds_in_day: int
@@ -402,11 +424,17 @@ def _dict_to_config(cfg_dict: dict) -> Config:  # type: ignore
                     # Plain list (e.g., list[str])
                     kwargs[field_name] = value
             elif origin is dict:
-                # Handle Dict[str, SomeDataclass] types
+                # Handle Dict[K, SomeDataclass] types
                 args = get_args(field_type)
                 if len(args) >= 2 and is_dataclass(args[1]):
                     value_class: type = args[1]  # type: ignore[assignment]
-                    kwargs[field_name] = {k: build_nested(v, value_class) for k, v in value.items()}
+                    key_type = args[0]
+                    converted = {}
+                    for k, v in value.items():
+                        # Convert key type (e.g., str "1" -> int 1)
+                        ck = key_type(k) if key_type is not str and isinstance(k, str) else k
+                        converted[ck] = build_nested(v, value_class)
+                    kwargs[field_name] = converted
                 else:
                     kwargs[field_name] = value
             elif is_dataclass(field_type):


### PR DESCRIPTION
## Why
Zone-end reports showed flow rates but had no anomaly detection. Unknown zones or misconfigured irrigation could waste water without alerting. Test files also contained hardcoded device IPs that matched production config.

## Impact
RachioFlume now alerts (P2 emergency) when a zone's flow exceeds its adaptive threshold (avg + max(0.5 GPM, 10% of avg)). Short runs (<5 min) are excluded to avoid false positives. All test files now use RFC 5737 documentation IPs (192.0.2.0/24) instead of real device addresses.

## Changes
- **Zone thresholds**: Per-zone avg_gpm config in default.yaml/local.yaml with adaptive threshold formula
- **Min runtime guard**: Only alert if zone ran > 5 min (configurable via min_runtime_minutes)
- **Integration test**: Fetches production DB from Aibo and validates threshold logic against real data
- **Security scrub**: Replaced hardcoded IPs in NodeCheck/SamsungFrame tests with 192.0.2.x
- **Config**: Added Aibo SSH config to local.yaml (gitignored)
- **Docs**: Added secrets management section to top-level README

## Files Changed
- RachioFlume/alert_engine.py, alert_rules.py, rfmanager.py
- RachioFlume/test_zone_thresholds.py (new integration test)
- config/default.yaml, config/local.yaml, lib/config.py
- NodeCheck/test_nodes.py, SamsungFrame/test_*.py
- README.md, RachioFlume/README.md