### PR TITLE
feat(RachioFlume): refactor alerts config, unify zone-end dispatch, add stale-zone monitor

### DIFF
--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -153,64 +153,18 @@ class AlertEngine:
     # ------------------------------------------------------------------ #
 
     def _get_zone_threshold(self, zone_number: Optional[int]) -> tuple[float, float]:
-        """Get threshold for a zone.
+        """Get anomaly threshold + configured baseline for a zone.
 
         Returns:
-            (threshold_gpm, avg_gpm) tuple
+            (threshold_gpm, baseline_avg_gpm) tuple.
+            For unknown zones returns (absolute_gpm, 0.0).
         """
         if zone_number is None or zone_number not in self.zone_thresholds:
-            # Unknown zone: default to avg_gpm=0, threshold=0.5
             return self.absolute_gpm, 0.0
 
         zt = self.zone_thresholds[zone_number]
         threshold = zt.compute_threshold(self.absolute_gpm, self.percent_above)
         return threshold, zt.avg_gpm
-
-    def _check_zone_threshold(
-        self,
-        zone_name: str,
-        zone_number: Optional[int],
-        avg_gpm: float,
-        runtime_min: float,
-        now: datetime,
-        dry_run: bool,
-    ) -> bool:
-        """Check if zone flow exceeds threshold and send alert if so.
-
-        Only fires if runtime_min > self.min_runtime_minutes (short runs
-        are excluded to avoid false positives from test cycles or glitches).
-
-        Returns True if alert was sent (or would be sent in dry-run).
-        """
-        if runtime_min <= self.min_runtime_minutes:
-            return False
-
-        threshold, expected_avg = self._get_zone_threshold(zone_number)
-
-        if avg_gpm <= threshold:
-            return False
-
-        # Alert: zone flow exceeds threshold
-        deviation = avg_gpm - expected_avg
-        deviation_pct = (deviation / expected_avg * 100) if expected_avg > 0 else 0
-
-        msg = (
-            f"Zone '{zone_name}' flow anomaly detected.\n"
-            f"Avg flow: {avg_gpm:.2f} GPM (threshold: {threshold:.2f} GPM)\n"
-            f"Deviation: +{deviation:.2f} GPM ({deviation_pct:.0f}%)"
-        )
-
-        if not dry_run:
-            self.pushover.send_message(msg, title="RachioFlume: Zone Anomaly", priority=2)
-            self.logger.warning(
-                f"Zone anomaly alert sent for '{zone_name}': {avg_gpm:.2f} GPM > {threshold:.2f} GPM"
-            )
-        else:
-            self.logger.info(
-                f"[DRY RUN] Would alert zone anomaly for '{zone_name}': {avg_gpm:.2f} GPM > {threshold:.2f} GPM"
-            )
-
-        return True
 
     # ------------------------------------------------------------------ #
     # Zone-end reporting                                                  #
@@ -265,7 +219,7 @@ class AlertEngine:
             reverse=True,
         )[0]
 
-    def _send_zone_report(
+    def _send_zone_outcome(
         self,
         zone_name: str,
         zone_number: Optional[int],
@@ -274,26 +228,41 @@ class AlertEngine:
         total_gal: float,
         cycle: int,
     ) -> None:
+        """Emit exactly one Pushover per zone end.
+
+        Picks (title, priority) based on whether the anomaly threshold is
+        exceeded; otherwise sends the routine Zone Report. The displayed
+        `(thresh X.XX)` is always the anomaly trigger value (matches what
+        actually fires the anomaly), and Total is included on both paths.
+        """
+        threshold, baseline = self._get_zone_threshold(zone_number)
+        is_anomaly = runtime_min > self.min_runtime_minutes and baseline > 0 and avg_gpm > threshold
+
         cycle_label = f" (Cycle {cycle})" if cycle > 1 else ""
-        baseline = (
-            self.zone_thresholds[zone_number].avg_gpm
-            if zone_number is not None and zone_number in self.zone_thresholds
-            else None
-        )
+        header = f"'{zone_name}'{cycle_label}"
         flow_line = (
-            f"Avg flow: {avg_gpm:.2f} GPM (thresh {baseline:.2f})"
-            if baseline is not None
+            f"Avg flow: {avg_gpm:.2f} GPM (thresh {threshold:.2f})"
+            if baseline > 0
             else f"Avg flow: {avg_gpm:.2f} GPM"
         )
-        msg = (
-            f"Zone '{zone_name}' completed{cycle_label}.\n"
-            f"Runtime: {runtime_min:.0f} min\n"
-            f"{flow_line}\n"
-            f"Total: {total_gal:.1f} gal"
-        )
-        self.pushover.send_message(msg, title="RachioFlume: Zone Report", priority=-1)
+        lines = [
+            header,
+            f"Runtime: {runtime_min:.0f} min",
+            flow_line,
+            f"Total: {total_gal:.1f} gal",
+        ]
+        if is_anomaly:
+            deviation = avg_gpm - baseline
+            deviation_pct = (deviation / baseline * 100) if baseline > 0 else 0
+            lines.append(f"Deviation: +{deviation:.2f} GPM ({deviation_pct:.0f}%)")
+            title, priority = "RachioFlume: Zone Anomaly", 2
+        else:
+            title, priority = "RachioFlume: Zone Report", -1
+
+        self.pushover.send_message("\n".join(lines), title=title, priority=priority)
         self.logger.info(
-            f"Zone-end report sent for '{zone_name}'{cycle_label}: {runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
+            f"Zone outcome sent for '{zone_name}'{cycle_label}: "
+            f"{runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal, anomaly={is_anomaly}"
         )
 
     def _check_zone_end_report(
@@ -342,23 +311,17 @@ class AlertEngine:
 
         if not dry_run:
             if runtime_min > 0:
-                self._send_zone_report(
+                # Single dispatch: report or anomaly, never both.
+                self._send_zone_outcome(
                     zone_name, zone_number, runtime_min, avg_gpm, total_gal, cycle
-                )
-                # Check if flow exceeds zone threshold
-                self._check_zone_threshold(
-                    zone_name, zone_number, avg_gpm, runtime_min, now, dry_run
                 )
             counts[zone_name] = cycle
             _save_count_map(self.db, _today_key(_REPORTED_ZONES_KEY, now), counts)
         else:
             self.logger.info(
-                f"[DRY RUN] Would report zone '{zone_name}' (cycle {cycle}): {runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
+                f"[DRY RUN] Would emit outcome for '{zone_name}' (cycle {cycle}): "
+                f"{runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal"
             )
-            if runtime_min > 0:
-                self._check_zone_threshold(
-                    zone_name, zone_number, avg_gpm, runtime_min, now, dry_run
-                )
 
         return True
 
@@ -509,6 +472,10 @@ class AlertEngine:
                 results.append({"zone_report": True, "zone": zone_to_report})
 
         # --- Suppress rule evaluation while irrigating or within slack ---
+        # Two independent suppression sources: (a) the in-process Rachio
+        # controller state above, (b) the cross-process hose-timer
+        # last-active key written by HoseTimerProcessor. Same slack window
+        # applies to both so behavior is symmetric.
         suppressed_by: Optional[str] = None
         if rachio_active:
             suppressed_by = f"rachio:{rachio_active.name}"
@@ -517,6 +484,19 @@ class AlertEngine:
             threshold = timedelta(minutes=max_duration + RACHIO_POST_ACTIVE_SLACK_MINUTES)
             if now - last_rachio_active_at < threshold:
                 suppressed_by = f"rachio:{last_rachio_zone} (recent)"
+
+        if not suppressed_by:
+            hose_blob = self.db.get_metadata("alert::__hose__::last_active")
+            if hose_blob:
+                try:
+                    hose_data = json.loads(hose_blob)
+                    last_hose_at = datetime.fromisoformat(hose_data["at"])
+                    max_duration = max((r.duration_minutes for r in self.rules), default=0)
+                    threshold = timedelta(minutes=max_duration + RACHIO_POST_ACTIVE_SLACK_MINUTES)
+                    if now - last_hose_at < threshold:
+                        suppressed_by = f"hose:{hose_data.get('device')} (recent)"
+                except (json.JSONDecodeError, KeyError, ValueError) as e:
+                    self.logger.warning(f"Bad hose last-active blob, ignoring: {e}")
 
         if suppressed_by:
             self.logger.debug(f"Rule evaluation suppressed by: {suppressed_by}")

--- a/RachioFlume/alert_rules.py
+++ b/RachioFlume/alert_rules.py
@@ -47,7 +47,12 @@ class ZoneThreshold(BaseModel):
 
 
 def load_rules_from_config() -> list[AlertRule]:
-    """Build AlertRule list from `cfg.rachio_flume.alerts`."""
+    """Build non-Rachio flow-rule list from `cfg.rachio_flume.alerts`.
+
+    These are whole-house sustained-flow rules (Pipe Break / High Flow / Mid
+    Flow / Leak) that apply to Flume readings independent of Rachio activity.
+    Suppressed during/just-after any Rachio activity (controller or hose timer).
+    """
     cfg = get_config()
     alerts_cfg = cfg.rachio_flume.alerts
     default_retrigger = alerts_cfg.default_retrigger_minutes
@@ -58,7 +63,7 @@ def load_rules_from_config() -> list[AlertRule]:
             duration_minutes=r.duration_minutes,
             retrigger_minutes=default_retrigger,
         )
-        for r in alerts_cfg.rules
+        for r in alerts_cfg.default_flow_rules
     ]
 
 
@@ -66,15 +71,16 @@ def load_zone_thresholds_from_config() -> dict[str, dict[str, ZoneThreshold]]:
     """Build {device_label -> {zone_key -> ZoneThreshold}} from config.
 
     `zone_key` is a stringified zone_number for controllers, or the valve name
