### PR TITLE
Guard vcgencmd on readable /dev/vcio with sysfs fallback

### DIFF
--- a/NodeCheck/check_hw_specs.py
+++ b/NodeCheck/check_hw_specs.py
@@ -80,9 +80,26 @@ emit "USB" "$(lsusb 2>/dev/null | sed 's/^Bus [0-9]* Device [0-9]*: ID [0-9a-f:]
 OS_NAME=$(. /etc/os-release 2>/dev/null && echo "$PRETTY_NAME")
 emit "OS" "${OS_NAME:-n/a}"
 emit "Kernel" "$(uname -srm 2>/dev/null)"
-emit "Firmware" "$(vcgencmd version 2>/dev/null | head -1 | sed 's/^ *//')"
-TEMP=$(vcgencmd measure_temp 2>/dev/null | sed "s/temp=//; s/'C/ C/")
-[ -z "$TEMP" ] && TEMP=$(awk '{printf "%.1f C",$1/1000}' /sys/class/thermal/thermal_zone0/temp 2>/dev/null)
+# Firmware + Temperature: Pi uses vcgencmd (needs a *readable* /dev/vcio, i.e.
+# user in the video group). Other hosts, or Pis where the user lacks perms,
+# fall back to DMI sysfs (firmware) and thermal_zone sysfs (temperature).
+if [ -r /dev/vcio ] && command -v vcgencmd >/dev/null 2>&1; then
+    emit "Firmware" "$(vcgencmd version 2>/dev/null | head -1 | sed 's/^ *//')"
+    TEMP=$(vcgencmd measure_temp 2>/dev/null | sed "s/temp=//; s/'C/ C/")
+else
+    FW_VER=$(cat /sys/class/dmi/id/bios_version 2>/dev/null)
+    FW_DATE=$(cat /sys/class/dmi/id/bios_date 2>/dev/null)
+    if [ -n "$FW_VER" ] || [ -n "$FW_DATE" ]; then
+        emit "Firmware" "${FW_VER:-unknown} (${FW_DATE:-unknown})"
+    else
+        emit "Firmware" "n/a"
+    fi
+    TEMP=""
+fi
+if [ -z "$TEMP" ]; then
+    TZ=$(ls /sys/class/thermal/thermal_zone*/temp 2>/dev/null | head -1)
+    [ -n "$TZ" ] && TEMP=$(awk '{printf "%.1f C",$1/1000}' "$TZ" 2>/dev/null)
+fi
 emit "Temperature" "${TEMP:-n/a}"
 """
 

--- a/NodeCheck/check_hw_specs.py
+++ b/NodeCheck/check_hw_specs.py
@@ -97,8 +97,12 @@ else
     TEMP=""
 fi
 if [ -z "$TEMP" ]; then
-    TZ=$(ls /sys/class/thermal/thermal_zone*/temp 2>/dev/null | head -1)
-    [ -n "$TZ" ] && TEMP=$(awk '{printf "%.1f C",$1/1000}' "$TZ" 2>/dev/null)
+    # Prefer a CPU thermal zone; fall back to thermal_zone0.
+    TZ=$(for z in /sys/class/thermal/thermal_zone*; do
+             [ -r "$z/type" ] && grep -qi cpu "$z/type" && echo "$z/temp" && break
+         done)
+    [ -z "$TZ" ] && TZ=/sys/class/thermal/thermal_zone0/temp
+    [ -r "$TZ" ] && TEMP=$(awk '{printf "%.1f C",$1/1000}' "$TZ" 2>/dev/null)
 fi
 emit "Temperature" "${TEMP:-n/a}"
 """


### PR DESCRIPTION
## Why
`check_hw_specs.py` assumed `vcgencmd` works whenever `/dev/vcio` exists. On a Pi where the SSH user lacks `video`-group membership, `/dev/vcio` exists but is **unreadable** (`crw-rw---- root:video`), so `vcgencmd` printed `Can't open device file: /dev/vcio` straight into the Firmware and Temperature fields.

## Impact
Firmware/Temperature now degrade gracefully on any host where `vcgencmd` is unusable — whether a real non-Pi host (no `/dev/vcio`) or a Pi with missing permissions. No regression on Pis where `vcgencmd` works.

## Changes
- Guard switched from `-c /dev/vcio` (exists) to `-r /dev/vcio` (**readable** by the current user).
- Added fallbacks when `vcgencmd` is unusable:
  - **Firmware** → DMI sysfs (`/sys/class/dmi/id/bios_version`, `bios_date`); `n/a` if absent (Pis have no DMI).
  - **Temperature** → first `thermal_zone*/temp` sysfs entry.

## References
- Predecessor: PR #197 (added `NodeCheck/check_hw_specs.py`)
- Repro host: 199 (Pi 4, `abutala` not in `video` group) — Firmware row showed `Can't open device file: /dev/vcio`
- Verified on 199 (fallback: `Firmware n/a`, `Temperature 53.6 C`) and aibo (no regression: `Firmware Feb 29 2024…`, `Temperature 33.6 C` via `vcgencmd`)
- Note: on a Pi the only firmware source is `vcgencmd`; DMI fallback helps x86/real-PC hosts only. Fixing 199 firmware fully = `sudo usermod -aG video abutala` on 199 (applied separately).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)