### PR TITLE
feat(notify): lower informational Pushovers to P-1, right-size stray P2s

### DIFF
--- a/August/august_client.py
+++ b/August/august_client.py
@@ -318,7 +318,7 @@ class AugustMonitor:
                 self.pushover.send_message(
                     message,
                     title="August Lock Secured",
-                    priority=0,
+                    priority=-1,
                 )
 
                 del self.unlock_start_times[lock_id]
@@ -339,7 +339,7 @@ class AugustMonitor:
                 ajar_duration = current_time - self.ajar_start_times[lock_id]
                 message = f"Door {status.lock_name} closed after {ajar_duration / 60:.1f} minutes"
                 self.logger.info(message)
-                self.pushover.send_message(message, title="August Door Closed", priority=0)
+                self.pushover.send_message(message, title="August Door Closed", priority=-1)
 
                 del self.ajar_start_times[lock_id]
         else:

--- a/August/august_manager.py
+++ b/August/august_manager.py
@@ -23,12 +23,12 @@ async def _test() -> None:
         statuses = await client.get_all_lock_statuses()
         for _, status in statuses.items():
             message += f"{status.lock_name}: {status.battery_level}%\n"
-        pushover.send_message(message, title="August Battery Status", priority=0)
+        pushover.send_message(message, title="August Battery Status", priority=-1)
     except Exception as e:
         pushover.send_message(
             f"Error initializing August client: {e}",
             title="August Battery Status",
-            priority=2,
+            priority=1,
         )
     finally:
         await client.close()
@@ -134,7 +134,7 @@ def main() -> None:
     except Exception as e:
         logger.error(f"Unexpected error: {e}")
         if args.command == "test":
-            pushover.send_message(f"August test failed: {e}", title="August Error", priority=2)
+            pushover.send_message(f"August test failed: {e}", title="August Error", priority=1)
         sys.exit(1)
 
 

--- a/LaunchJobs/notify.py
+++ b/LaunchJobs/notify.py
@@ -56,7 +56,7 @@ def notify(
     client = sender if sender is not None else _default_sender(job)
     title = f"[LaunchJobs] {job.name}: {status}"
     message = body or f"Completed at {datetime.now():%Y-%m-%d %H:%M:%S}"
-    return client.send_message(message, title=title, priority=0)
+    return client.send_message(message, title=title, priority=-1)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/NetworkCheck/external_ip_reporter.py
+++ b/NetworkCheck/external_ip_reporter.py
@@ -71,7 +71,7 @@ def main() -> None:
         alert=is_error,
     )
 
-    pushover.send_message(ip_address, title=title)
+    pushover.send_message(ip_address, title=title, priority=-1)
 
 
 if __name__ == "__main__":

--- a/NetworkCheck/test_uplink.py
+++ b/NetworkCheck/test_uplink.py
@@ -185,7 +185,7 @@ def main() -> None:
         alert=alert,
     )
 
-    pushover.send_message(final_message, title="SpeedTest")
+    pushover.send_message(final_message, title="SpeedTest", priority=-1)
 
     logger.info("Speed test completed")
 

--- a/NodeCheck/heartbeat_nodes.py
+++ b/NodeCheck/heartbeat_nodes.py
@@ -111,7 +111,7 @@ class HeartbeatMonitor:
             if count == 1
             else f"{count} nodes recovered: {node_list}"
         )
-        self.pushover.send_message(message, title=title, priority=0)
+        self.pushover.send_message(message, title=title, priority=-1)
         logger.info(f"Sent recovery notification: {message}")
 
     def run_continuous_monitoring(self, poll_time: int, cooloff_time: int) -> None:

--- a/NodeCheck/manage_nodes.py
+++ b/NodeCheck/manage_nodes.py
@@ -122,17 +122,20 @@ class NodeChecker:
                 pushover.send_message(
                     f"{self.mode.title()} node reboot completed successfully",
                     title=f"{self.mode.title()} Reboot Complete",
+                    priority=-1,
                 )
 
         if self.reboot_failures:
             pushover.send_message(
                 f"{self.mode.title()} nodes failed to reboot: {', '.join(self.reboot_failures)}",
                 title="Node Reboot Failed",
+                priority=1,
             )
         if self.recovery_failures:
             pushover.send_message(
                 f"{self.mode.title()} nodes failed to recover: {', '.join(self.recovery_failures)}",
                 title="Node Recovery Failed",
+                priority=1,
             )
 
         Mailer.sendmail(

--- a/NodeCheck/purge_old_foscam_files.py
+++ b/NodeCheck/purge_old_foscam_files.py
@@ -103,7 +103,7 @@ def purge_old_foscam_files() -> tuple[bool, str]:
 
     finally:
         # Restore original working directory
-        pushover.send_message(pushover_msg, title="Foscam Cleanup")
+        pushover.send_message(pushover_msg, title="Foscam Cleanup", priority=-1)
         os.chdir(original_cwd)
 
     return success, "\n".join(messages)

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -420,7 +420,7 @@ class AlertEngine:
 
     def _send_clear(self, rule: AlertRule) -> None:
         msg = f"{rule.name}: condition cleared."
-        self.pushover.send_message(msg, title=f"RachioFlume: {rule.name} cleared", priority=0)
+        self.pushover.send_message(msg, title=f"RachioFlume: {rule.name} cleared", priority=-1)
         self.logger.info(f"Clear notification: {rule.name}")
 
     # ------------------------------------------------------------------ #

--- a/RachioFlume/rfmanager.py
+++ b/RachioFlume/rfmanager.py
@@ -393,7 +393,7 @@ def generate_report(args: argparse.Namespace) -> int:
         pushover.send_message(
             f"Error generating report: {e}",
             title="RachioFlume Report Error",
-            priority=2,
+            priority=1,
         )
         return 1
 
@@ -415,7 +415,7 @@ def generate_summary_report(_args: argparse.Namespace) -> int:
         pushover.send_message(
             f"Error generating summary report: {e}",
             title="RachioFlume Report Error",
-            priority=2,
+            priority=1,
         )
         return 1
 
@@ -437,7 +437,7 @@ def generate_raw_report(args: argparse.Namespace) -> int:
         pushover.send_message(
             f"Error generating raw report: {e}",
             title="RachioFlume Report Error",
-            priority=2,
+            priority=1,
         )
         return 1
 

--- a/RachioFlume/test_alert_engine.py
+++ b/RachioFlume/test_alert_engine.py
@@ -209,7 +209,7 @@ async def test_evaluate_suppressed_by_active_rachio_zone(
     assert engine._load_state(rule).last_state is None
 
 
-async def test_evaluate_clear_emits_priority_0(engine: AlertEngine, rule: AlertRule) -> None:
+async def test_evaluate_clear_emits_priority_neg1(engine: AlertEngine, rule: AlertRule) -> None:
     # Seed state as if rule was active last cycle
     engine._save_state(
         rule,
@@ -222,7 +222,7 @@ async def test_evaluate_clear_emits_priority_0(engine: AlertEngine, rule: AlertR
     assert results[0]["action"] == AlertAction.FIRE_CLEAR.value
     engine.pushover.send_message.assert_called_once()  # type: ignore[attr-defined]
     _, kwargs = engine.pushover.send_message.call_args  # type: ignore[attr-defined]
-    assert kwargs["priority"] == 0
+    assert kwargs["priority"] == -1
     assert engine._load_state(rule).last_state == "clear"
 
 

--- a/SamsungFrame/batch_upload.py
+++ b/SamsungFrame/batch_upload.py
@@ -732,7 +732,7 @@ def send_batch_notification(summary: BatchUploadSummary, interrupted: bool = Fal
         priority = 1  # High priority
         title = "Samsung Batch Upload - Partial Success"
     else:
-        priority = 0
+        priority = -1
         title = "Samsung Batch Upload - Complete"
 
     message = (

--- a/Tesla/manage_power.py
+++ b/Tesla/manage_power.py
@@ -199,7 +199,7 @@ class PowerwallManager:
             self.logger.warning(message)
 
             if self.send_notifications or decision_point.always_notify:
-                self.pushover.send_message(message, title="Powerwall Alert", priority=0)
+                self.pushover.send_message(message, title="Powerwall Status", priority=-1)
 
         return changes_made
 
@@ -258,8 +258,8 @@ class PowerwallManager:
         self.logger.info(f"Connected to site: {site_name}")
         self.pushover.send_message(
             f"Powerwall monitoring started for: {site_name}",
-            title="Powerwall Alert",
-            priority=0,
+            title="Powerwall Status",
+            priority=-1,
         )
 
         sleep_time = 0


### PR DESCRIPTION
## Summary

Audit and rebalance all Pushover notification priorities so background status pings stop vibrating the phone while genuine emergencies stay loud.

- Lowered informational (P0 → P-1) across 11 call sites in August / NodeCheck / NetworkCheck / RachioFlume / SamsungFrame / LaunchJobs / Tesla
- Raised NodeCheck reboot/recovery **failures** default-P0 → P1 (were quietly ignorable)
- Lowered stray P2 → P1 on 5 sites where the alert was loud-but-not-emergency (August init/test, RachioFlume report/summary/raw CLI exceptions)
- Renamed Tesla P-1 status pushes "Powerwall Alert" → "Powerwall Status" (P2 emergency pushes keep the "Alert" title)

## Full priority table (post-change)

### P2 — Emergency
| File:Line | Trigger |
|---|---|
| August/august_client.py:421 | Lock failure |
| NodeCheck/heartbeat_nodes.py:96 | Nodes down |
| NodeCheck/manage_nodes.py:114 | Scheduled node check failed |
| RachioFlume/alert_engine.py:273 (dynamic) | Zone anomaly (fire predicate) |
| RachioFlume/alert_engine.py:418 | Rule fire (leak) |
| RachioFlume/hose_timer_processor.py:295 (dynamic) | Hose zone anomaly |
| RachioFlume/rfmanager.py:257 | Collection loop crash |
| Tesla/manage_power.py:344, :357 | Powerwall critical |

### P1 — High
| File:Line | Trigger |
|---|---|
| August/august_manager.py:28 | Init failure *(lowered from P2)* |
| August/august_manager.py:137 | `test` CLI failure *(lowered from P2)* |
| August/august_client.py:397 | Ajar warning batch |
| August/august_client.py:458 | Lock recovery |
| NodeCheck/manage_nodes.py:132 | Reboot failed *(raised from P0)* |
| NodeCheck/manage_nodes.py:138 | Recovery failed *(raised from P0)* |
| RachioFlume/rfmanager.py:396, :418, :440 | Report/summary/raw CLI exceptions *(lowered from P2)* |
| SamsungFrame/batch_upload.py:729, :732 (dynamic) | Batch interrupted / partial |

### P-1 — Quiet / informational
| File:Line | Trigger |
|---|---|
| August/august_manager.py:26 | Battery Status |
| August/august_client.py:321 | Lock Secured |
| August/august_client.py:342 | Door Closed |
| NodeCheck/heartbeat_nodes.py:114 | All nodes recovered |
| NodeCheck/manage_nodes.py:125 | Reboot Complete |
| NodeCheck/purge_old_foscam_files.py:106 | Foscam Cleanup |
| NetworkCheck/external_ip_reporter.py:74 | External IP change |
| NetworkCheck/test_uplink.py:188 | SpeedTest result |
| RachioFlume/alert_engine.py:273 (dynamic) | Zone Report (non-fire) |
| RachioFlume/hose_timer_processor.py:295 (dynamic) | Hose Zone Report |
| RachioFlume/alert_engine.py:423 | Rule cleared |
| RachioFlume/stale_zone_checker.py:177 | Stale zone |
| SamsungFrame/batch_upload.py:735 (dynamic) | Batch Complete |
| LaunchJobs/notify.py:59 | Generic launchjob status |
| Tesla/manage_power.py:202, :262 | Powerwall Status |

## Test plan
- [x] `uv run python -m pytest August/ RachioFlume/ Tesla/ SamsungFrame/` → 198 passed
- [x] `uv run pytest NodeCheck` → 29 passed
- [x] Pre-commit hooks (format, tests, secret scan) pass
- [ ] Observe real-world: next collector-cycle "cleared" ping arrives quiet; next zone anomaly still buzzes

## References
- Plan: `~/.claude/plans/lower-all-informational-pushovers-enumerated-charm.md`
- `lib/MyPushover.py` — API contract (P0 default; P2 sets retry=1800 expire=3600)