### PR TITLE
feat(RachioFlume): Smart Hose Timer support + per-zone baseline in pushover

### DIFF
--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -266,13 +266,29 @@ class AlertEngine:
         )[0]
 
     def _send_zone_report(
-        self, zone_name: str, runtime_min: float, avg_gpm: float, total_gal: float, cycle: int
+        self,
+        zone_name: str,
+        zone_number: Optional[int],
+        runtime_min: float,
+        avg_gpm: float,
+        total_gal: float,
+        cycle: int,
     ) -> None:
         cycle_label = f" (Cycle {cycle})" if cycle > 1 else ""
+        baseline = (
+            self.zone_thresholds[zone_number].avg_gpm
+            if zone_number is not None and zone_number in self.zone_thresholds
+            else None
+        )
+        flow_line = (
+            f"Avg flow: {avg_gpm:.2f} GPM (thresh {baseline:.2f})"
+            if baseline is not None
+            else f"Avg flow: {avg_gpm:.2f} GPM"
+        )
         msg = (
             f"Zone '{zone_name}' completed{cycle_label}.\n"
             f"Runtime: {runtime_min:.0f} min\n"
-            f"Avg flow: {avg_gpm:.2f} GPM\n"
+            f"{flow_line}\n"
             f"Total: {total_gal:.1f} gal"
         )
         self.pushover.send_message(msg, title="RachioFlume: Zone Report", priority=-1)
@@ -326,7 +342,9 @@ class AlertEngine:
 
         if not dry_run:
             if runtime_min > 0:
-                self._send_zone_report(zone_name, runtime_min, avg_gpm, total_gal, cycle)
+                self._send_zone_report(
+                    zone_name, zone_number, runtime_min, avg_gpm, total_gal, cycle
+                )
                 # Check if flow exceeds zone threshold
                 self._check_zone_threshold(
                     zone_name, zone_number, avg_gpm, runtime_min, now, dry_run

--- a/RachioFlume/alert_rules.py
+++ b/RachioFlume/alert_rules.py
@@ -25,9 +25,15 @@ class AlertRule(BaseModel):
 
 
 class ZoneThreshold(BaseModel):
-    """Per-zone flow threshold for anomaly detection."""
+    """Per-zone flow baseline for anomaly detection.
 
-    zone_number: int
+    `zone_key` is the device-local identifier — stringified zone_number for
+    controllers (e.g. "1") or the valve name for hose timers
+    (e.g. "Upper Deck Planters"). Device scope is tracked separately by the
+    caller's keying strategy (see load_zone_thresholds_from_config).
+    """
+
+    zone_key: str
     name: str
     avg_gpm: float
 
@@ -56,15 +62,51 @@ def load_rules_from_config() -> list[AlertRule]:
     ]
 
 
-def load_zone_thresholds_from_config() -> dict[int, ZoneThreshold]:
-    """Build zone threshold map from cfg.rachio_flume.alerts.zone_thresholds."""
+def load_zone_thresholds_from_config() -> dict[str, dict[str, ZoneThreshold]]:
+    """Build {device_label -> {zone_key -> ZoneThreshold}} from config.
+
+    `zone_key` is a stringified zone_number for controllers, or the valve name
+    for hose timers — matches the structure of cfg.rachio_flume.alerts.zone_thresholds.
+
+    Inner entries arrive as plain dicts (OmegaConf does not auto-construct
+    dataclasses at depth-2 of Dict[Dict[...]]). Read fields by key.
+    """
     cfg = get_config()
     alerts_cfg = cfg.rachio_flume.alerts
-    thresholds = {}
-    for zone_num, zt_cfg in alerts_cfg.zone_thresholds.items():
-        thresholds[zone_num] = ZoneThreshold(
-            zone_number=zone_num,
-            name=zt_cfg.name,
-            avg_gpm=zt_cfg.avg_gpm,
-        )
-    return thresholds
+    out: dict[str, dict[str, ZoneThreshold]] = {}
+    for device_label, zones in alerts_cfg.zone_thresholds.items():
+        out[device_label] = {}
+        for zone_key, zt_cfg in zones.items():
+            zk = str(zone_key)
+            # zt_cfg may be a dict (depth-2 OmegaConf) or a ZoneThresholdConfig
+            # (if the loader was ever extended). Accept both.
+            if isinstance(zt_cfg, dict):
+                name = zt_cfg["name"]
+                avg_gpm = zt_cfg["avg_gpm"]
+            else:
+                name = zt_cfg.name
+                avg_gpm = zt_cfg.avg_gpm
+            out[device_label][zk] = ZoneThreshold(
+                zone_key=zk,
+                name=name,
+                avg_gpm=avg_gpm,
+            )
+    return out
+
+
+def get_controller_zone_thresholds(
+    all_thresholds: dict[str, dict[str, ZoneThreshold]],
+    device_label: str,
+) -> dict[int, ZoneThreshold]:
+    """Filter to controller thresholds for one device, keyed by zone_number (int).
+
+    Convenience for AlertEngine which historically keys by int zone_number.
+    """
+    out: dict[int, ZoneThreshold] = {}
+    for zone_key, zt in all_thresholds.get(device_label, {}).items():
+        try:
+            out[int(zone_key)] = zt
+        except ValueError:
+            # Non-integer keys belong to hose timers; skip.
+            continue
+    return out

--- a/RachioFlume/collector.py
+++ b/RachioFlume/collector.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Optional, Dict, Any, List
 
 from RachioFlume.alert_engine import AlertEngine
+from RachioFlume.hose_timer_processor import HoseTimerProcessor
 from RachioFlume.rachio_client import RachioClient
 from RachioFlume.flume_client import FlumeClient
 from RachioFlume.data_storage import WaterTrackingDB
@@ -19,6 +20,7 @@ class WaterTrackingCollector:
         db_path: str,
         poll_interval_seconds: int = 300,  # 5 minutes default
         alert_engine: Optional[AlertEngine] = None,
+        hose_processors: Optional[List[HoseTimerProcessor]] = None,
     ):
         self.logger = get_logger(__name__)
 
@@ -27,6 +29,7 @@ class WaterTrackingCollector:
         self.flume_client = FlumeClient()
         self.poll_interval = poll_interval_seconds
         self.alert_engine = alert_engine
+        self.hose_processors = hose_processors or []
 
         # Initialize last collection times from database to avoid duplicates
         self.last_rachio_collection: Optional[datetime] = self.db.get_last_collection_timestamp(
@@ -141,6 +144,15 @@ class WaterTrackingCollector:
 
         # Process the collected data
         await self.process_collected_data()
+
+        # Evaluate hose-timer processors (one per Smart Hose Timer base station).
+        # Synchronous calls — each issues 1-2 HTTP requests per valve, well
+        # under the 5-minute poll cadence even with several base stations.
+        for proc in self.hose_processors:
+            try:
+                proc.evaluate()
+            except Exception as e:
+                self.logger.error(f"Hose-timer processor '{proc.client.label}' failed: {e}")
 
         # Evaluate usage alerts (no-op if engine not configured)
         if self.alert_engine is not None:

--- a/RachioFlume/data_storage.py
+++ b/RachioFlume/data_storage.py
@@ -96,6 +96,62 @@ class WaterTrackingDB:
             """
             )
 
+            # === Hose-timer tables (Rachio Smart Hose Timer / cloud-rest.rach.io) ===
+            # Kept in separate tables from the controller schema so multiple
+            # Bluetooth valves under one or more base stations can coexist
+            # without zone_number collisions or schema migrations.
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS hose_valves (
+                    id TEXT PRIMARY KEY,                    -- valveId
+                    base_station_id TEXT NOT NULL,
+                    base_station_label TEXT NOT NULL,       -- human label (e.g. "Hose Drip Jasmine")
+                    name TEXT NOT NULL,                     -- valve name (e.g. "Upper Deck Planters")
+                    default_runtime_seconds INTEGER,
+                    detect_flow BOOLEAN DEFAULT 0,
+                    battery_status TEXT,
+                    connected BOOLEAN DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """
+            )
+
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS hose_watering_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    valve_id TEXT NOT NULL,
+                    base_station_id TEXT NOT NULL,
+                    event_date TIMESTAMP NOT NULL,          -- run start time
+                    event_type TEXT NOT NULL,               -- ZONE_STARTED | ZONE_COMPLETED
+                    duration_seconds INTEGER,               -- planned (start) or actual (complete)
+                    reason TEXT,                            -- QUICK_RUN | SCHEDULE | etc.
+                    flow_detected INTEGER,                  -- 0/1, NULL if not reported
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(valve_id, event_date, event_type)
+                )
+            """
+            )
+
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS hose_zone_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    valve_id TEXT NOT NULL,
+                    base_station_id TEXT NOT NULL,
+                    valve_name TEXT NOT NULL,
+                    base_station_label TEXT NOT NULL,
+                    start_time TIMESTAMP NOT NULL,
+                    end_time TIMESTAMP,
+                    duration_seconds INTEGER,
+                    flow_detected INTEGER,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(valve_id, start_time)
+                )
+            """
+            )
+
             # Create indexes for better query performance
             cursor.execute(
                 "CREATE INDEX IF NOT EXISTS idx_watering_events_date ON watering_events(event_date)"
@@ -108,6 +164,12 @@ class WaterTrackingDB:
             )
             cursor.execute(
                 "CREATE INDEX IF NOT EXISTS idx_zone_sessions_times ON zone_sessions(start_time, end_time)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hose_events_valve ON hose_watering_events(valve_id, event_date)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hose_sessions_times ON hose_zone_sessions(start_time, end_time)"
             )
 
             conn.commit()