-    for hose timers — matches the structure of cfg.rachio_flume.alerts.zone_thresholds.
+    for hose timers — matches the structure of
+    cfg.rachio_flume.alerts.zone_anomaly.zone_thresholds.
 
     Inner entries arrive as plain dicts (OmegaConf does not auto-construct
     dataclasses at depth-2 of Dict[Dict[...]]). Read fields by key.
     """
     cfg = get_config()
-    alerts_cfg = cfg.rachio_flume.alerts
+    za_cfg = cfg.rachio_flume.alerts.zone_anomaly
     out: dict[str, dict[str, ZoneThreshold]] = {}
-    for device_label, zones in alerts_cfg.zone_thresholds.items():
+    for device_label, zones in za_cfg.zone_thresholds.items():
         out[device_label] = {}
         for zone_key, zt_cfg in zones.items():
             zk = str(zone_key)

--- a/RachioFlume/collector.py
+++ b/RachioFlume/collector.py
@@ -9,6 +9,7 @@ from RachioFlume.hose_timer_processor import HoseTimerProcessor
 from RachioFlume.rachio_client import RachioClient
 from RachioFlume.flume_client import FlumeClient
 from RachioFlume.data_storage import WaterTrackingDB
+from RachioFlume.stale_zone_checker import StaleZoneChecker
 from lib.logger import get_logger
 
 
@@ -21,6 +22,7 @@ class WaterTrackingCollector:
         poll_interval_seconds: int = 300,  # 5 minutes default
         alert_engine: Optional[AlertEngine] = None,
         hose_processors: Optional[List[HoseTimerProcessor]] = None,
+        stale_zone_checker: Optional[StaleZoneChecker] = None,
     ):
         self.logger = get_logger(__name__)
 
@@ -30,6 +32,7 @@ class WaterTrackingCollector:
         self.poll_interval = poll_interval_seconds
         self.alert_engine = alert_engine
         self.hose_processors = hose_processors or []
+        self.stale_zone_checker = stale_zone_checker
 
         # Initialize last collection times from database to avoid duplicates
         self.last_rachio_collection: Optional[datetime] = self.db.get_last_collection_timestamp(
@@ -160,6 +163,13 @@ class WaterTrackingCollector:
                 await self.alert_engine.evaluate()
             except Exception as e:
                 self.logger.error(f"Error evaluating alerts: {e}")
+
+        # Stale-zone check (gated to once per hour internally)
+        if self.stale_zone_checker is not None:
+            try:
+                self.stale_zone_checker.maybe_evaluate()
+            except Exception as e:
+                self.logger.error(f"Error checking stale zones: {e}")
 
         self.logger.info("Data collection cycle completed")
 

--- a/RachioFlume/hose_timer_processor.py
+++ b/RachioFlume/hose_timer_processor.py
@@ -23,6 +23,13 @@ def _state_key(valve_id: str) -> str:
     return f"hose::valve::{valve_id}::last_action"
 
 
+# Cross-component key: AlertEngine reads this to suppress Flume rule alerts
+# while a hose-timer valve is running or recently ran. Mirrors the controller's
+# in-memory rachio state — kept in DB metadata so the two processors stay
+# decoupled (HoseTimerProcessor writes; AlertEngine reads).
+_HOSE_LAST_ACTIVE_KEY = "alert::__hose__::last_active"
+
+
 class HoseTimerProcessor:
     """Detect runs on hose-timer valves and emit pushover zone-end reports.
 
@@ -37,12 +44,18 @@ class HoseTimerProcessor:
         db: WaterTrackingDB,
         thresholds: Optional[dict[str, ZoneThreshold]] = None,
         flume_client: Optional[FlumeClient] = None,
+        absolute_gpm: float = 0.5,
+        percent_above: float = 10.0,
+        min_runtime_minutes: int = 5,
     ) -> None:
         self.client = client
         self.pushover = pushover
         self.db = db
         self.thresholds = thresholds or {}
         self.flume = flume_client
+        self.absolute_gpm = absolute_gpm
+        self.percent_above = percent_above
+        self.min_runtime_minutes = min_runtime_minutes
         self.logger = get_logger(__name__)
 
     def evaluate(self, *, dry_run: bool = False, now: Optional[datetime] = None) -> list[dict]:
@@ -60,9 +73,20 @@ class HoseTimerProcessor:
         if not dry_run and valves:
             self.db.save_hose_valves([v.model_dump() for v in valves])
 
+        any_active = False
         for valve in valves:
             entry = self._evaluate_valve(valve, now, dry_run)
             results.append(entry)
+            if entry["action"] in ("run_started", "still_running", "run_completed"):
+                any_active = True
+
+        # Stamp last-active timestamp so AlertEngine can suppress Flume rules
+        # while a hose valve is running or just ran.
+        if any_active and not dry_run:
+            self.db.set_metadata(
+                _HOSE_LAST_ACTIVE_KEY,
+                json.dumps({"at": now.isoformat(), "device": self.client.label}),
+            )
 
         return results
 
@@ -167,7 +191,7 @@ class HoseTimerProcessor:
                             _state_key(valve.id),
                             json.dumps({**cached, "finalized": True}),
                         )
