### PR TITLE
feat(RachioFlume): drop Flume bridge readings, lower Mid Flow threshold to 2.0

### DIFF
--- a/RachioFlume/data_storage.py
+++ b/RachioFlume/data_storage.py
@@ -183,7 +183,14 @@ class WaterTrackingDB:
         self._dedup_water_readings()
 
     def _dedup_water_readings(self) -> None:
-        """Collapse duplicate-per-timestamp rows in water_readings (one-shot)."""
+        """Collapse duplicate-per-timestamp rows in water_readings (one-shot).
+
+        Uses an atomic DML transaction (UPDATE-then-DELETE) rather than a
+        DDL table-swap. sqlite3's `executescript` auto-commits between
+        statements, so a failure mid-script between DROP and RENAME would
+        leave the table missing; UPDATE+DELETE inside one BEGIN/COMMIT can
+        be cleanly rolled back on error.
+        """
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -194,20 +201,33 @@ class WaterTrackingDB:
             if dupes == 0:
                 return
             self.logger.info(f"Deduping {dupes} legacy duplicate-per-timestamp water_readings rows")
-            cursor.executescript(
-                """
-                CREATE TABLE water_readings_new AS
-                SELECT MIN(id) AS id, timestamp, MAX(value) AS value,
-                       MAX(unit) AS unit, MAX(created_at) AS created_at
-                FROM water_readings
-                GROUP BY timestamp;
-                DROP TABLE water_readings;
-                ALTER TABLE water_readings_new RENAME TO water_readings;
-                CREATE INDEX IF NOT EXISTS idx_water_readings_timestamp
-                    ON water_readings(timestamp);
-                """
-            )
-            conn.commit()
+            try:
+                cursor.execute("BEGIN")
+                # Promote every duplicate row's value to the max for its timestamp,
+                # so legacy bridge=0 / meter=N pairs all carry the meter's reading
+                # before we delete duplicates.
+                cursor.execute(
+                    """
+                    UPDATE water_readings
+                    SET value = (
+                        SELECT MAX(value) FROM water_readings AS w2
+                        WHERE w2.timestamp = water_readings.timestamp
+                    )
+                    """
+                )
+                # Keep lowest-id row per timestamp; delete the rest.
+                cursor.execute(
+                    """
+                    DELETE FROM water_readings
+                    WHERE id NOT IN (
+                        SELECT MIN(id) FROM water_readings GROUP BY timestamp
+                    )
+                    """
+                )
+                cursor.execute("COMMIT")
+            except Exception:
+                cursor.execute("ROLLBACK")
+                raise
 
     @contextmanager
     def get_connection(self) -> Generator[sqlite3.Connection, None, None]:

--- a/RachioFlume/data_storage.py
+++ b/RachioFlume/data_storage.py
@@ -174,6 +174,41 @@ class WaterTrackingDB:
 
             conn.commit()
 
