### PR TITLE
fix(NodeCheck): retry deep heartbeat post-reboot to avoid false offline

### DIFF
--- a/NodeCheck/manage_nodes.py
+++ b/NodeCheck/manage_nodes.py
@@ -73,12 +73,16 @@ class NodeChecker:
                 self.log_message(f">> ERROR: Oops! Node did not reboot: {node.name}")
                 self.reboot_failures.append(node.name)
 
-        # Wait for nodes to come back up
-        self.log_message("Sleep until nodes restart...")
-        time.sleep(60)  # Wait for nodes to stabilize
+        # Wait for nodes to come back up and pass the full (deep) heartbeat.
+        # Ping responds before SSH/services on a fresh Windows boot, so a ping-only
+        # recovery check followed by a deep connectivity check produces a false
+        # "offline" seconds after a successful reboot. Retry the deep heartbeat
+        # (ping + service-level probe) with backoff instead.
+        self.log_message("Waiting for nodes to recover...")
+        time.sleep(60)  # initial stabilization before probing
         all_recovered = True
         for node in self.nodes:
-            if node.check_state(desired_up=True, attempts=180):
+            if self._wait_for_heartbeat(node, attempts=12, delay=15):
                 self.log_message(f"   {self.mode}: {node.name} back online.")
             else:
                 self.log_message(f">> ERROR: {self.mode}: {node.name} failed online.")
@@ -86,6 +90,19 @@ class NodeChecker:
                 all_recovered = False
 
         return all_recovered
+
+    def _wait_for_heartbeat(self, node: GenericNode, attempts: int, delay: int) -> bool:
+        """Retry the deep heartbeat until it passes or attempts are exhausted."""
+        for attempt in range(attempts):
+            if node.heartbeat():
+                return True
+            if attempt < attempts - 1:
+                logger.debug(
+                    f"{node.name} heartbeat attempt {attempt + 1}/{attempts} failed; "
+                    f"retrying in {delay}s"
+                )
+                time.sleep(delay)
+        return False
 
     def generate_report(
         self, is_healthy: bool, always_email: bool = False, was_rebooted: bool = False
@@ -160,14 +177,13 @@ if __name__ == "__main__":
     connectivity_ok = checker.check_connectivity()
     system_healthy = connectivity_ok
 
-    # Reboot if requested
+    # Reboot if requested. reboot_nodes verifies deep recovery (ping + service
+    # probe) with retries, so no separate post-reboot connectivity check is
+    # needed — that earlier check ran the deep probe too soon after boot and
+    # produced false "offline" alerts for a successful reboot.
     if args.reboot:
         reboot_ok = checker.reboot_nodes()
         system_healthy = system_healthy and reboot_ok
-
-        # Re-check health after reboot
-        final_health = checker.check_connectivity()
-        system_healthy = system_healthy and final_health
 
     # Generate final report
     checker.generate_report(

--- a/NodeCheck/test_nodes.py
+++ b/NodeCheck/test_nodes.py
@@ -7,6 +7,7 @@ from typing import Any
 import json
 import socket
 from unittest.mock import MagicMock
+from NodeCheck.manage_nodes import NodeChecker
 from NodeCheck.nodes import FoscamNode, GenericNode, SomfyMyLinkNode, WindowsNode
 from lib.config import NodeConfig, NodeType
 
@@ -378,6 +379,41 @@ class TestSomfyMyLinkNode:
 
         assert node.heartbeat() is True
         mock_conn.assert_called_once_with(("192.0.2.43", 55555), timeout=4)
+
+
+class TestWaitForHeartbeat:
+    """Test NodeChecker._wait_for_heartbeat — the post-reboot deep recovery probe.
+
+    Bypasses NodeChecker.__init__ (which loads full config) since the method only
+    needs `self`. delay=0 keeps tests instant without patching time.sleep.
+    """
+
+    def _checker(self) -> NodeChecker:
+        return NodeChecker.__new__(NodeChecker)
+
+    def test_passes_on_first_attempt(self) -> None:
+        """Healthy node -> no retries."""
+        node = MagicMock()
+        node.heartbeat.return_value = True
+
+        assert self._checker()._wait_for_heartbeat(node, attempts=3, delay=0) is True
+        node.heartbeat.assert_called_once()
+
+    def test_passes_after_retries(self) -> None:
+        """Node needs a few attempts before deep heartbeat succeeds (services coming up)."""
+        node = MagicMock()
+        node.heartbeat.side_effect = [False, False, True]
+
+        assert self._checker()._wait_for_heartbeat(node, attempts=5, delay=0) is True
+        assert node.heartbeat.call_count == 3
+
+    def test_exhausts_attempts(self) -> None:
+        """Node never recovers -> False after exactly `attempts` probes."""
+        node = MagicMock()
+        node.heartbeat.return_value = False
+
+        assert self._checker()._wait_for_heartbeat(node, attempts=4, delay=0) is False
+        assert node.heartbeat.call_count == 4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
The weekly Sunday 5am Windows reboot job (`manage_nodes.py --reboot --type windows`) confirmed recovery via ping-only `check_state`, then ran a final `check_connectivity()` calling `WindowsNode.heartbeat()` (ping + SSH `net statistics workstation`). ICMP responds before SSH/services come up on a fresh Windows boot, so the deep probe ran ~13s after first ping and returned False — a spurious "Beta offline" emergency Pushover + email for a reboot that had actually succeeded.

Observed on aibo 2026-06-28: Beta rebooted cleanly at 05:01:55 (uptime confirmed by the continuous `heartbeat_nodes` monitor at 05:56:42), but `manage_nodes` logged `>> ERROR windows: Beta offline` at 05:01:23 and fired a failure alert.

## Impact
Windows reboot job no longer emits false "offline" alerts immediately after a successful reboot. Recovery is now verified with the deep heartbeat (the same probe the continuous monitor uses), with backoff to let SSH/services stabilize post-boot.

## Changes
- Replace ping-only recovery loop in `reboot_nodes` with `_wait_for_heartbeat`: retries the full deep heartbeat (12 attempts × 15s after a 60s initial stabilization).
- Drop the redundant post-reboot `check_connectivity()` in `main` — `reboot_nodes` now verifies deep health itself, so the earlier too-soon deep probe is gone.
- Add `TestWaitForHeartbeat` covering first-try success, retry-then-success, and attempt-exhaustion.

## References
- aibo logs: `~/logs/manage_nodes.py.log` (2026-06-28 05:00:02–05:01:23), `~/logs/heartbeat_nodes.py.log` (2026-06-28 05:56:42)
- aibo crontab: `0 5 * * 0` → `manage_nodes.py --reboot --type windows --always_email`
- Windows host: "Beta" (192.168.1.100)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)