@@ -435,6 +497,107 @@ class WaterTrackingDB:
             cursor = conn.cursor()
             cursor.execute("DELETE FROM collection_metadata WHERE key = ?", (key,))
             conn.commit()
+
+    # =====================================================================
+    # Hose-timer storage (separate from controller schema)
+    # =====================================================================
+
+    def save_hose_valves(self, valves: List[Dict[str, Any]]) -> None:
+        """Upsert hose-timer valves (one row per (base_station, valve))."""
+        if not valves:
+            return
+        self.logger.info(f"Saving {len(valves)} hose-timer valves")
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            for v in valves:
+                cursor.execute(
+                    """
+                    INSERT OR REPLACE INTO hose_valves (
+                        id, base_station_id, base_station_label, name,
+                        default_runtime_seconds, detect_flow, battery_status,
+                        connected, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        v["id"],
+                        v["base_station_id"],
+                        v["base_station_label"],
+                        v["name"],
+                        v.get("default_runtime_seconds"),
+                        1 if v.get("detect_flow") else 0,
+                        v.get("battery_status"),
+                        1 if v.get("connected", True) else 0,
+                        datetime.now(),
+                    ),
+                )
+            conn.commit()
+
+    def save_hose_watering_event(self, event: Dict[str, Any]) -> None:
+        """Insert a hose-timer event (idempotent on (valve_id, event_date, event_type))."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO hose_watering_events (
+                    valve_id, base_station_id, event_date, event_type,
+                    duration_seconds, reason, flow_detected
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event["valve_id"],
+                    event["base_station_id"],
+                    event["event_date"],
+                    event["event_type"],
+                    event.get("duration_seconds"),
+                    event.get("reason"),
+                    None
+                    if event.get("flow_detected") is None
+                    else (1 if event["flow_detected"] else 0),
+                ),
+            )
+            conn.commit()
+
+    def save_hose_zone_session(self, session: Dict[str, Any]) -> None:
+        """Insert a finalized hose-timer session row."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO hose_zone_sessions (
+                    valve_id, base_station_id, valve_name, base_station_label,
+                    start_time, end_time, duration_seconds, flow_detected
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session["valve_id"],
+                    session["base_station_id"],
+                    session["valve_name"],
+                    session["base_station_label"],
+                    session["start_time"],
+                    session["end_time"],
+                    session["duration_seconds"],
+                    None
+                    if session.get("flow_detected") is None
+                    else (1 if session["flow_detected"] else 0),
+                ),
+            )
+            conn.commit()
+
+    def get_hose_zone_sessions(
+        self, start_date: datetime, end_date: datetime
+    ) -> List[Dict[str, Any]]:
+        """Get hose-timer sessions for a date range."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT * FROM hose_zone_sessions
+                WHERE start_time >= ? AND start_time <= ?
+                ORDER BY start_time
+                """,
+                (start_date, end_date),
+            )
+            return [dict(row) for row in cursor.fetchall()]
 
     def get_last_data_timestamp(self, source: str) -> Optional[datetime]:
         """Get the actual last timestamp from data tables."""

--- a/RachioFlume/hose_timer_processor.py
+++ b/RachioFlume/hose_timer_processor.py
@@ -69,7 +69,13 @@ class HoseTimerProcessor:
     def _evaluate_valve(self, valve: HoseValve, now: datetime, dry_run: bool) -> dict:
         action = valve.last_watering_action
         cached_blob = self.db.get_metadata(_state_key(valve.id))
-        cached = json.loads(cached_blob) if cached_blob else None
+        cached: Optional[dict] = None
+        if cached_blob:
+            try:
+                cached = json.loads(cached_blob)
+            except json.JSONDecodeError as e:
+                self.logger.warning(f"Corrupt cached state for valve {valve.id} ({e}); ignoring")
+                cached = None
 
         entry: dict = {
             "device": self.client.label,

--- a/RachioFlume/hose_timer_processor.py
+++ b/RachioFlume/hose_timer_processor.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 from RachioFlume.alert_rules import ZoneThreshold
 from RachioFlume.data_storage import WaterTrackingDB
+from RachioFlume.flume_client import FlumeClient
 from RachioFlume.rachio_hose_client import HoseValve, RachioHoseClient
 from lib.MyPushover import Pushover
 from lib.logger import get_logger
@@ -35,11 +36,13 @@ class HoseTimerProcessor:
         pushover: Pushover,
         db: WaterTrackingDB,
         thresholds: Optional[dict[str, ZoneThreshold]] = None,
+        flume_client: Optional[FlumeClient] = None,
     ) -> None:
         self.client = client
         self.pushover = pushover
         self.db = db
         self.thresholds = thresholds or {}
+        self.flume = flume_client
         self.logger = get_logger(__name__)
 
     def evaluate(self, *, dry_run: bool = False, now: Optional[datetime] = None) -> list[dict]:
@@ -129,6 +132,7 @@ class HoseTimerProcessor:
                 end_dt = start_dt + timedelta(seconds=duration_sec)
                 if now >= end_dt:
                     flow_detected = cached.get("flow_detected")
+                    total_gal, avg_gpm = self._flume_window_flow(start_dt, end_dt)
                     if not dry_run:
                         self.db.save_hose_watering_event(
                             {
@@ -157,26 +161,59 @@ class HoseTimerProcessor:
                             _state_key(valve.id),
                             json.dumps({**cached, "finalized": True}),
                         )
-                        self._send_zone_report(valve, duration_sec, flow_detected)
+                        self._send_zone_report(
+                            valve, duration_sec, avg_gpm, total_gal, flow_detected
+                        )
                     entry["action"] = "run_completed"
                     entry["duration_seconds"] = duration_sec
                     entry["flow_detected"] = flow_detected
+                    entry["avg_gpm"] = avg_gpm
+                    entry["total_gal"] = total_gal
                     self.logger.info(
                         f"hose run completed: '{self.client.label}/{valve.name}' "
-                        f"dur={duration_sec}s flow_detected={flow_detected}"
+                        f"dur={duration_sec}s avg_gpm={avg_gpm:.2f} total_gal={total_gal:.1f} "
+                        f"flow_detected={flow_detected}"
                     )
 
         return entry
 
+    def _flume_window_flow(self, start_dt: datetime, end_dt: datetime) -> tuple[float, float]:
+        """Sum Flume per-minute readings over the run window.
+
+        Returns (total_gallons, avg_gpm). Flume measures whole-house water,
+        so non-irrigation use during the window inflates the number — same
+        caveat as the controller path. Returns (0, 0) if Flume unavailable
+        or no readings.
+        """
+        if self.flume is None:
+            return 0.0, 0.0
+        try:
+            readings = self.flume.get_usage(start_dt, end_dt, bucket="MIN")
+        except Exception as e:
+            self.logger.warning(f"Flume window query failed: {e}")
+            return 0.0, 0.0
+        if not readings:
+            return 0.0, 0.0
+        total_gal = sum(r.value for r in readings)
+        # Per-minute bucket; len(readings) is minute count
+        avg_gpm = total_gal / len(readings) if readings else 0.0
+        return total_gal, avg_gpm
+
     def _send_zone_report(
-        self, valve: HoseValve, duration_sec: int, flow_detected: Optional[bool]
+        self,
+        valve: HoseValve,
+        duration_sec: int,
+        avg_gpm: float,
+        total_gal: float,
+        flow_detected: Optional[bool],
     ) -> None:
         runtime_min = duration_sec / 60.0
         baseline = self.thresholds[valve.name].avg_gpm if valve.name in self.thresholds else None
-        if baseline is not None:
-            flow_line = f"Configured baseline: {baseline:.2f} GPM"
-        else:
-            flow_line = "No configured baseline."
+        flow_line = (
+            f"Avg flow: {avg_gpm:.2f} GPM (thresh {baseline:.2f})"
+            if baseline is not None
+            else f"Avg flow: {avg_gpm:.2f} GPM"
+        )
         sensor_line = (
             "Flow sensor: detected"
             if flow_detected
@@ -186,6 +223,7 @@ class HoseTimerProcessor:
             f"Valve '{valve.name}' on {valve.base_station_label} completed.",
             f"Runtime: {runtime_min:.0f} min",
             flow_line,
+            f"Total: {total_gal:.1f} gal",
         ]
         if sensor_line:
             lines.append(sensor_line)
@@ -193,5 +231,6 @@ class HoseTimerProcessor:
         self.pushover.send_message(msg, title="RachioFlume: Hose Run", priority=-1)
         self.logger.info(
             f"Hose zone-end report sent for '{valve.base_station_label}/{valve.name}': "
-            f"{runtime_min:.0f} min, flow_detected={flow_detected}"
+            f"{runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal, "
+            f"flow_detected={flow_detected}"
         )

--- a/RachioFlume/hose_timer_processor.py
+++ b/RachioFlume/hose_timer_processor.py
@@ -1,0 +1,197 @@
+"""Per-cycle hose-timer processor.
+
+Polls each hose-timer base station, detects valve run transitions
+(start / end) via the `lastWateringAction` discriminator, persists
+events and sessions, and emits a P-1 pushover zone-end report when a
+run completes — same format as the controller path, with the device
+label and the configured baseline GPM appended for context.
+"""
+
+import json
+from datetime import datetime, timedelta
+from typing import Optional
+
+from RachioFlume.alert_rules import ZoneThreshold
+from RachioFlume.data_storage import WaterTrackingDB
+from RachioFlume.rachio_hose_client import HoseValve, RachioHoseClient
+from lib.MyPushover import Pushover
+from lib.logger import get_logger
+
+
+def _state_key(valve_id: str) -> str:
+    return f"hose::valve::{valve_id}::last_action"
+
+
+class HoseTimerProcessor:
+    """Detect runs on hose-timer valves and emit pushover zone-end reports.
+
+    Threshold lookup uses valve name as the zone_key (matches
+    cfg.rachio_flume.alerts.zone_thresholds[device_label][valve_name]).
+    """
+
+    def __init__(
+        self,
+        client: RachioHoseClient,
+        pushover: Pushover,
+        db: WaterTrackingDB,
+        thresholds: Optional[dict[str, ZoneThreshold]] = None,
+    ) -> None:
+        self.client = client
+        self.pushover = pushover
+        self.db = db
+        self.thresholds = thresholds or {}
+        self.logger = get_logger(__name__)
+
+    def evaluate(self, *, dry_run: bool = False, now: Optional[datetime] = None) -> list[dict]:
+        if now is None:
+            now = datetime.now()
+        results: list[dict] = []
+
+        try:
+            valves = self.client.list_valves()
+        except Exception as e:
+            self.logger.error(f"listValves failed for '{self.client.label}': {e}")
+            return [{"error": str(e), "device": self.client.label}]
+
+        # Persist current valve roster for inventory + reporter joins.
+        if not dry_run and valves:
+            self.db.save_hose_valves([v.model_dump() for v in valves])
+
+        for valve in valves:
+            entry = self._evaluate_valve(valve, now, dry_run)
+            results.append(entry)
+
+        return results
+
+    def _evaluate_valve(self, valve: HoseValve, now: datetime, dry_run: bool) -> dict:
+        action = valve.last_watering_action
+        cached_blob = self.db.get_metadata(_state_key(valve.id))
+        cached = json.loads(cached_blob) if cached_blob else None
+
+        entry: dict = {
+            "device": self.client.label,
+            "valve": valve.name,
+            "action": "nothing",
+        }
+
+        if action:
+            start_dt = RachioHoseClient.parse_action_start(action)
+            duration_sec = RachioHoseClient.parse_action_duration(action)
+            if start_dt is None:
+                self.logger.warning(
+                    f"hose '{self.client.label}/{valve.name}' lastWateringAction missing parseable start"
+                )
+                return entry
+
+            cached_start = cached.get("start") if cached else None
+            if cached_start != start_dt.isoformat():
+                # New run started since last poll
+                if not dry_run:
+                    self.db.save_hose_watering_event(
+                        {
+                            "valve_id": valve.id,
+                            "base_station_id": valve.base_station_id,
+                            "event_date": start_dt,
+                            "event_type": "ZONE_STARTED",
+                            "duration_seconds": duration_sec,
+                            "reason": action.get("reason"),
+                            "flow_detected": action.get("flowDetected"),
+                        }
+                    )
+                    self.db.set_metadata(
+                        _state_key(valve.id),
+                        json.dumps(
+                            {
+                                "start": start_dt.isoformat(),
+                                "duration_seconds": duration_sec,
+                                "reason": action.get("reason"),
+                                "flow_detected": action.get("flowDetected"),
+                                "valve_name": valve.name,
+                                "finalized": False,
+                            }
+                        ),
+                    )
+                entry["action"] = "run_started"
+                entry["start"] = start_dt.isoformat()
+                entry["duration_seconds"] = duration_sec
+                self.logger.info(
+                    f"hose run started: '{self.client.label}/{valve.name}' "
+                    f"start={start_dt.isoformat()} dur={duration_sec}s"
+                )
+            else:
+                entry["action"] = "still_running"
+        else:
+            # No active action. If we have a cached unfinalized run whose
+            # window has elapsed, finalize it.
+            if cached and not cached.get("finalized"):
+                start_dt = datetime.fromisoformat(cached["start"])
+                duration_sec = int(cached.get("duration_seconds") or 0)
+                end_dt = start_dt + timedelta(seconds=duration_sec)
+                if now >= end_dt:
+                    flow_detected = cached.get("flow_detected")
+                    if not dry_run:
+                        self.db.save_hose_watering_event(
+                            {
+                                "valve_id": valve.id,
+                                "base_station_id": valve.base_station_id,
+                                "event_date": end_dt,
+                                "event_type": "ZONE_COMPLETED",
+                                "duration_seconds": duration_sec,
+                                "reason": cached.get("reason"),
+                                "flow_detected": flow_detected,
+                            }
+                        )
+                        self.db.save_hose_zone_session(
+                            {
+                                "valve_id": valve.id,
+                                "base_station_id": valve.base_station_id,
+                                "valve_name": valve.name,
+                                "base_station_label": valve.base_station_label,
+                                "start_time": start_dt,
+                                "end_time": end_dt,
+                                "duration_seconds": duration_sec,
+                                "flow_detected": flow_detected,
+                            }
+                        )
+                        self.db.set_metadata(
+                            _state_key(valve.id),
+                            json.dumps({**cached, "finalized": True}),
+                        )
+                        self._send_zone_report(valve, duration_sec, flow_detected)
+                    entry["action"] = "run_completed"
+                    entry["duration_seconds"] = duration_sec
+                    entry["flow_detected"] = flow_detected
+                    self.logger.info(
+                        f"hose run completed: '{self.client.label}/{valve.name}' "
+                        f"dur={duration_sec}s flow_detected={flow_detected}"
+                    )
+
+        return entry
+
+    def _send_zone_report(
+        self, valve: HoseValve, duration_sec: int, flow_detected: Optional[bool]
+    ) -> None:
+        runtime_min = duration_sec / 60.0
+        baseline = self.thresholds[valve.name].avg_gpm if valve.name in self.thresholds else None
+        if baseline is not None:
+            flow_line = f"Configured baseline: {baseline:.2f} GPM"
+        else:
+            flow_line = "No configured baseline."
+        sensor_line = (
+            "Flow sensor: detected"
+            if flow_detected
+            else ("Flow sensor: NOT detected" if flow_detected is False else "")
+        )
+        lines = [
+            f"Valve '{valve.name}' on {valve.base_station_label} completed.",
+            f"Runtime: {runtime_min:.0f} min",
+            flow_line,
+        ]
+        if sensor_line:
+            lines.append(sensor_line)
+        msg = "\n".join(lines)
+        self.pushover.send_message(msg, title="RachioFlume: Hose Run", priority=-1)
+        self.logger.info(
+            f"Hose zone-end report sent for '{valve.base_station_label}/{valve.name}': "
+            f"{runtime_min:.0f} min, flow_detected={flow_detected}"
+        )

--- a/RachioFlume/rachio_client.py
+++ b/RachioFlume/rachio_client.py
@@ -35,16 +35,29 @@ class RachioClient:
 
     BASE_URL = "https://api.rach.io/1/public"
 
-    def __init__(self, api_key: Optional[str] = None, device_id: Optional[str] = None):
-        """Initialize Rachio client.
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        device_id: Optional[str] = None,
+        label: Optional[str] = None,
+    ):
+        """Initialize Rachio Smart Sprinkler Controller client.
 
         Args:
             api_key: Rachio API key (defaults to cfg.rachio.api_key)
-            device_id: Rachio device ID (defaults to cfg.rachio.rachio_id)
+            device_id: Rachio device ID (defaults to first controller in cfg.rachio.devices)
+            label: Human-readable device label (defaults to matching controller's label)
         """
         cfg = get_config()
         self.api_key = api_key or cfg.rachio.api_key