-                        self._send_zone_report(
+                        self._send_zone_outcome(
                             valve, duration_sec, avg_gpm, total_gal, flow_detected
                         )
                     entry["action"] = "run_completed"
@@ -205,7 +229,7 @@ class HoseTimerProcessor:
         avg_gpm = total_gal / len(readings) if readings else 0.0
         return total_gal, avg_gpm
 
-    def _send_zone_report(
+    def _send_zone_outcome(
         self,
         valve: HoseValve,
         duration_sec: int,
@@ -213,11 +237,25 @@ class HoseTimerProcessor:
         total_gal: float,
         flow_detected: Optional[bool],
     ) -> None:
+        """Emit exactly one Pushover per valve run.
+
+        Routes to Zone Anomaly (P2) when measured flow exceeds the configured
+        baseline's anomaly threshold (same formula as the controller path);
+        otherwise sends Zone Report (P-1). The trimmed first line clusters
+        visually with controller zone entries in the Pushover feed.
+        """
         runtime_min = duration_sec / 60.0
-        baseline = self.thresholds[valve.name].avg_gpm if valve.name in self.thresholds else None
+        zt = self.thresholds.get(valve.name)
+        baseline = zt.avg_gpm if zt else 0.0
+        threshold = (
+            zt.compute_threshold(self.absolute_gpm, self.percent_above) if zt else self.absolute_gpm
+        )
+        is_anomaly = runtime_min > self.min_runtime_minutes and baseline > 0 and avg_gpm > threshold
+
+        header = f"'{valve.name}' @ {valve.base_station_label}"
         flow_line = (
-            f"Avg flow: {avg_gpm:.2f} GPM (thresh {baseline:.2f})"
-            if baseline is not None
+            f"Avg flow: {avg_gpm:.2f} GPM (thresh {threshold:.2f})"
+            if baseline > 0
             else f"Avg flow: {avg_gpm:.2f} GPM"
         )
         sensor_line = (
@@ -226,17 +264,26 @@ class HoseTimerProcessor:
             else ("Flow sensor: NOT detected" if flow_detected is False else "")
         )
         lines = [
-            f"Valve '{valve.name}' on {valve.base_station_label} completed.",
+            header,
             f"Runtime: {runtime_min:.0f} min",
             flow_line,
             f"Total: {total_gal:.1f} gal",
         ]
+        if is_anomaly:
+            deviation = avg_gpm - baseline
+            deviation_pct = (deviation / baseline * 100) if baseline > 0 else 0
+            lines.append(f"Deviation: +{deviation:.2f} GPM ({deviation_pct:.0f}%)")
         if sensor_line:
             lines.append(sensor_line)
-        msg = "\n".join(lines)
-        self.pushover.send_message(msg, title="RachioFlume: Hose Run", priority=-1)
+
+        if is_anomaly:
+            title, priority = "RachioFlume: Zone Anomaly", 2
+        else:
+            title, priority = "RachioFlume: Zone Report", -1
+
+        self.pushover.send_message("\n".join(lines), title=title, priority=priority)
         self.logger.info(
-            f"Hose zone-end report sent for '{valve.base_station_label}/{valve.name}': "
+            f"Hose zone outcome sent for '{valve.base_station_label}/{valve.name}': "
             f"{runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal, "
-            f"flow_detected={flow_detected}"
+            f"anomaly={is_anomaly}, flow_detected={flow_detected}"
         )

--- a/RachioFlume/rfmanager.py
+++ b/RachioFlume/rfmanager.py
@@ -17,6 +17,7 @@ from RachioFlume.flume_client import FlumeClient
 from RachioFlume.hose_timer_processor import HoseTimerProcessor
 from RachioFlume.rachio_client import RachioClient
 from RachioFlume.rachio_hose_client import RachioHoseClient
+from RachioFlume.stale_zone_checker import StaleZoneChecker
 from lib.MyPushover import Pushover
 from RachioFlume.reporter import WeeklyReporter
 from lib.logger import get_logger
@@ -173,7 +174,7 @@ def _build_alert_engine() -> AlertEngine:
     """
     rules = load_rules_from_config()
     all_thresholds = load_zone_thresholds_from_config()
-    alerts_cfg = cfg.rachio_flume.alerts
+    za_cfg = cfg.rachio_flume.alerts.zone_anomaly
 
     controllers = [d for d in cfg.rachio.devices if d.type == "controller"]
     if not controllers:
@@ -189,9 +190,9 @@ def _build_alert_engine() -> AlertEngine:
         db=WaterTrackingDB(DB_PATH),
         rules=rules,
         zone_thresholds=controller_thresholds,
-        absolute_gpm=alerts_cfg.absolute_gpm,
-        percent_above=alerts_cfg.percent_above,
-        min_runtime_minutes=alerts_cfg.min_runtime_minutes,
+        absolute_gpm=za_cfg.absolute_gpm,
+        percent_above=za_cfg.percent_above,
+        min_runtime_minutes=za_cfg.min_runtime_minutes,
     )
 
 
@@ -199,9 +200,12 @@ def _build_hose_processors(db: WaterTrackingDB) -> list[HoseTimerProcessor]:
     """One HoseTimerProcessor per Smart Hose Timer base station in config.
 
     Each processor gets a shared FlumeClient so the zone-end report uses the
-    same house-water source as the controller path.
+    same house-water source as the controller path, plus the same
+    absolute_gpm / percent_above so the displayed (thresh ...) matches the
+    actual anomaly trigger value used by the controller path.
     """
     all_thresholds = load_zone_thresholds_from_config()
+    za_cfg = cfg.rachio_flume.alerts.zone_anomaly
     flume_client = (
         FlumeClient() if any(d.type == "hose_timer" for d in cfg.rachio.devices) else None
     )
@@ -221,6 +225,9 @@ def _build_hose_processors(db: WaterTrackingDB) -> list[HoseTimerProcessor]:
                 db=db,
                 thresholds=all_thresholds.get(dev.label, {}),
                 flume_client=flume_client,
+                absolute_gpm=za_cfg.absolute_gpm,
+                percent_above=za_cfg.percent_above,
+                min_runtime_minutes=za_cfg.min_runtime_minutes,
             )
         )
     return processors
@@ -235,11 +242,17 @@ def run_collection(args: argparse.Namespace) -> int:
         alert_engine = _build_alert_engine() if cfg.rachio_flume.alerts.enabled else None
         db = WaterTrackingDB(DB_PATH)
         hose_processors = _build_hose_processors(db)
+        stale_checker = StaleZoneChecker(
+            db=db,
+            pushover=pushover,
+            stale_zone_days=cfg.rachio_flume.alerts.stale_zone_days,
+        )
         collector = WaterTrackingCollector(
             DB_PATH,
             args.interval,
             alert_engine=alert_engine,
             hose_processors=hose_processors,
+            stale_zone_checker=stale_checker,
         )
         if alert_engine is not None:
             logger.info(f"Alerts enabled with {len(alert_engine.rules)} rules")

--- a/RachioFlume/stale_zone_checker.py
+++ b/RachioFlume/stale_zone_checker.py
@@ -1,0 +1,183 @@
+"""Stale-zone monitoring.
+
+Fires a P-1 heads-up if any enabled controller zone or connected hose-timer
+valve hasn't run within `stale_zone_days`. Catches accidentally-disabled
+schedules, offline hose-timer hubs, dead valve batteries, etc.
+
+Dedup: at most one notification per zone per day (stored in metadata).
+Cadence: gated to once per hour from the collector cycle (no need to spam
+on every 5-minute poll).
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from RachioFlume.data_storage import WaterTrackingDB
+from lib.MyPushover import Pushover
+from lib.logger import get_logger
+
+_LAST_RUN_KEY = "stale_zone::last_run"
+_NOTIFIED_KEY_TMPL = "stale_zone::notified::{source}::{zone_key}::{date}"
+_CHECK_INTERVAL = timedelta(hours=1)
+
+
+class StaleZoneChecker:
+    """Once-an-hour scan for zones that haven't run within N days."""
+
+    def __init__(
+        self,
+        db: WaterTrackingDB,
+        pushover: Pushover,
+        stale_zone_days: int = 7,
+    ) -> None:
+        self.db = db
+        self.pushover = pushover
+        self.stale_zone_days = stale_zone_days
+        self.logger = get_logger(__name__)
+
+    def maybe_evaluate(self, *, dry_run: bool = False, now: Optional[datetime] = None) -> bool:
+        """Run the stale-zone scan if at least 1 hour has elapsed since the
+        last run. Returns True if the scan actually ran this call.
+        """
+        if now is None:
+            now = datetime.now()
+        last_run_blob = self.db.get_metadata(_LAST_RUN_KEY)
+        if last_run_blob:
+            try:
+                last_run = datetime.fromisoformat(last_run_blob)
+                if now - last_run < _CHECK_INTERVAL:
+                    return False
+            except ValueError:
+                pass  # corrupt timestamp — treat as never-run
+        self.evaluate(dry_run=dry_run, now=now)
+        if not dry_run:
+            self.db.set_metadata(_LAST_RUN_KEY, now.isoformat())
+        return True
+
+    def evaluate(self, *, dry_run: bool = False, now: Optional[datetime] = None) -> list[dict]:
+        """Scan all enabled zones; alert any stale beyond the threshold."""
+        if now is None:
+            now = datetime.now()
+        cutoff = now - timedelta(days=self.stale_zone_days)
+        results: list[dict] = []
+        date_str = now.strftime("%Y-%m-%d")
+
+        # --- Controller zones ---
+        with self.db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT zone_number, name FROM zones WHERE enabled = 1 ORDER BY zone_number"
+            )
+            controller_zones = [(int(r["zone_number"]), r["name"]) for r in cursor.fetchall()]
+            cursor.execute(
+                """
+                SELECT zone_number, MAX(start_time) AS last_start
+                FROM zone_sessions
+                GROUP BY zone_number
+                """
+            )
+            controller_last = {
+                int(r["zone_number"]): datetime.fromisoformat(r["last_start"])
+                for r in cursor.fetchall()
+                if r["last_start"]
+            }
+
+        for zone_number, zone_name in controller_zones:
+            last_seen = controller_last.get(zone_number)
+            if last_seen and last_seen >= cutoff:
+                continue
+            entry = self._maybe_notify(
+                source="controller",
+                zone_key=str(zone_number),
+                zone_label=zone_name,
+                location="",
+                last_seen=last_seen,
+                now=now,
+                date_str=date_str,
+                dry_run=dry_run,
+            )
+            results.append(entry)
+
+        # --- Hose-timer valves ---
+        with self.db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT id, name, base_station_label FROM hose_valves
+                WHERE connected = 1
+                """
+            )
+            valves = [(r["id"], r["name"], r["base_station_label"]) for r in cursor.fetchall()]
+            cursor.execute(
+                """
+                SELECT valve_id, MAX(start_time) AS last_start
+                FROM hose_zone_sessions
+                GROUP BY valve_id
+                """
+            )
+            hose_last = {
+                r["valve_id"]: datetime.fromisoformat(r["last_start"])
+                for r in cursor.fetchall()
+                if r["last_start"]
+            }
+
+        for valve_id, valve_name, base_label in valves:
+            last_seen = hose_last.get(valve_id)
+            if last_seen and last_seen >= cutoff:
+                continue
+            entry = self._maybe_notify(
+                source="hose",
+                zone_key=valve_id,
+                zone_label=valve_name,
+                location=f" @ {base_label}",
+                last_seen=last_seen,
+                now=now,
+                date_str=date_str,
+                dry_run=dry_run,
+            )
+            results.append(entry)
+
+        return results
+
+    def _maybe_notify(
+        self,
+        *,
+        source: str,
+        zone_key: str,
+        zone_label: str,
+        location: str,
+        last_seen: Optional[datetime],
+        now: datetime,
+        date_str: str,
+        dry_run: bool,
+    ) -> dict:
+        dedup_key = _NOTIFIED_KEY_TMPL.format(source=source, zone_key=zone_key, date=date_str)
+        already_notified = bool(self.db.get_metadata(dedup_key))
+
+        entry = {
+            "source": source,
+            "zone": zone_label,
+            "last_seen": last_seen.isoformat() if last_seen else None,
+            "notified": False,
+        }
+
+        if already_notified or dry_run:
+            if dry_run:
+                self.logger.info(
+                    f"[DRY RUN] Would alert stale {source} zone "
+                    f"'{zone_label}'{location} (last_seen={last_seen})"
+                )
+            return entry
+
+        last_seen_str = last_seen.strftime("%Y-%m-%d %H:%M") if last_seen else "never"
+        msg = (
+            f"'{zone_label}'{location} — no run in {self.stale_zone_days}+ days\n"
+            f"Last seen: {last_seen_str}"
+        )
+        self.pushover.send_message(msg, title="RachioFlume: Stale Zone", priority=-1)
+        self.db.set_metadata(dedup_key, now.isoformat())
+        self.logger.info(
+            f"Stale-zone alert sent: {source} '{zone_label}' last_seen={last_seen_str}"
+        )
+        entry["notified"] = True
+        return entry

--- a/RachioFlume/test_hose_timer.py
+++ b/RachioFlume/test_hose_timer.py
@@ -11,7 +11,11 @@ import pytest
 
 from RachioFlume.alert_rules import ZoneThreshold
 from RachioFlume.data_storage import WaterTrackingDB
-from RachioFlume.hose_timer_processor import HoseTimerProcessor, _state_key
+from RachioFlume.hose_timer_processor import (
+    _HOSE_LAST_ACTIVE_KEY,
+    HoseTimerProcessor,
+    _state_key,
+)
 from RachioFlume.rachio_hose_client import HoseValve, RachioHoseClient
 
 
@@ -117,7 +121,8 @@ class TestHoseTimerProcessor:
         msg = call_args[0][0]
         assert "Hose Drip Jasmine" in msg
         assert "Upper Deck Planters" in msg
-        assert "thresh 0.50" in msg  # configured baseline appears in flow line
+        # Unified anomaly threshold (computed): baseline 0.5 + max(0.5, 10%*0.5) = 1.00
+        assert "thresh 1.00" in msg
         assert "Avg flow:" in msg
         assert "Total:" in msg
         assert "Flow sensor: detected" in msg
@@ -197,6 +202,80 @@ class TestHoseTimerProcessor:
         # No state persisted
         assert tmp_db.get_metadata(_state_key("valve-1")) is None
         pushover.send_message.assert_not_called()
+
+
+class TestZoneOutcomeDispatch:
+    """Verify _send_zone_outcome routes to Anomaly vs Report correctly."""
+
+    def _outcome_call(self, pushover: MagicMock) -> Any:
+        return pushover.send_message.call_args
+
+    def test_outcome_below_threshold_is_report(self, tmp_db: WaterTrackingDB) -> None:
+        valve = _valve()
+        proc, pushover = _make_processor(tmp_db, valve)
+        # baseline=0.5, thresh=1.0; avg_gpm=0.4 → below → report
+        proc._send_zone_outcome(
+            valve, duration_sec=600, avg_gpm=0.4, total_gal=4.0, flow_detected=False
+        )
+        call = self._outcome_call(pushover)
+        assert call[1]["priority"] == -1
+        assert call[1]["title"] == "RachioFlume: Zone Report"
+        assert "Deviation" not in call[0][0]
+        assert "'Upper Deck Planters' @ Hose Drip Jasmine" in call[0][0]
+
+    def test_outcome_above_threshold_is_anomaly(self, tmp_db: WaterTrackingDB) -> None:
+        valve = _valve()
+        proc, pushover = _make_processor(tmp_db, valve)
+        # baseline=0.5, thresh=1.0; avg_gpm=1.5 with 10-min runtime → anomaly
+        proc._send_zone_outcome(
+            valve, duration_sec=600, avg_gpm=1.5, total_gal=15.0, flow_detected=True
+        )
+        call = self._outcome_call(pushover)
+        assert call[1]["priority"] == 2
+        assert call[1]["title"] == "RachioFlume: Zone Anomaly"
+        body = call[0][0]
+        assert "Deviation" in body
+        assert "Total: 15.0 gal" in body
+        assert "(thresh 1.00)" in body  # unified threshold
+
+    def test_outcome_short_run_skips_anomaly(self, tmp_db: WaterTrackingDB) -> None:
+        valve = _valve()
+        proc, pushover = _make_processor(tmp_db, valve)
+        # Short 1-min run, over threshold, but min_runtime_minutes=5 → report
+        proc._send_zone_outcome(
+            valve, duration_sec=60, avg_gpm=1.5, total_gal=1.5, flow_detected=False
+        )
+        call = self._outcome_call(pushover)
+        assert call[1]["priority"] == -1
+        assert call[1]["title"] == "RachioFlume: Zone Report"
+        assert "Deviation" not in call[0][0]
+
+
+class TestHoseActivitySuppression:
+    """Verify that running valves stamp the cross-component suppression key."""
+
+    def test_active_run_writes_last_active_key(self, tmp_db: WaterTrackingDB) -> None:
+        action = {
+            "start": "2026-06-27T07:46:46Z",
+            "durationSeconds": "60",
+            "reason": "QUICK_RUN",
+            "flowDetected": False,
+        }
+        valve = _valve(action)
+        proc, _ = _make_processor(tmp_db, valve)
+        # Cycle 1 sees a new run → run_started, should stamp key
+        proc.evaluate(now=datetime(2026, 6, 27, 7, 47, 0))
+        blob = tmp_db.get_metadata(_HOSE_LAST_ACTIVE_KEY)
+        assert blob is not None
+        data = json.loads(blob)
+        assert data["device"] == "Hose Drip Jasmine"
+        assert "at" in data
+
+    def test_idle_valve_does_not_stamp_key(self, tmp_db: WaterTrackingDB) -> None:
+        valve = _valve(action=None)
+        proc, _ = _make_processor(tmp_db, valve)
+        proc.evaluate(now=datetime(2026, 6, 27, 7, 47, 0))
+        assert tmp_db.get_metadata(_HOSE_LAST_ACTIVE_KEY) is None
 
 
 class TestListValvesParsing:

--- a/RachioFlume/test_stale_zone_checker.py
+++ b/RachioFlume/test_stale_zone_checker.py
@@ -1,0 +1,177 @@
+"""Tests for the stale-zone checker."""
+
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from RachioFlume.data_storage import WaterTrackingDB
+from RachioFlume.stale_zone_checker import StaleZoneChecker, _LAST_RUN_KEY
+
+
+@pytest.fixture
+def tmp_db() -> Iterator[WaterTrackingDB]:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = f.name
+    try:
+        yield WaterTrackingDB(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def _seed_controller_zone(
+    db: WaterTrackingDB, zone_number: int, name: str, enabled: bool = True
+) -> None:
+    with db.get_connection() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO zones (id, zone_number, name, enabled) VALUES (?, ?, ?, ?)",
+            (f"z{zone_number}", zone_number, name, 1 if enabled else 0),
+        )
+        conn.commit()
+
+
+def _seed_zone_session(db: WaterTrackingDB, zone_number: int, start: datetime) -> None:
+    with db.get_connection() as conn:
+        conn.execute(
+            """INSERT INTO zone_sessions
+               (zone_name, zone_number, start_time, end_time, duration_seconds)
+               VALUES (?, ?, ?, ?, ?)""",
+            (f"Z{zone_number}", zone_number, start, start + timedelta(minutes=10), 600),
+        )
+        conn.commit()
+
+
+def _seed_valve(db: WaterTrackingDB, valve_id: str, valve_name: str, base_label: str) -> None:
+    with db.get_connection() as conn:
+        conn.execute(
+            """INSERT OR REPLACE INTO hose_valves
+               (id, base_station_id, base_station_label, name,
+                default_runtime_seconds, detect_flow, battery_status, connected)
+               VALUES (?, 'bs1', ?, ?, 600, 1, 'GOOD', 1)""",
+            (valve_id, base_label, valve_name),
+        )
+        conn.commit()
+
+
+def _seed_hose_session(
+    db: WaterTrackingDB, valve_id: str, valve_name: str, base_label: str, start: datetime
+) -> None:
+    with db.get_connection() as conn:
+        conn.execute(
+            """INSERT INTO hose_zone_sessions
+               (valve_id, base_station_id, valve_name, base_station_label,
+                start_time, end_time, duration_seconds)
+               VALUES (?, 'bs1', ?, ?, ?, ?, ?)""",
+            (
+                valve_id,
+                valve_name,
+                base_label,
+                start,
+                start + timedelta(minutes=10),
+                600,
+            ),
+        )
+        conn.commit()
+
+
+class TestStaleZoneChecker:
+    def test_fresh_zone_no_alert(self, tmp_db: WaterTrackingDB) -> None:
+        now = datetime(2026, 6, 28, 8, 0, 0)
+        _seed_controller_zone(tmp_db, 1, "Z1")
+        _seed_zone_session(tmp_db, 1, now - timedelta(days=2))  # fresh
+        pushover = MagicMock()
+        checker = StaleZoneChecker(tmp_db, pushover, stale_zone_days=7)
+        results = checker.evaluate(now=now)
+        assert len(results) == 0
+        pushover.send_message.assert_not_called()
+
+    def test_stale_controller_zone_alerts(self, tmp_db: WaterTrackingDB) -> None:
+        now = datetime(2026, 6, 28, 8, 0, 0)
+        _seed_controller_zone(tmp_db, 1, "Z1 FS - Sergio Outer")
+        _seed_zone_session(tmp_db, 1, now - timedelta(days=10))  # stale
+        pushover = MagicMock()
+        checker = StaleZoneChecker(tmp_db, pushover, stale_zone_days=7)
+        results = checker.evaluate(now=now)
+        assert len(results) == 1
+        assert results[0]["notified"] is True
+        pushover.send_message.assert_called_once()
+        call = pushover.send_message.call_args
+        assert "Stale Zone" in call[1]["title"]
+        assert call[1]["priority"] == -1
+        body = call[0][0]
+        assert "Z1 FS - Sergio Outer" in body
+        assert "7+ days" in body
+
+    def test_never_run_zone_alerts(self, tmp_db: WaterTrackingDB) -> None:
+        now = datetime(2026, 6, 28, 8, 0, 0)
+        _seed_controller_zone(tmp_db, 9, "Z9 FD - Garage")
+        # No session ever
+        pushover = MagicMock()
+        checker = StaleZoneChecker(tmp_db, pushover, stale_zone_days=7)
+        results = checker.evaluate(now=now)
+        assert results[0]["notified"] is True
+        body = pushover.send_message.call_args[0][0]
+        assert "never" in body.lower()
+
+    def test_disabled_zone_skipped(self, tmp_db: WaterTrackingDB) -> None:
+        now = datetime(2026, 6, 28, 8, 0, 0)
+        _seed_controller_zone(tmp_db, 13, "Zone 13", enabled=False)
+        pushover = MagicMock()
+        checker = StaleZoneChecker(tmp_db, pushover, stale_zone_days=7)
+        results = checker.evaluate(now=now)
+        assert len(results) == 0
+
+    def test_stale_hose_valve_alerts(self, tmp_db: WaterTrackingDB) -> None:
+        now = datetime(2026, 6, 28, 8, 0, 0)
+        _seed_valve(tmp_db, "v1", "Upper Deck Planters", "Hose Drip Jasmine")
+        _seed_hose_session(
+            tmp_db, "v1", "Upper Deck Planters", "Hose Drip Jasmine", now - timedelta(days=14)
+        )
+        pushover = MagicMock()
+        checker = StaleZoneChecker(tmp_db, pushover, stale_zone_days=7)
+        results = checker.evaluate(now=now)
+        assert any(r["source"] == "hose" and r["notified"] for r in results)
+        body = pushover.send_message.call_args[0][0]
+        assert "Upper Deck Planters" in body
+        assert "@ Hose Drip Jasmine" in body
+
+    def test_daily_dedup_blocks_second_notification(self, tmp_db: WaterTrackingDB) -> None:
+        now = datetime(2026, 6, 28, 8, 0, 0)
+        _seed_controller_zone(tmp_db, 1, "Z1")
+        # Stale by 10 days
+        _seed_zone_session(tmp_db, 1, now - timedelta(days=10))
+        pushover = MagicMock()
+        checker = StaleZoneChecker(tmp_db, pushover, stale_zone_days=7)
+        checker.evaluate(now=now)
+        pushover.send_message.assert_called_once()
+        # Second call same day - dedup
+        checker.evaluate(now=now + timedelta(hours=3))
+        pushover.send_message.assert_called_once()  # still 1
+        # Next day - alert again
+        checker.evaluate(now=now + timedelta(days=1))
+        assert pushover.send_message.call_count == 2
+
+    def test_maybe_evaluate_hourly_gate(self, tmp_db: WaterTrackingDB) -> None:
+        now = datetime(2026, 6, 28, 8, 0, 0)
+        pushover = MagicMock()
+        checker = StaleZoneChecker(tmp_db, pushover, stale_zone_days=7)
+        # First call runs
+        assert checker.maybe_evaluate(now=now) is True
+        assert tmp_db.get_metadata(_LAST_RUN_KEY) is not None
+        # Call 30 min later — gated, doesn't run
+        assert checker.maybe_evaluate(now=now + timedelta(minutes=30)) is False
+        # Call 65 min later — runs again
+        assert checker.maybe_evaluate(now=now + timedelta(minutes=65)) is True
+
+    def test_dry_run_does_not_send_or_persist(self, tmp_db: WaterTrackingDB) -> None:
+        now = datetime(2026, 6, 28, 8, 0, 0)
+        _seed_controller_zone(tmp_db, 1, "Z1")
+        _seed_zone_session(tmp_db, 1, now - timedelta(days=10))
+        pushover = MagicMock()
+        checker = StaleZoneChecker(tmp_db, pushover, stale_zone_days=7)
+        checker.maybe_evaluate(now=now, dry_run=True)
+        pushover.send_message.assert_not_called()
+        assert tmp_db.get_metadata(_LAST_RUN_KEY) is None

--- a/RachioFlume/test_zone_thresholds.py
+++ b/RachioFlume/test_zone_thresholds.py
@@ -99,7 +99,7 @@ def mock_engine(prod_db_path: str, zone_thresholds: dict[int, ZoneThreshold]) ->
     pushover = MagicMock()
 
     cfg = get_config()
-    alerts_cfg = cfg.rachio_flume.alerts
+    za_cfg = cfg.rachio_flume.alerts.zone_anomaly
 
     return AlertEngine(
         flume_client=flume,
@@ -108,9 +108,9 @@ def mock_engine(prod_db_path: str, zone_thresholds: dict[int, ZoneThreshold]) ->
         db=db,
         rules=[],
         zone_thresholds=zone_thresholds,
-        absolute_gpm=alerts_cfg.absolute_gpm,
-        percent_above=alerts_cfg.percent_above,
-        min_runtime_minutes=alerts_cfg.min_runtime_minutes,
+        absolute_gpm=za_cfg.absolute_gpm,
+        percent_above=za_cfg.percent_above,
+        min_runtime_minutes=za_cfg.min_runtime_minutes,
     )
 
 
@@ -165,82 +165,55 @@ class TestZoneThresholdChecking:
         assert avg_gpm == 0.0
         assert threshold == 0.5
 
-    def test_check_zone_threshold_no_alert(self, mock_engine: AlertEngine) -> None:
-        """Test that normal flow doesn't trigger alert."""
-        now = datetime.now()
-        # Zone 10 threshold is 7.7 GPM, send 7.0 GPM (below threshold)
-        alerted = mock_engine._check_zone_threshold(
-            zone_name="Z10 BB - Redwoods",
-            zone_number=10,
-            avg_gpm=7.0,
-            runtime_min=10.0,
-            now=now,
-            dry_run=False,
-        )
-        assert alerted is False
-        mock_engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
-
-    def test_check_zone_threshold_alert_triggered(self, mock_engine: AlertEngine) -> None:
-        """Test that excessive flow triggers alert."""
-        now = datetime.now()
-        # Zone 10 threshold is 7.7 GPM, send 8.5 GPM (above threshold)
-        alerted = mock_engine._check_zone_threshold(
-            zone_name="Z10 BB - Redwoods",
-            zone_number=10,
-            avg_gpm=8.5,
-            runtime_min=10.0,
-            now=now,
-            dry_run=False,
-        )
-        assert alerted is True
-        mock_engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
+    def _outcome_title(self, mock_engine: AlertEngine) -> str:
         call_args: Any = mock_engine.pushover.send_message.call_args  # type: ignore[attr-defined]
-        assert "anomaly" in call_args[1]["title"].lower() or "anomaly" in call_args[0][0].lower()
-        assert call_args[1]["priority"] == 2  # P2 emergency
+        return call_args[1]["title"]  # type: ignore[no-any-return]
 
-    def test_check_zone_threshold_unknown_zone_alerts(self, mock_engine: AlertEngine) -> None:
-        """Test that unknown zone with any flow triggers alert."""
-        now = datetime.now()
-        # Unknown zone threshold is 0.5 GPM, send 0.6 GPM
-        alerted = mock_engine._check_zone_threshold(
-            zone_name="Unknown Zone",
-            zone_number=99,
-            avg_gpm=0.6,
-            runtime_min=10.0,
-            now=now,
-            dry_run=False,
-        )
-        assert alerted is True
+    def _outcome_priority(self, mock_engine: AlertEngine) -> int:
+        call_args: Any = mock_engine.pushover.send_message.call_args  # type: ignore[attr-defined]
+        return call_args[1]["priority"]  # type: ignore[no-any-return]
+
+    def _outcome_body(self, mock_engine: AlertEngine) -> str:
+        call_args: Any = mock_engine.pushover.send_message.call_args  # type: ignore[attr-defined]
+        return call_args[0][0]  # type: ignore[no-any-return]
+
+    def test_zone_outcome_below_threshold_is_report(self, mock_engine: AlertEngine) -> None:
+        """Normal flow → routine Zone Report (P-1), not anomaly."""
+        # Zone 10 threshold is 7.7 GPM, send 7.0 GPM (below threshold)
+        mock_engine._send_zone_outcome("Z10 BB - Redwoods", 10, 10.0, 7.0, 70.0, 1)
         mock_engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
+        assert "Zone Report" in self._outcome_title(mock_engine)
+        assert self._outcome_priority(mock_engine) == -1
+        assert "Deviation" not in self._outcome_body(mock_engine)
 
-    def test_check_zone_threshold_dry_run(self, mock_engine: AlertEngine) -> None:
-        """Test dry run doesn't send actual alert."""
-        now = datetime.now()
-        alerted = mock_engine._check_zone_threshold(
-            zone_name="Z10 BB - Redwoods",
-            zone_number=10,
-            avg_gpm=8.5,
-            runtime_min=10.0,
-            now=now,
-            dry_run=True,
-        )
-        assert alerted is True
-        mock_engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
+    def test_zone_outcome_above_threshold_is_anomaly(self, mock_engine: AlertEngine) -> None:
+        """Excessive flow → Zone Anomaly (P2) with Deviation line + Total."""
+        # Zone 10 threshold is 7.7 GPM, send 8.5 GPM (above)
+        mock_engine._send_zone_outcome("Z10 BB - Redwoods", 10, 10.0, 8.5, 85.0, 1)
+        mock_engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
+        assert "Zone Anomaly" in self._outcome_title(mock_engine)
+        assert self._outcome_priority(mock_engine) == 2
+        body = self._outcome_body(mock_engine)
+        assert "Deviation" in body
+        assert "Total: 85.0 gal" in body
+        assert "(thresh 7.70)" in body  # unified threshold value
 
-    def test_check_zone_threshold_short_run_skipped(self, mock_engine: AlertEngine) -> None:
-        """Test that short runs (<= min_runtime_minutes) don't trigger alerts."""
-        now = datetime.now()
-        # Zone 10 threshold is 7.7 GPM, send 8.5 GPM (above threshold) but short runtime
-        alerted = mock_engine._check_zone_threshold(
-            zone_name="Z10 BB - Redwoods",
-            zone_number=10,
-            avg_gpm=8.5,
-            runtime_min=3.0,  # less than min_runtime_minutes (5)
-            now=now,
-            dry_run=False,
-        )
-        assert alerted is False
-        mock_engine.pushover.send_message.assert_not_called()  # type: ignore[attr-defined]
+    def test_zone_outcome_unknown_zone_no_baseline(self, mock_engine: AlertEngine) -> None:
+        """Unknown zone has no configured baseline → routine report, no thresh."""
+        mock_engine._send_zone_outcome("Unknown Zone", 99, 10.0, 0.6, 6.0, 1)
+        mock_engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
+        assert "Zone Report" in self._outcome_title(mock_engine)
+        body = self._outcome_body(mock_engine)
+        assert "(thresh" not in body  # no baseline → no thresh display
+        assert "Deviation" not in body  # no baseline → can't be anomaly
+
+    def test_zone_outcome_short_run_is_report_not_anomaly(self, mock_engine: AlertEngine) -> None:
+        """Short run (<= min_runtime_minutes) skips the anomaly path even when over threshold."""
+        # 3 min run, well over threshold, but below min_runtime_minutes → report only
+        mock_engine._send_zone_outcome("Z10 BB - Redwoods", 10, 3.0, 8.5, 25.5, 1)
+        mock_engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
+        assert "Zone Report" in self._outcome_title(mock_engine)
+        assert "Deviation" not in self._outcome_body(mock_engine)
 
 
 class TestRealZoneData:
@@ -301,9 +274,8 @@ def main() -> int:
     for zone_num in sorted(zone_thresholds.keys()):
         zt = zone_thresholds[zone_num]
         cfg = get_config()
-        threshold = zt.compute_threshold(
-            cfg.rachio_flume.alerts.absolute_gpm, cfg.rachio_flume.alerts.percent_above
-        )
+        za_cfg = cfg.rachio_flume.alerts.zone_anomaly
+        threshold = zt.compute_threshold(za_cfg.absolute_gpm, za_cfg.percent_above)
         print(f"    Zone {zone_num:2d}: avg={zt.avg_gpm:5.2f} GPM, threshold={threshold:5.2f} GPM")
 
     # Test threshold checking
@@ -315,7 +287,7 @@ def main() -> int:
     pushover = MagicMock()
 
     cfg = get_config()
-    alerts_cfg = cfg.rachio_flume.alerts
+    za_cfg = cfg.rachio_flume.alerts.zone_anomaly
 
     engine = AlertEngine(
         flume_client=flume,
@@ -324,9 +296,9 @@ def main() -> int:
         db=db,
         rules=[],
         zone_thresholds=zone_thresholds,
-        absolute_gpm=alerts_cfg.absolute_gpm,
-        percent_above=alerts_cfg.percent_above,
-        min_runtime_minutes=alerts_cfg.min_runtime_minutes,
+        absolute_gpm=za_cfg.absolute_gpm,
+        percent_above=za_cfg.percent_above,
+        min_runtime_minutes=za_cfg.min_runtime_minutes,
     )
 
     # Test known zone
@@ -337,16 +309,19 @@ def main() -> int:
     threshold, avg = engine._get_zone_threshold(99)
     print(f"  ✓ Zone 99 (unknown): avg={avg:.2f}, threshold={threshold:.2f}")
 
-    # Test alert triggering
-    now = datetime.now()
-    alerted = engine._check_zone_threshold("Z10 BB", 10, 8.5, 10.0, now, dry_run=True)
-    print(f"  ✓ Zone 10 @ 8.5 GPM: alert={'YES' if alerted else 'NO'} (expected: YES)")
+    # Test outcome dispatch via _send_zone_outcome
+    now = datetime.now()  # noqa: F841 -- kept for downstream code below
+    engine._send_zone_outcome("Z10 BB", 10, 10.0, 8.5, 85.0, 1)
+    title = engine.pushover.send_message.call_args[1]["title"]  # type: ignore[attr-defined]
+    print(f"  ✓ Zone 10 @ 8.5 GPM: {title} (expected: Zone Anomaly)")
 
-    alerted = engine._check_zone_threshold("Z10 BB", 10, 7.0, 10.0, now, dry_run=True)
-    print(f"  ✓ Zone 10 @ 7.0 GPM: alert={'YES' if alerted else 'NO'} (expected: NO)")
+    engine._send_zone_outcome("Z10 BB", 10, 10.0, 7.0, 70.0, 1)
+    title = engine.pushover.send_message.call_args[1]["title"]  # type: ignore[attr-defined]
+    print(f"  ✓ Zone 10 @ 7.0 GPM: {title} (expected: Zone Report)")
 
-    alerted = engine._check_zone_threshold("Unknown", 99, 0.6, 10.0, now, dry_run=True)
-    print(f"  ✓ Zone 99 @ 0.6 GPM: alert={'YES' if alerted else 'NO'} (expected: YES)")
+    engine._send_zone_outcome("Unknown", 99, 10.0, 0.6, 6.0, 1)
+    title = engine.pushover.send_message.call_args[1]["title"]  # type: ignore[attr-defined]
+    print(f"  ✓ Zone 99 @ 0.6 GPM: {title} (expected: Zone Report; unknown→no baseline)")
 
     # Check real data
     print("\n[4/4] Checking real zone data from production...")

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -237,26 +237,34 @@ flume:
 rachio_flume:
   alerts:
     enabled: true
-    default_retrigger_minutes: 30
-    # Zone-end anomaly threshold: alert when flow exceeds zone avg by the
-    # greater of absolute_gpm or (percent_above / 100 * avg_gpm).
-    # "adaptive" = max(absolute_gpm, percent_above/100 * avg_gpm)
-    threshold_mode: adaptive
-    absolute_gpm: 0.5        # min deviation above average (GPM)
-    percent_above: 10        # min deviation above average (%)
-    min_runtime_minutes: 5   # zone must run this long (min) before threshold alert fires
-    rules:
+    default_retrigger_minutes: 30   # cadence for re-firing default_flow_rules
+
+    # === Per-zone anomaly check (Rachio-sourced; fires at run end) ===
+    # threshold = avg_gpm + max(absolute_gpm, percent_above/100 * avg_gpm)
+    zone_anomaly:
+      threshold_mode: adaptive       # informational; computation is "adaptive"
+      absolute_gpm: 0.5              # min deviation above average (GPM)
+      percent_above: 10              # min deviation above average (%)
+      min_runtime_minutes: 5         # zone must run this long before anomaly fires
+      # Per-zone baseline flow rates (GPM) from historical data.
+      # Outer key = device label (matches rachio.devices[].label).
+      # Inner key = zone identifier:
+      #   - Controllers: stringified zone_number (e.g. "1")
+      #   - Hose timers: valve name (e.g. "Upper Deck Planters")
+      zone_thresholds: {}
+
+    # === Whole-house sustained-flow rules (Flume only; no Rachio context) ===
+    # Suppressed while any Rachio activity (controller OR hose-timer) is recent.
+    default_flow_rules:
       - {name: "Pipe Break", min_gpm: 8.0, duration_minutes: 10}
       - {name: "High Flow",  min_gpm: 5.4, duration_minutes: 4}
       - {name: "Mid Flow",   min_gpm: 2.6, duration_minutes: 14}
       - {name: "Leak",       min_gpm: 0.1, duration_minutes: 120}
-    # Per-zone baseline flow rates (GPM) from historical data.
-    # Outer key = device label (matches rachio.devices[].label).
-    # Inner key = zone identifier:
-    #   - Controllers: stringified zone_number (e.g. "1")
-    #   - Hose timers: valve name (e.g. "Upper Deck Planters")
-    # Alert fires when zone-end flow > avg + max(absolute_gpm, percent_above/100 * avg).
-    zone_thresholds: {}
+
+    # === Stale-zone monitoring ===
+    # Fire a P-1 heads-up if any enabled controller zone or connected
+    # hose-timer valve hasn't run within this many days.
+    stale_zone_days: 7
 
 # === PersonalCalSync (Google Apps Script) ===
 personal_cal_sync:

--- a/lib/config.py
+++ b/lib/config.py
@@ -260,20 +260,39 @@ class ZoneThresholdConfig:
 
 
 @dataclass
-class RachioFlumeAlertsConfig:
-    """Usage alert configuration for RachioFlume"""
+class ZoneAnomalyConfig:
+    """Per-zone anomaly check for Rachio-sourced runs (controller + hose timer).
 
-    enabled: bool
-    default_retrigger_minutes: int
-    threshold_mode: str  # "adaptive", "absolute", or "percent"
+    Fires at zone end when measured flow exceeds the configured baseline:
+      threshold = avg_gpm + max(absolute_gpm, percent_above/100 * avg_gpm)
+    """
+
+    threshold_mode: str  # "adaptive", "absolute", or "percent" (currently informational)
     absolute_gpm: float  # min deviation above average (GPM)
     percent_above: float  # min deviation above average (%)
-    min_runtime_minutes: int  # zone must run this long before threshold alert fires
-    rules: list[AlertRuleConfig]
+    min_runtime_minutes: int  # zone must run this long before anomaly fires
     # device_label -> zone_key -> threshold.
     # For controllers, zone_key is the integer zone_number (as a string for YAML).
     # For hose timers, zone_key is the valve name (matches getValve.name).
     zone_thresholds: Dict[str, Dict[str, ZoneThresholdConfig]]
+
+
+@dataclass
+class RachioFlumeAlertsConfig:
+    """Usage alert configuration for RachioFlume.
+
+    Two independent alert paths share this block:
+    - zone_anomaly: scoped to Rachio events (per-zone, at run end).
+    - default_flow_rules: whole-house sustained-flow rules (Flume only);
+      suppressed while any Rachio activity is recent.
+    - stale_zone_days: heads-up if an enabled zone hasn't run in N days.
+    """
+
+    enabled: bool
+    default_retrigger_minutes: int  # cadence for re-firing default_flow_rules
+    zone_anomaly: ZoneAnomalyConfig
+    default_flow_rules: list[AlertRuleConfig]
+    stale_zone_days: int
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Five interlocking cleanups to RachioFlume alerts, all touching the same `rachio_flume.alerts` config block and Pushover dispatch path. Bundled in one PR so the config refactor (#1) doesn't have to be re-touched by each follow-up.

Prompted by the 28-Jun screenshot showing two pushovers for the same Z1 FS run end at 6:59 AM (Zone Report P-1 + Zone Anomaly P2 within seconds of each other), plus the realization that `absolute_gpm` / `percent_above` are scoped to per-zone anomaly detection but were sitting alongside the unrelated whole-house sustained-flow `rules`.

## What changed

### 1. Config refactor (`rachio_flume.alerts`)

Split into three scoped blocks:
- `zone_anomaly{}` — per-zone anomaly check (Rachio-sourced): `threshold_mode`, `absolute_gpm`, `percent_above`, `min_runtime_minutes`, `zone_thresholds`.
- `default_flow_rules[]` — whole-house sustained-flow rules (Flume only, no Rachio context). Was misnamed `rules`.
- `stale_zone_days: 7` — new, for stale-zone monitoring.

New `ZoneAnomalyConfig` dataclass; old loose fields deleted from `RachioFlumeAlertsConfig` (no deprecation shim, per repo convention).

### 2. One pushover per zone end (no Report + Anomaly duplicate)

`_send_zone_report` + `_check_zone_threshold` collapsed into a single `_send_zone_outcome` on both `AlertEngine` and `HoseTimerProcessor`. Picks `(title, priority)` based on whether the measured flow exceeds the anomaly threshold, then sends one pushover with the full payload. Anomaly path now includes the `Total: N.N gal` line that was previously missing.

### 3. Unified threshold value

The displayed `(thresh X.XX)` on every zone-end report is now the computed anomaly trigger value — matches the actual fire condition. Previously the report showed the raw baseline `avg_gpm` while the anomaly fired off the higher computed threshold.

### 4. Trimmed first line + unified pushover titles

- Controller: `Zone 'Z2 FS - Sergio Inner' completed (Cycle 2).` → `'Z2 FS - Sergio Inner' (Cycle 2)`
- Hose timer: `Valve 'Upper Deck Planters' on Hose Drip Jasmine completed.` → `'Upper Deck Planters' @ Hose Drip Jasmine`
- Hose-timer title set aligns to controller's `RachioFlume: Zone Report` / `RachioFlume: Zone Anomaly` (drops the `Hose Run` variant).

### 5. Hose-timer activity suppresses Flume rule alerts

`HoseTimerProcessor` now stamps `alert::__hose__::last_active` on any active/recent valve cycle. `AlertEngine` reads it as a second suppression source alongside the controller-active check, using the same `max_rule_duration + RACHIO_POST_ACTIVE_SLACK_MINUTES` window. Decoupled via DB metadata.

### 6. Stale-zone monitor (new)

`StaleZoneChecker` fires a P-1 heads-up if any enabled controller zone or connected hose-timer valve hasn't run within `stale_zone_days` (default 7). Daily dedup per zone + hourly evaluation cadence gate. Wired into the collector cycle.

## Test plan

- [x] `make test` — 80 RachioFlume tests pass (12 new)
- [x] `make lint` — ruff + mypy + vulture + semgrep + codespell + deptry clean
- [x] `uv run python RachioFlume/rfmanager.py alerts test` — dry-run prints expected rule list under new config shape
- [x] `uv run python RachioFlume/rfmanager.py list-devices` — still enumerates both devices correctly
- [ ] Live verification on next controller run (Tue/Fri 6:05 AM schedule): exactly **one** Pushover per zone end with unified `(thresh …)` value
- [ ] Live verification on next hose-timer run: `alerts test` shows `suppressed_by: hose:Hose Drip Jasmine (recent)`

## References

- Plan: `/tmp/rachioflume_threshold_unify_plan.md`
- Previous related PR: #199 (initial Smart Hose Timer support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)