+        # One-shot dedup of legacy per-device rows in water_readings.
+        # Pre-2026-06-28, the Flume collector saved one row per (timestamp,
+        # device), so each minute had two rows: the real meter value and a
+        # 0.0 from the bridge. Dedup by keeping MAX value per timestamp —
+        # since the bridge always read 0, MAX preserves the meter's reading
+        # for every minute that ever had real flow.
+        self._dedup_water_readings()
+
+    def _dedup_water_readings(self) -> None:
+        """Collapse duplicate-per-timestamp rows in water_readings (one-shot)."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT COUNT(*) - COUNT(DISTINCT timestamp) AS dupes FROM water_readings"
+            )
+            row = cursor.fetchone()
+            dupes = (row["dupes"] if row else 0) or 0
+            if dupes == 0:
+                return
+            self.logger.info(f"Deduping {dupes} legacy duplicate-per-timestamp water_readings rows")
+            cursor.executescript(
+                """
+                CREATE TABLE water_readings_new AS
+                SELECT MIN(id) AS id, timestamp, MAX(value) AS value,
+                       MAX(unit) AS unit, MAX(created_at) AS created_at
+                FROM water_readings
+                GROUP BY timestamp;
+                DROP TABLE water_readings;
+                ALTER TABLE water_readings_new RENAME TO water_readings;
+                CREATE INDEX IF NOT EXISTS idx_water_readings_timestamp
+                    ON water_readings(timestamp);
+                """
+            )
+            conn.commit()
+
     @contextmanager
     def get_connection(self) -> Generator[sqlite3.Connection, None, None]:
         """Get database connection with automatic cleanup."""

--- a/RachioFlume/flume_client.py
+++ b/RachioFlume/flume_client.py
@@ -256,9 +256,12 @@ class FlumeClient:
         # location it gives the engine a single coherent flow series instead
         # of N interleaved per-device rows. Sum is the correct combinator
         # because each meter measures a disjoint physical sub-flow.
+        # Round timestamps to the minute before merging so sub-second drift
+        # between per-device responses doesn't escape the dedup.
         merged: dict[datetime, float] = {}
         for r in all_readings:
-            merged[r.timestamp] = merged.get(r.timestamp, 0.0) + r.value
+            minute_key = r.timestamp.replace(second=0, microsecond=0)
+            merged[minute_key] = merged.get(minute_key, 0.0) + r.value
         deduped = [WaterReading(timestamp=ts, value=v) for ts, v in sorted(merged.items())]
         if len(deduped) != len(all_readings):
             self.logger.debug(

--- a/RachioFlume/flume_client.py
+++ b/RachioFlume/flume_client.py
@@ -151,32 +151,37 @@ class FlumeClient:
                 except Exception:
                     pass  # Fall back to default naming
 
+        # Flume API enumerates type=1 (Wi-Fi bridge — relay only, no flow)
+        # and type=2 (water sensor — the actual meter). Bridges always report
+        # value=0 every minute, which used to produce duplicate-zero rows in
+        # water_readings and inflate-CV the engine's sustained-flow predicate
+        # into rejecting genuine multi-fixture events (e.g. a shower at
+        # 2.4 GPM showing as `[2.4, 0.0, 2.4, 0.0, ...]` after interleave).
+        # Skip non-meter device types entirely.
         devices = []
+        skipped = 0
         for device_data in device_list:
-            # Create meaningful device names based on type and location
             device_type = device_data.get("type", 0)
-            product = device_data.get("product", "flume")
-
-            if device_type == 1:
-                # Type 1 is typically the bridge/hub
-                device_name = f"{location_name or 'Flume'} Bridge"
-            elif device_type == 2:
-                # Type 2 is typically the water sensor
-                device_name = f"{location_name or 'Flume'} Water Sensor"
-            else:
-                device_name = f"{location_name or 'Flume'} Device ({product})"
-
+            if device_type != 2:
+                skipped += 1
+                self.logger.debug(
+                    f"Skipping non-meter Flume device id={device_data.get('id')} type={device_type}"
+                )
+                continue
             devices.append(
                 Device(
                     id=device_data["id"],
-                    name=device_name,
+                    name=f"{location_name or 'Flume'} Water Sensor",
                     location=location_name,
                     active=device_data.get("connected", True),
                 )
             )
 
         self._devices = devices
-        self.logger.info(f"Found {len(devices)} Flume devices: {[d.name for d in devices]}")
+        self.logger.info(
+            f"Found {len(devices)} Flume water meters "
+            f"(skipped {skipped} non-meter devices): {[d.name for d in devices]}"
+        )
         return devices
 
     def get_usage(
@@ -246,10 +251,21 @@ class FlumeClient:
                 )
                 continue
 
-        # Sort readings by timestamp
-        all_readings.sort(key=lambda x: x.timestamp)
-        self.logger.info(f"Retrieved {len(all_readings)} total water readings across all devices")
-        return all_readings
+        # Aggregate per-minute across all meters (sum). With one water meter
+        # this is a no-op deduplication; with multiple meters at the same
+        # location it gives the engine a single coherent flow series instead
+        # of N interleaved per-device rows. Sum is the correct combinator
+        # because each meter measures a disjoint physical sub-flow.
+        merged: dict[datetime, float] = {}
+        for r in all_readings:
+            merged[r.timestamp] = merged.get(r.timestamp, 0.0) + r.value
+        deduped = [WaterReading(timestamp=ts, value=v) for ts, v in sorted(merged.items())]
+        if len(deduped) != len(all_readings):
+            self.logger.debug(
+                f"Merged {len(all_readings)} per-device rows → {len(deduped)} per-minute rows"
+            )
+        self.logger.info(f"Retrieved {len(deduped)} per-minute water readings")
+        return deduped
 
     def get_current_usage_rate(self) -> Optional[float]:
         """Get current water usage rate across all devices in gallons per minute."""

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -258,7 +258,7 @@ rachio_flume:
     default_flow_rules:
       - {name: "Pipe Break", min_gpm: 8.0, duration_minutes: 10}
       - {name: "High Flow",  min_gpm: 5.4, duration_minutes: 4}
-      - {name: "Mid Flow",   min_gpm: 2.6, duration_minutes: 14}
+      - {name: "Mid Flow",   min_gpm: 2.0, duration_minutes: 14}
       - {name: "Leak",       min_gpm: 0.1, duration_minutes: 120}
 
     # === Stale-zone monitoring ===


### PR DESCRIPTION
## Summary

The Flume API enumerates the Wi-Fi bridge (device `type=1`) alongside the actual water meter (`type=2`). The bridge reports `value=0` every minute. Pre-this-PR, the collector saved both, so `water_readings` had two rows per timestamp — meter's reading + a 0.0 from the bridge.

Engine consequences: pulling a window for sustained-flow rules produced an interleaved `[2.4, 0.0, 2.4, 0.0, ...]` series. Mean was diluted ~50%, CV gate rejected the window. **Net effect: sustained-flow rules silently failed on real household events** (showers, dishwashers, multi-fixture concurrency) — observed empirically as "zero default_flow_rules fires in 7 days" while the user knows the family showers daily.

## Changes

- `flume_client.get_devices()` filters to `type=2` (water meter) only; bridges are skipped with a `Skipping non-meter Flume device …` debug log.
- `flume_client.get_usage()` aggregates remaining devices per-minute via sum. With one meter this is a deduplicating no-op; with multiple meters it gives the engine a coherent single per-minute series.
- `data_storage._dedup_water_readings()` runs once at init: collapses any duplicate-per-timestamp rows in legacy DBs by keeping `MAX(value)` per timestamp. Idempotent. On the live aibo DB, 8,802 legacy bridge-zero rows get cleaned on first deploy.
- `config/default.yaml`: Mid Flow `min_gpm: 2.6 → 2.0`. Catches sustained multi-fixture household events (dishwasher + sink concurrent, etc.) that 2.6 was missing. Real household showers run at ~2.4 GPM — under 2.6 the rule could never fire even with clean data.

## 7-day prod-DB replay (the headline)

| Metric | Before this PR | After |
| --- | --- | --- |
| Zone Anomaly (P2) | 12 | 8 *(after baseline tuning in local.yaml — separate, not in this PR)* |
| Zone Report (P-1) | 13 | 15 |
| **Mid Flow (P2)** | **0** | **1 fire + 1 clear** ✓ |
| Pipe Break / High Flow / Leak | 0 / 0 / 0 | 0 / 0 / 0 *(no events present)* |
| Cycles suppressed by Rachio | 1,160 | 1,096 |
| Legacy bridge rows deduped on first init | — | 8,802 |

The Mid Flow fire (2026-06-23 11:12 → cleared 11:17) is a 5-min sustained ≥2.0 GPM event, exactly the kind of "real" signal that was previously invisible.

## Test plan

- [x] `make test` — 80 RachioFlume tests pass
- [x] `make lint` — ruff + mypy + vulture + semgrep + codespell + deptry clean
- [x] `uv run python RachioFlume/rfmanager.py alerts replay --hours 168 --db /tmp/aibo_water_tracking.db` — Mid Flow fires once on real data; no false positives
- [ ] Live verification on aibo: deploy this PR, watch for next afternoon-multi-fixture event (dishwasher + sink, etc.) to confirm Mid Flow fires Pushover P2

## Deployment

No config-schema change. To deploy on aibo:

```bash
ssh abutala@aibo 'cd ~/Code && git fetch origin && git pull origin main'
ssh abutala@aibo 'pkill -f ".venv/bin/python3 RachioFlume/rfmanager.py"'
# The one-shot DB dedup runs automatically on next start.
```

On first start after deploy, the log will print `Deduping 8802 legacy duplicate-per-timestamp water_readings rows`. That's a normal one-time migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)