-        self.device_id = device_id or cfg.rachio.rachio_id
+        if device_id is None:
+            controllers = [d for d in cfg.rachio.devices if d.type == "controller"]
+            if not controllers:
+                raise ValueError("No controller device configured in cfg.rachio.devices")
+            device_id = controllers[0].id
+            label = label or controllers[0].label
+        self.device_id = device_id
+        self.label = label or device_id
 
         if not self.api_key:
             raise ValueError("Rachio API key required")

--- a/RachioFlume/rachio_hose_client.py
+++ b/RachioFlume/rachio_hose_client.py
@@ -1,0 +1,149 @@
+"""Rachio Smart Hose Timer client (cloud-rest.rach.io/valve/*).
+
+The hose-timer API is a separate service from the controller API
+(api.rach.io/1/public/device/*) but accepts the same Bearer api_key.
+Unlike the controller API, there is NO history endpoint — historical runs
+must be synthesized from state-transition polling of `getValve`.
+
+When a valve is running, getValve returns:
+    state.reportedState.lastWateringAction = {
+        "start": "2026-06-27T07:46:46Z",
+        "durationSeconds": "30",
+        "reason": "QUICK_RUN",
+        "flowDetected": false
+    }
+The field disappears ~5-10s after the run completes. Run detection caches
+the last-seen action and synthesizes ZONE_STARTED on first observation,
+ZONE_COMPLETED on disappearance (or when start+duration elapses).
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+from pydantic import BaseModel
+
+from lib.logger import get_logger
+
+
+class HoseValve(BaseModel):
+    """One hose-timer valve."""
+
+    id: str
+    base_station_id: str
+    base_station_label: str
+    name: str
+    default_runtime_seconds: int
+    detect_flow: bool
+    battery_status: Optional[str] = None
+    connected: bool = True
+    last_watering_action: Optional[Dict[str, Any]] = None
+
+
+class RachioHoseClient:
+    """Client for one Smart Hose Timer base station and its valves."""
+
+    BASE_URL = "https://cloud-rest.rach.io"
+
+    def __init__(self, api_key: str, base_station_id: str, label: str):
+        self.api_key = api_key
+        self.base_station_id = base_station_id
+        self.label = label
+        self.headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        self.logger = get_logger(__name__)
+        self.logger.info(
+            f"Hose timer client initialized: label='{label}' base_station={base_station_id}"
+        )
+
+    def get_base_station(self) -> Dict[str, Any]:
+        url = f"{self.BASE_URL}/valve/getBaseStation/{self.base_station_id}"
+        r = requests.get(url, headers=self.headers, timeout=10)
+        r.raise_for_status()
+        body: Dict[str, Any] = r.json()
+        bs: Dict[str, Any] = body.get("baseStation", {})
+        return bs
+
+    def list_valves(self) -> List[HoseValve]:
+        """Fetch all valves under this base station."""
+        url = f"{self.BASE_URL}/valve/listValves/{self.base_station_id}"
+        r = requests.get(url, headers=self.headers, timeout=10)
+        r.raise_for_status()
+        body: Dict[str, Any] = r.json()
+        valves: List[HoseValve] = []
+        for v in body.get("valves", []):
+            reported = (v.get("state") or {}).get("reportedState") or {}
+            try:
+                runtime_sec = int(reported.get("defaultRuntimeSeconds", "0"))
+            except (TypeError, ValueError):
+                runtime_sec = 0
+            valves.append(
+                HoseValve(
+                    id=v["id"],
+                    base_station_id=self.base_station_id,
+                    base_station_label=self.label,
+                    name=v["name"],
+                    default_runtime_seconds=runtime_sec,
+                    detect_flow=bool(v.get("detectFlow", False)),
+                    battery_status=reported.get("batteryStatus"),
+                    connected=bool(reported.get("connected", True)),
+                    last_watering_action=reported.get("lastWateringAction"),
+                )
+            )
+        self.logger.info(f"Found {len(valves)} valves on '{self.label}'")
+        return valves
+
+    def get_valve(self, valve_id: str) -> HoseValve:
+        """Fetch one valve's current state (used for active-zone checks)."""
+        url = f"{self.BASE_URL}/valve/getValve/{valve_id}"
+        r = requests.get(url, headers=self.headers, timeout=10)
+        r.raise_for_status()
+        v = r.json().get("valve", {})
+        reported = (v.get("state") or {}).get("reportedState") or {}
+        try:
+            runtime_sec = int(reported.get("defaultRuntimeSeconds", "0"))
+        except (TypeError, ValueError):
+            runtime_sec = 0
+        return HoseValve(
+            id=v["id"],
+            base_station_id=self.base_station_id,
+            base_station_label=self.label,
+            name=v["name"],
+            default_runtime_seconds=runtime_sec,
+            detect_flow=bool(v.get("detectFlow", False)),
+            battery_status=reported.get("batteryStatus"),
+            connected=bool(reported.get("connected", True)),
+            last_watering_action=reported.get("lastWateringAction"),
+        )
+
+    @staticmethod
+    def parse_action_start(action: Dict[str, Any]) -> Optional[datetime]:
+        """Parse the ISO8601 'start' field from a lastWateringAction."""
+        s = action.get("start")
+        if not s:
+            return None
+        # Rachio returns "2026-06-27T07:46:46Z" — handle trailing Z.
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(s)
+            if dt.tzinfo is not None:
+                # Strip tz to align with the rest of the codebase (naive local).
+                dt = dt.astimezone().replace(tzinfo=None)
+            return dt
+        except ValueError:
+            return None
+
+    @staticmethod
+    def parse_action_duration(action: Dict[str, Any]) -> int:
+        try:
+            return int(action.get("durationSeconds", "0"))
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def utcnow_naive() -> datetime:
+        """Return current time as naive datetime (matches codebase convention)."""
+        return datetime.now(timezone.utc).astimezone().replace(tzinfo=None)

--- a/RachioFlume/reporter.py
+++ b/RachioFlume/reporter.py
@@ -1,7 +1,7 @@
 """Weekly reporting system for water tracking data."""
 
 import json
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
 from typing import Dict, Any, List
 from pathlib import Path
@@ -35,6 +35,18 @@ class ReportSummary:
 
 
 @dataclass
+class HoseValveStats:
+    """Statistics for a single hose-timer valve in a reporting period."""
+
+    base_station_label: str
+    valve_name: str
+    sessions: int
+    total_duration_hours: float
+    average_duration_minutes: float
+    flow_detected_sessions: int
+
+
+@dataclass
 class WaterUsageReport:
     """Complete water usage report."""
 
@@ -43,6 +55,7 @@ class WaterUsageReport:
     period_end: datetime
     summary: ReportSummary
     zones: List[ZoneStats]
+    hose_valves: List[HoseValveStats] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for compatibility."""
@@ -109,6 +122,37 @@ class WeeklyReporter:
             zones_watered=len(zone_stats),
         )
 
+        # Aggregate hose-timer sessions
+        hose_sessions = self.db.get_hose_zone_sessions(period_start, period_end)
+        hose_agg: Dict[tuple, Dict[str, Any]] = {}
+        for s in hose_sessions:
+            key = (s["base_station_label"], s["valve_name"])
+            slot = hose_agg.setdefault(
+                key,
+                {"sessions": 0, "duration_sec_total": 0, "flow_detected": 0},
+            )
+            slot["sessions"] += 1
+            slot["duration_sec_total"] += s.get("duration_seconds") or 0
+            if s.get("flow_detected"):
+                slot["flow_detected"] += 1
+
+        hose_valves = sorted(
+            (
+                HoseValveStats(
+                    base_station_label=label,
+                    valve_name=name,
+                    sessions=v["sessions"],
+                    total_duration_hours=round(v["duration_sec_total"] / 3600.0, 2),
+                    average_duration_minutes=round(
+                        (v["duration_sec_total"] / max(v["sessions"], 1)) / 60.0, 1
+                    ),
+                    flow_detected_sessions=v["flow_detected"],
+                )
+                for (label, name), v in hose_agg.items()
+            ),
+            key=lambda h: (h.base_station_label, h.valve_name),
+        )
+
         # Create and return the report
         return WaterUsageReport(
             report_generated=datetime.now(),
@@ -116,6 +160,7 @@ class WeeklyReporter:
             period_end=period_end,
             summary=summary,
             zones=formatted_zones,
+            hose_valves=hose_valves,
         )
 
     def save_report_to_file(self, report: WaterUsageReport, filename: str) -> None:
@@ -168,6 +213,21 @@ class WeeklyReporter:
                     f"{zone.average_flow_rate_gpm:<4.1f}"
                 )
                 report_text.append(zone_line)
+
+        if report.hose_valves:
+            report_text.append("\nHOSE TIMER VALVES:")
+            header = f"{'Base/Valve':<32} {'Runs':<4} {'Hrs':<5} {'Avg(m)':<6} {'Flow':<4}"
+            report_text.append(header)
+            report_text.append("-" * len(header))
+            for hv in report.hose_valves:
+                label = f"{hv.base_station_label}/{hv.valve_name}"[:32]
+                report_text.append(
+                    f"{label:<32} "
+                    f"{hv.sessions:<4} "
+                    f"{hv.total_duration_hours:<5.1f} "
+                    f"{hv.average_duration_minutes:<6.1f} "
+                    f"{hv.flow_detected_sessions:<4}"
+                )
 
         report_text.append("\n" + "=" * 35)
         return "\n".join(report_text)

--- a/RachioFlume/rfmanager.py
+++ b/RachioFlume/rfmanager.py
@@ -279,18 +279,19 @@ def list_devices(_args: argparse.Namespace) -> int:
     headers = {"Authorization": f"Bearer {api_key}"}
 
     try:
-        person = requests.get(
-            "https://api.rach.io/1/public/person/info", headers=headers, timeout=10
-        ).json()
-        pid = person["id"]
-        info = requests.get(
-            f"https://api.rach.io/1/public/person/{pid}", headers=headers, timeout=10
-        ).json()
-        bs = requests.get(
+        r = requests.get("https://api.rach.io/1/public/person/info", headers=headers, timeout=10)
+        r.raise_for_status()
+        pid = r.json()["id"]
+        r = requests.get(f"https://api.rach.io/1/public/person/{pid}", headers=headers, timeout=10)
+        r.raise_for_status()
+        info = r.json()
+        r = requests.get(
             f"https://cloud-rest.rach.io/valve/listBaseStations/{pid}",
             headers=headers,
             timeout=10,
-        ).json()
+        )
+        r.raise_for_status()
+        bs = r.json()
     except Exception as e:
         logger.error(f"Rachio API error: {e}")
         return 1
@@ -311,12 +312,13 @@ def list_devices(_args: argparse.Namespace) -> int:
     logger.info("Hose-Timer base stations (Smart Hose Timer):")
     for b in bs.get("baseStations", []):
         try:
-            valves = requests.get(
+            r = requests.get(
                 f"https://cloud-rest.rach.io/valve/listValves/{b['id']}",
                 headers=headers,
                 timeout=10,
-            ).json()
-            valve_list = [v.get("name") for v in valves.get("valves", [])]
+            )
+            r.raise_for_status()
+            valve_list = [v.get("name") for v in r.json().get("valves", [])]
         except Exception as e:
             valve_list = [f"<error: {e}>"]
         logger.info(

--- a/RachioFlume/rfmanager.py
+++ b/RachioFlume/rfmanager.py
@@ -196,8 +196,15 @@ def _build_alert_engine() -> AlertEngine:
 
 
 def _build_hose_processors(db: WaterTrackingDB) -> list[HoseTimerProcessor]:
-    """One HoseTimerProcessor per Smart Hose Timer base station in config."""
+    """One HoseTimerProcessor per Smart Hose Timer base station in config.
+
+    Each processor gets a shared FlumeClient so the zone-end report uses the
+    same house-water source as the controller path.
+    """
     all_thresholds = load_zone_thresholds_from_config()
+    flume_client = (
+        FlumeClient() if any(d.type == "hose_timer" for d in cfg.rachio.devices) else None
+    )
     processors: list[HoseTimerProcessor] = []
     for dev in cfg.rachio.devices:
         if dev.type != "hose_timer":
@@ -213,6 +220,7 @@ def _build_hose_processors(db: WaterTrackingDB) -> list[HoseTimerProcessor]:
                 pushover=pushover,
                 db=db,
                 thresholds=all_thresholds.get(dev.label, {}),
+                flume_client=flume_client,
             )
         )
     return processors

--- a/RachioFlume/rfmanager.py
+++ b/RachioFlume/rfmanager.py
@@ -6,11 +6,17 @@ import argparse
 import sys
 from time import sleep
 from RachioFlume.alert_engine import AlertEngine
-from RachioFlume.alert_rules import load_rules_from_config, load_zone_thresholds_from_config
+from RachioFlume.alert_rules import (
+    get_controller_zone_thresholds,
+    load_rules_from_config,
+    load_zone_thresholds_from_config,
+)
 from RachioFlume.collector import WaterTrackingCollector
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import FlumeClient
+from RachioFlume.hose_timer_processor import HoseTimerProcessor
 from RachioFlume.rachio_client import RachioClient
+from RachioFlume.rachio_hose_client import RachioHoseClient
 from lib.MyPushover import Pushover
 from RachioFlume.reporter import WeeklyReporter
 from lib.logger import get_logger
@@ -50,6 +56,12 @@ def main() -> int:
 
     # Status command
     subparsers.add_parser("status", help="Show current system status")
+
+    # List-devices command
+    subparsers.add_parser(
+        "list-devices",
+        help="List all Rachio devices visible from the API (controllers + hose timers)",
+    )
 
     # Reporting commands
     report_parser = subparsers.add_parser("report", help="Generate period reports")
@@ -137,6 +149,8 @@ def main() -> int:
         return run_collection(args)
     elif args.command == "status":
         return show_status(args)
+    elif args.command == "list-devices":
+        return list_devices(args)
     elif args.command == "report":
         return generate_report(args)
     elif args.command == "summary":
@@ -152,21 +166,56 @@ def main() -> int:
 
 
 def _build_alert_engine() -> AlertEngine:
-    """Construct an AlertEngine sharing the rfmanager-level Pushover instance."""
+    """Construct an AlertEngine sharing the rfmanager-level Pushover instance.
+
+    Uses the first controller device in cfg.rachio.devices. Zone thresholds
+    are filtered to that controller's labelled block.
+    """
     rules = load_rules_from_config()
-    zone_thresholds = load_zone_thresholds_from_config()
+    all_thresholds = load_zone_thresholds_from_config()
     alerts_cfg = cfg.rachio_flume.alerts
+
+    controllers = [d for d in cfg.rachio.devices if d.type == "controller"]
+    if not controllers:
+        raise ValueError("No controller device configured in cfg.rachio.devices")
+    primary = controllers[0]
+    rachio_client = RachioClient(device_id=primary.id, label=primary.label)
+    controller_thresholds = get_controller_zone_thresholds(all_thresholds, primary.label)
+
     return AlertEngine(
         flume_client=FlumeClient(),
-        rachio_client=RachioClient(),
+        rachio_client=rachio_client,
         pushover=pushover,
         db=WaterTrackingDB(DB_PATH),
         rules=rules,
-        zone_thresholds=zone_thresholds,
+        zone_thresholds=controller_thresholds,
         absolute_gpm=alerts_cfg.absolute_gpm,
         percent_above=alerts_cfg.percent_above,
         min_runtime_minutes=alerts_cfg.min_runtime_minutes,
     )
+
+
+def _build_hose_processors(db: WaterTrackingDB) -> list[HoseTimerProcessor]:
+    """One HoseTimerProcessor per Smart Hose Timer base station in config."""
+    all_thresholds = load_zone_thresholds_from_config()
+    processors: list[HoseTimerProcessor] = []
+    for dev in cfg.rachio.devices:
+        if dev.type != "hose_timer":
+            continue
+        client = RachioHoseClient(
+            api_key=cfg.rachio.api_key,
+            base_station_id=dev.id,
+            label=dev.label,
+        )
+        processors.append(
+            HoseTimerProcessor(
+                client=client,
+                pushover=pushover,
+                db=db,
+                thresholds=all_thresholds.get(dev.label, {}),
+            )
+        )
+    return processors
 
 
 def run_collection(args: argparse.Namespace) -> int:
@@ -176,9 +225,20 @@ def run_collection(args: argparse.Namespace) -> int:
     try:
         cfg = get_config()
         alert_engine = _build_alert_engine() if cfg.rachio_flume.alerts.enabled else None
-        collector = WaterTrackingCollector(DB_PATH, args.interval, alert_engine=alert_engine)
+        db = WaterTrackingDB(DB_PATH)
+        hose_processors = _build_hose_processors(db)
+        collector = WaterTrackingCollector(
+            DB_PATH,
+            args.interval,
+            alert_engine=alert_engine,
+            hose_processors=hose_processors,
+        )
         if alert_engine is not None:
             logger.info(f"Alerts enabled with {len(alert_engine.rules)} rules")
+        if hose_processors:
+            logger.info(
+                f"Hose-timer processors active for: {[p.client.label for p in hose_processors]}"
+            )
 
         logger.info(f"Starting continuous collection every {args.interval} seconds")
         logger.info("Press Ctrl+C to stop")
@@ -197,6 +257,67 @@ def run_collection(args: argparse.Namespace) -> int:
         )
         sleep(3600)  ## cooldown for an hour.
         return 1
+
+
+def list_devices(_args: argparse.Namespace) -> int:
+    """Print all Rachio devices visible from the live API."""
+    import requests
+
+    logger = get_logger(__name__)
+    api_key = cfg.rachio.api_key
+    if not api_key:
+        logger.error("cfg.rachio.api_key is empty")
+        return 1
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    try:
+        person = requests.get(
+            "https://api.rach.io/1/public/person/info", headers=headers, timeout=10
+        ).json()
+        pid = person["id"]
+        info = requests.get(
+            f"https://api.rach.io/1/public/person/{pid}", headers=headers, timeout=10
+        ).json()
+        bs = requests.get(
+            f"https://cloud-rest.rach.io/valve/listBaseStations/{pid}",
+            headers=headers,
+            timeout=10,
+        ).json()
+    except Exception as e:
+        logger.error(f"Rachio API error: {e}")
+        return 1
+
+    logger.info("=" * 60)
+    logger.info(f"Rachio person_id: {pid}")
+    logger.info("=" * 60)
+
+    logger.info("Controllers (Smart Sprinkler):")
+    for d in info.get("devices", []):
+        zones = [(z.get("zoneNumber"), z.get("name")) for z in d.get("zones", [])]
+        logger.info(
+            f"  id={d.get('id')}  name='{d.get('name')}'  model={d.get('model')}  "
+            f"on={d.get('on')}  zones={len(zones)}"
+        )
+
+    logger.info("")
+    logger.info("Hose-Timer base stations (Smart Hose Timer):")
+    for b in bs.get("baseStations", []):
+        try:
+            valves = requests.get(
+                f"https://cloud-rest.rach.io/valve/listValves/{b['id']}",
+                headers=headers,
+                timeout=10,
+            ).json()
+            valve_list = [v.get("name") for v in valves.get("valves", [])]
+        except Exception as e:
+            valve_list = [f"<error: {e}>"]
+        logger.info(
+            f"  id={b.get('id')}  name='{b.get('name')}'  "
+            f"serial={b.get('serialNumber')}  valves={valve_list}"
+        )
+
+    logger.info("=" * 60)
+    return 0
 
 
 def show_status(_args: argparse.Namespace) -> int:

--- a/RachioFlume/test_alert_engine.py
+++ b/RachioFlume/test_alert_engine.py
@@ -41,9 +41,9 @@ def engine(db: WaterTrackingDB, rule: AlertRule) -> AlertEngine:
     pushover.send_message.return_value = True
     # Provide zone thresholds high enough that test flow rates don't trigger anomalies
     zone_thresholds = {
-        1: ZoneThreshold(zone_number=1, name="Z1*", avg_gpm=10.0),
-        2: ZoneThreshold(zone_number=2, name="Z2*", avg_gpm=10.0),
-        3: ZoneThreshold(zone_number=3, name="Z3*", avg_gpm=10.0),
+        1: ZoneThreshold(zone_key="1", name="Z1*", avg_gpm=10.0),
+        2: ZoneThreshold(zone_key="2", name="Z2*", avg_gpm=10.0),
+        3: ZoneThreshold(zone_key="3", name="Z3*", avg_gpm=10.0),
     }
     return AlertEngine(
         flume_client=flume,

--- a/RachioFlume/test_hose_timer.py
+++ b/RachioFlume/test_hose_timer.py
@@ -117,7 +117,9 @@ class TestHoseTimerProcessor:
         msg = call_args[0][0]
         assert "Hose Drip Jasmine" in msg
         assert "Upper Deck Planters" in msg
-        assert "0.50 GPM" in msg  # configured baseline
+        assert "thresh 0.50" in msg  # configured baseline appears in flow line
+        assert "Avg flow:" in msg
+        assert "Total:" in msg
         assert "Flow sensor: detected" in msg
         # Session row persisted
         sessions = tmp_db.get_hose_zone_sessions(
@@ -147,7 +149,9 @@ class TestHoseTimerProcessor:
 
         pushover.send_message.assert_called_once()
         msg = pushover.send_message.call_args[0][0]
-        assert "No configured baseline" in msg
+        # No baseline -> just "Avg flow: X.XX GPM" without (thresh ...)
+        assert "Avg flow:" in msg
+        assert "thresh" not in msg
 
     def test_completion_only_after_window_elapses(self, tmp_db: WaterTrackingDB) -> None:
         """If action disappears before start+duration, don't finalize yet.

--- a/RachioFlume/test_hose_timer.py
+++ b/RachioFlume/test_hose_timer.py
@@ -1,0 +1,241 @@
+"""Tests for the Rachio Smart Hose Timer integration."""
+
+import json
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from RachioFlume.alert_rules import ZoneThreshold
+from RachioFlume.data_storage import WaterTrackingDB
+from RachioFlume.hose_timer_processor import HoseTimerProcessor, _state_key
+from RachioFlume.rachio_hose_client import HoseValve, RachioHoseClient
+
+
+@pytest.fixture
+def tmp_db() -> Iterator[WaterTrackingDB]:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = f.name
+    try:
+        yield WaterTrackingDB(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def _valve(action: Dict[str, Any] | None = None) -> HoseValve:
+    return HoseValve(
+        id="valve-1",
+        base_station_id="bs-1",
+        base_station_label="Hose Drip Jasmine",
+        name="Upper Deck Planters",
+        default_runtime_seconds=600,
+        detect_flow=True,
+        battery_status="GOOD",
+        connected=True,
+        last_watering_action=action,
+    )
+
+
+def _make_processor(
+    tmp_db: WaterTrackingDB, valve: HoseValve
+) -> tuple[HoseTimerProcessor, MagicMock]:
+    client = MagicMock(spec=RachioHoseClient)
+    client.label = "Hose Drip Jasmine"
+    client.list_valves.return_value = [valve]
+    pushover = MagicMock()
+    thresholds = {
+        "Upper Deck Planters": ZoneThreshold(
+            zone_key="Upper Deck Planters", name="UDP", avg_gpm=0.5
+        )
+    }
+    proc = HoseTimerProcessor(client=client, pushover=pushover, db=tmp_db, thresholds=thresholds)
+    return proc, pushover
+
+
+class TestParseAction:
+    def test_parse_start_handles_trailing_z(self) -> None:
+        action = {"start": "2026-06-27T07:46:46Z", "durationSeconds": "30"}
+        dt = RachioHoseClient.parse_action_start(action)
+        assert dt is not None
+        # Result is naive local; just verify it round-trips
+        assert dt.year == 2026 and dt.month == 6 and dt.day == 27
+
+    def test_parse_duration_handles_string(self) -> None:
+        assert RachioHoseClient.parse_action_duration({"durationSeconds": "120"}) == 120
+        assert RachioHoseClient.parse_action_duration({"durationSeconds": 30}) == 30
+        assert RachioHoseClient.parse_action_duration({}) == 0
+
+
+class TestHoseTimerProcessor:
+    def test_run_started_persists_state_and_event(self, tmp_db: WaterTrackingDB) -> None:
+        action = {
+            "start": "2026-06-27T07:46:46Z",
+            "durationSeconds": "60",
+            "reason": "QUICK_RUN",
+            "flowDetected": False,
+        }
+        valve = _valve(action)
+        proc, pushover = _make_processor(tmp_db, valve)
+
+        results = proc.evaluate(now=datetime(2026, 6, 27, 7, 47, 0))
+
+        assert len(results) == 1
+        assert results[0]["action"] == "run_started"
+        # No pushover on start, only on completion
+        pushover.send_message.assert_not_called()
+        # State key persisted
+        blob = tmp_db.get_metadata(_state_key("valve-1"))
+        assert blob is not None
+        cached = json.loads(blob)
+        assert cached["finalized"] is False
+        assert cached["duration_seconds"] == 60
+
+    def test_run_completed_sends_pushover_and_session(self, tmp_db: WaterTrackingDB) -> None:
+        # Seed processor with a started run
+        action = {
+            "start": "2026-06-27T07:46:46Z",
+            "durationSeconds": "60",
+            "reason": "QUICK_RUN",
+            "flowDetected": True,
+        }
+        valve = _valve(action)
+        proc, pushover = _make_processor(tmp_db, valve)
+        proc.evaluate(now=datetime(2026, 6, 27, 7, 47, 0))
+
+        # Next poll: action gone, now > start + duration
+        proc.client.list_valves.return_value = [_valve(action=None)]  # type: ignore[attr-defined]
+        results = proc.evaluate(now=datetime(2026, 6, 27, 7, 49, 0))
+
+        assert results[0]["action"] == "run_completed"
+        assert results[0]["flow_detected"] is True
+        pushover.send_message.assert_called_once()
+        # Verify pushover message contains threshold and device label
+        call_args = pushover.send_message.call_args
+        msg = call_args[0][0]
+        assert "Hose Drip Jasmine" in msg
+        assert "Upper Deck Planters" in msg
+        assert "0.50 GPM" in msg  # configured baseline
+        assert "Flow sensor: detected" in msg
+        # Session row persisted
+        sessions = tmp_db.get_hose_zone_sessions(
+            datetime(2026, 6, 27, 0, 0, 0), datetime(2026, 6, 27, 23, 59, 0)
+        )
+        assert len(sessions) == 1
+        assert sessions[0]["duration_seconds"] == 60
+        assert sessions[0]["flow_detected"] == 1
+
+    def test_no_pushover_when_no_baseline(self, tmp_db: WaterTrackingDB) -> None:
+        action = {
+            "start": "2026-06-27T07:46:46Z",
+            "durationSeconds": "60",
+            "reason": "QUICK_RUN",
+            "flowDetected": None,
+        }
+        valve = _valve(action)
+        client = MagicMock(spec=RachioHoseClient)
+        client.label = "Hose Drip Jasmine"
+        client.list_valves.return_value = [valve]
+        pushover = MagicMock()
+        proc = HoseTimerProcessor(client=client, pushover=pushover, db=tmp_db, thresholds={})
+
+        proc.evaluate(now=datetime(2026, 6, 27, 7, 47, 0))
+        client.list_valves.return_value = [_valve(action=None)]
+        proc.evaluate(now=datetime(2026, 6, 27, 7, 49, 0))
+
+        pushover.send_message.assert_called_once()
+        msg = pushover.send_message.call_args[0][0]
+        assert "No configured baseline" in msg
+
+    def test_completion_only_after_window_elapses(self, tmp_db: WaterTrackingDB) -> None:
+        """If action disappears before start+duration, don't finalize yet.
+
+        The processor converts the UTC action.start to local naive time.
+        Use the parsed start as the anchor so this test is tz-independent.
+        """
+        action = {
+            "start": "2026-06-27T07:46:46Z",
+            "durationSeconds": "600",  # 10-minute run
+            "reason": "QUICK_RUN",
+            "flowDetected": False,
+        }
+        local_start = RachioHoseClient.parse_action_start(action)
+        assert local_start is not None
+        valve = _valve(action)
+        proc, pushover = _make_processor(tmp_db, valve)
+        proc.evaluate(now=local_start + timedelta(seconds=14))
+
+        # Action vanishes 30s later, but window not yet elapsed (only 44s in)
+        proc.client.list_valves.return_value = [_valve(action=None)]  # type: ignore[attr-defined]
+        results = proc.evaluate(now=local_start + timedelta(seconds=44))
+        assert results[0]["action"] == "nothing"
+        pushover.send_message.assert_not_called()
+
+        # Now jump past the run window (>10 min in)
+        results = proc.evaluate(now=local_start + timedelta(minutes=11))
+        assert results[0]["action"] == "run_completed"
+        pushover.send_message.assert_called_once()
+
+    def test_dry_run_does_not_persist(self, tmp_db: WaterTrackingDB) -> None:
+        action = {
+            "start": "2026-06-27T07:46:46Z",
+            "durationSeconds": "30",
+            "reason": "QUICK_RUN",
+            "flowDetected": False,
+        }
+        valve = _valve(action)
+        proc, pushover = _make_processor(tmp_db, valve)
+
+        results = proc.evaluate(now=datetime(2026, 6, 27, 7, 47, 0), dry_run=True)
+        assert results[0]["action"] == "run_started"
+        # No state persisted
+        assert tmp_db.get_metadata(_state_key("valve-1")) is None
+        pushover.send_message.assert_not_called()
+
+
+class TestListValvesParsing:
+    def test_list_valves_handles_real_response(self) -> None:
+        """Verify the parser handles the real Rachio listValves response shape."""
+        import requests
+        from unittest.mock import patch
+
+        sample = {
+            "valves": [
+                {
+                    "id": "v1",
+                    "name": "Upper Deck Planters",
+                    "detectFlow": True,
+                    "state": {
+                        "reportedState": {
+                            "connected": True,
+                            "defaultRuntimeSeconds": "600",
+                            "batteryStatus": "GOOD",
+                            "lastWateringAction": {
+                                "start": "2026-06-27T07:46:46Z",
+                                "durationSeconds": "30",
+                                "reason": "QUICK_RUN",
+                                "flowDetected": False,
+                            },
+                        }
+                    },
+                }
+            ]
+        }
+        with patch.object(requests, "get") as mock_get:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = sample
+            mock_resp.raise_for_status.return_value = None
+            mock_get.return_value = mock_resp
+
+            client = RachioHoseClient(api_key="k", base_station_id="bs1", label="T")  # nosecret
+            valves = client.list_valves()
+            assert len(valves) == 1
+            v = valves[0]
+            assert v.name == "Upper Deck Planters"
+            assert v.default_runtime_seconds == 600
+            assert v.detect_flow is True
+            assert v.battery_status == "GOOD"
+            assert v.last_watering_action is not None
+            assert v.last_watering_action["reason"] == "QUICK_RUN"

--- a/RachioFlume/test_integration.py
+++ b/RachioFlume/test_integration.py
@@ -25,8 +25,14 @@ class TestRachioClient:
     @patch("RachioFlume.rachio_client.get_config")
     def test_init_missing_credentials(self, mock_config: Mock) -> None:
         """Test initialization fails without credentials."""
-        # Mock config to return empty values
-        mock_config.return_value = Mock(rachio=Mock(api_key="", rachio_id=""))
+        # Mock config: empty api_key, but one controller device so we exercise
+        # the api_key check rather than the no-devices path.
+        mock_config.return_value = Mock(
+            rachio=Mock(
+                api_key="",
+                devices=[Mock(id="dev1", label="Test", type="controller")],
+            )
+        )
         with pytest.raises(ValueError, match="Rachio API key required"):
             RachioClient()
 

--- a/RachioFlume/test_zone_thresholds.py
+++ b/RachioFlume/test_zone_thresholds.py
@@ -60,12 +60,33 @@ def prod_db_path() -> Generator[str, None, None]:
         Path(tmp_path).unlink(missing_ok=True)
 
 
+_FIXTURE_ZONE_AVGS = {
+    1: 5.0,
+    2: 6.5,
+    3: 2.0,
+    4: 3.0,
+    5: 3.5,
+    6: 4.5,
+    7: 2.5,
+    8: 3.0,
+    9: 1.5,
+    10: 7.0,
+    11: 6.0,
+    12: 0.75,
+}
+
+
 @pytest.fixture
 def zone_thresholds() -> dict[int, ZoneThreshold]:
-    """Load Rachio-Eden controller thresholds from config (keyed by zone_number)."""
-    reset_config()
-    all_thresholds = load_zone_thresholds_from_config()
-    return get_controller_zone_thresholds(all_thresholds, "Rachio-Eden")
+    """Fixture of controller zone thresholds keyed by zone_number.
+
+    Built inline rather than loaded from config so the test is hermetic and
+    does not depend on local.yaml (which is gitignored and absent in CI).
+    """
+    return {
+        n: ZoneThreshold(zone_key=str(n), name=f"Z{n}*", avg_gpm=avg)
+        for n, avg in _FIXTURE_ZONE_AVGS.items()
+    }
 
 
 @pytest.fixture

--- a/RachioFlume/test_zone_thresholds.py
+++ b/RachioFlume/test_zone_thresholds.py
@@ -21,7 +21,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from RachioFlume.alert_engine import AlertEngine
-from RachioFlume.alert_rules import ZoneThreshold, load_zone_thresholds_from_config
+from RachioFlume.alert_rules import (
+    ZoneThreshold,
+    get_controller_zone_thresholds,
+    load_zone_thresholds_from_config,
+)
 from RachioFlume.data_storage import WaterTrackingDB
 from lib.config import get_config, reset_config
 
@@ -58,9 +62,10 @@ def prod_db_path() -> Generator[str, None, None]:
 
 @pytest.fixture
 def zone_thresholds() -> dict[int, ZoneThreshold]:
-    """Load zone thresholds from config."""
+    """Load Rachio-Eden controller thresholds from config (keyed by zone_number)."""
     reset_config()
-    return load_zone_thresholds_from_config()
+    all_thresholds = load_zone_thresholds_from_config()
+    return get_controller_zone_thresholds(all_thresholds, "Rachio-Eden")
 
 
 @pytest.fixture
@@ -269,7 +274,8 @@ def main() -> int:
     # Load config and thresholds
     print("\n[2/4] Loading zone thresholds from config...")
     reset_config()
-    zone_thresholds = load_zone_thresholds_from_config()
+    all_thresholds = load_zone_thresholds_from_config()
+    zone_thresholds = get_controller_zone_thresholds(all_thresholds, "Rachio-Eden")
     print(f"  ✓ Loaded {len(zone_thresholds)} zone thresholds")
     for zone_num in sorted(zone_thresholds.keys()):
         zt = zone_thresholds[zone_num]

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -215,9 +215,12 @@ samsung_frame:
   slideshow_delay_seconds: 3  # delay before starting slideshow after upload
 
 # === Rachio Irrigation ===
+# `type`: "controller"  -> api.rach.io/1/public/device/*  (Smart Sprinkler Controller)
+#         "hose_timer"  -> cloud-rest.rach.io/valve/*     (Smart Hose Timer base station)
+# Override `devices` in local.yaml with real ids/labels.
 rachio:
-  api_key: ""  
-  rachio_id: ""  
+  api_key: ""
+  devices: []
 
 # === Flume Water Monitoring ===
 flume:
@@ -247,21 +250,13 @@ rachio_flume:
       - {name: "High Flow",  min_gpm: 5.4, duration_minutes: 4}
       - {name: "Mid Flow",   min_gpm: 2.6, duration_minutes: 14}
       - {name: "Leak",       min_gpm: 0.1, duration_minutes: 120}
-    # Per-zone average flow rates (GPM) from historical data.
+    # Per-zone baseline flow rates (GPM) from historical data.
+    # Outer key = device label (matches rachio.devices[].label).
+    # Inner key = zone identifier:
+    #   - Controllers: stringified zone_number (e.g. "1")
+    #   - Hose timers: valve name (e.g. "Upper Deck Planters")
     # Alert fires when zone-end flow > avg + max(absolute_gpm, percent_above/100 * avg).
-    zone_thresholds:
-      1:  {name: "Z1*",  avg_gpm: 5.0}
-      2:  {name: "Z2*",  avg_gpm: 6.5}
-      3:  {name: "Z3*",  avg_gpm: 2.0}
-      4:  {name: "Z4*",  avg_gpm: 3.0}
-      5:  {name: "Z5*",  avg_gpm: 3.5}
-      6:  {name: "Z6*",  avg_gpm: 4.5}
-      7:  {name: "Z7*",  avg_gpm: 2.5}
-      8:  {name: "Z8*",  avg_gpm: 3.0}
-      9:  {name: "Z9*",  avg_gpm: 1.5}
-      10: {name: "Z10*", avg_gpm: 7.0}
-      11: {name: "Z11*", avg_gpm: 6.0}
-      12: {name: "Z12*", avg_gpm: 0.75}
+    zone_thresholds: {}
 
 # === PersonalCalSync (Google Apps Script) ===
 personal_cal_sync:

--- a/lib/config.py
+++ b/lib/config.py
@@ -206,11 +206,30 @@ class SamsungFrameConfig:
 
 
 @dataclass
+class RachioDeviceConfig:
+    """One Rachio device.
+
+    `type` selects the API surface: 'controller' for traditional Rachio
+    Smart Sprinkler Controllers (api.rach.io/1/public/device/*), 'hose_timer'
+    for Smart Hose Timer base stations (cloud-rest.rach.io/valve/*).
+    `id` is the deviceId for controllers or the baseStationId for hose timers.
+    """
+
+    id: str
+    label: str
+    type: str  # "controller" | "hose_timer"
+
+
+@dataclass
 class RachioConfig:
-    """Rachio irrigation system configuration"""
+    """Rachio irrigation system configuration.
+
+    Single shared `api_key` works for both controller and hose-timer endpoints.
+    Add one entry per physical device in `devices`.
+    """
 
     api_key: str
-    rachio_id: str
+    devices: list[RachioDeviceConfig]
 
 
 @dataclass
@@ -251,7 +270,10 @@ class RachioFlumeAlertsConfig:
     percent_above: float  # min deviation above average (%)
     min_runtime_minutes: int  # zone must run this long before threshold alert fires
     rules: list[AlertRuleConfig]
-    zone_thresholds: Dict[int, ZoneThresholdConfig]  # zone_number -> threshold
+    # device_label -> zone_key -> threshold.
+    # For controllers, zone_key is the integer zone_number (as a string for YAML).
+    # For hose timers, zone_key is the valve name (matches getValve.name).
+    zone_thresholds: Dict[str, Dict[str, ZoneThresholdConfig]]
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Adds Rachio Smart Hose Timer ("Hose Drip Jasmine" with valve "Upper Deck Planters") as a fully tracked irrigation source alongside the existing Smart Sprinkler Controller (Rachio-Eden), and surfaces the configured baseline GPM in every zone-completion Pushover so anomalies are obvious at a glance.

- **PR contains three logical changes** (kept on one branch per request):
  1. Controller zone-completion pushover gains the configured baseline as `Avg flow: 4.82 GPM (thresh 5.0)` ([alert_engine.py](RachioFlume/alert_engine.py)).
  2. Multi-device support for Rachio Smart Hose Timers via a new parallel client / processor / storage path (the bulk of the diff).
  3. Hose-timer zone-end report uses Flume for actual flow stats (the valve's built-in flow sensor is binary and less sensitive than Flume on drip rates).

## Why a separate path for hose timers?

Hose timers are not exposed by the v1 public Rachio API (`api.rach.io/1/public/device/*`) — they live behind a separate service at `cloud-rest.rach.io/valve/*` that ships only `getValve` / `listValves` / start-stop endpoints. There is **no public history endpoint**, so run detection has to be synthesized from state-transition polling of `getValve`. Probed live to confirm the discriminator: when a valve is running, `state.reportedState.lastWateringAction` is populated and disappears ~5-10s after the run ends.

Verified against the production account:
- Controller `Rachio-Eden` (`5d11b1a5-2c5f-42ce-a751-78c6c263bf1e`, 16-zone)
- Hose hub `Hose Drip Jasmine` (base station `a632eacc-5a48-4e6b-9fad-4c72aef79011`, 1 valve `Upper Deck Planters`)

## Architecture

- **Config**: `rachio.devices` is now a list of `{id, label, type}`. `zone_thresholds` nests by device label; controllers index by stringified zone_number, hose timers by valve name.
- **New tables** (no migration to existing tables): `hose_valves`, `hose_watering_events`, `hose_zone_sessions`. Supports N valves under N base stations natively.
- **Run detection**: poll `getValve` once per cycle, cache `lastWateringAction.start`, synthesize `ZONE_STARTED` on first observation and `ZONE_COMPLETED` once `start + durationSeconds` elapses.
- **Flow source**: Flume per-minute readings over `[start, end]` give actual gallons + GPM; the valve's `flowDetected` boolean is kept as a supplementary diagnostic line.
- **Pushover**: hose-timer zone-end report mirrors the controller format: `Avg flow: X.XX GPM (thresh Y.YY)\nTotal: Z.Z gal\nFlow sensor: detected/NOT detected`.
- **Reporter**: period report adds a HOSE TIMER VALVES section.
- **CLI**: new `rfmanager list-devices` prints all controllers + base stations + valves visible from the live API.

## Test plan

- [x] `make test` — full suite, 68 RachioFlume tests pass (8 new hose-timer tests covering parse/start/end/no-baseline/dry-run/window-elapsed semantics)
- [x] `make lint` — ruff + mypy + vulture + semgrep + codespell + deptry clean
- [x] `uv run python RachioFlume/rfmanager.py list-devices` — prints both controller + hose-timer with valve enumeration
- [x] `uv run python RachioFlume/rfmanager.py alerts test` — controller alert engine still builds + dry-runs cleanly with the new config shape
- [x] **Live end-to-end test against production**: triggered a 60-second run via `startWatering` API; cycle 1 detected `run_started`, cycle 3 (post-end) finalized with Pushover dispatched and session row persisted (`duration_seconds=60`, `flow_detected=False`)
- [x] **Live verification against user's manual run**: 10-minute QUICK_RUN at 01:16:42 PDT; queried Flume window mid-run and confirmed 1.45 gal / 0.10 GPM over 5.6 min — Pushover sent with format `Avg flow: 0.10 GPM (thresh 0.50)`. Note: the valve's `flowDetected: False` despite Flume detecting 0.10 GPM confirms drip-rate is below the valve sensor's threshold but well within Flume's sensitivity, justifying Flume as the flow source.
- [ ] User to tune `Upper Deck Planters.avg_gpm` baseline downward in local.yaml — placeholder 0.50 is ~5x too high for observed drip rate.

## References

- Plan + live API findings: `/tmp/rachioflume_hose_timer_plan.md`
- rachiopy reference library (valve endpoint surface): https://github.com/rfverbruggen/rachiopy
- Rachio public API docs: https://rachio.readme.io/

🤖 Generated with [Claude Code](https://claude.com/claude-code)