### PR TITLE
fix(notify): P2 on Tesla silent exits + P1 on August auth failure

### DIFF
--- a/August/august_client.py
+++ b/August/august_client.py
@@ -40,6 +40,8 @@ class AugustClient:
         self.authenticator: Optional[AuthenticatorAsync] = None
         self.access_token: Optional[str] = None
         self.locks: Dict[str, Lock] = {}
+        cfg = get_config()
+        self.pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["August"])
 
     async def unlock_lock(self, lock_id: str) -> bool:
         """Unlock a specific lock."""
@@ -106,6 +108,11 @@ class AugustClient:
 
             if auth_result is None:
                 self.logger.error("Authentication returned None - check credentials")
+                self.pushover.send_message(
+                    "August auth returned None — check credentials",
+                    title="August Auth Failure",
+                    priority=1,
+                )
                 return False
 
             self.logger.debug(f"Authentication result state: {auth_result.state}")
@@ -117,15 +124,30 @@ class AugustClient:
             elif auth_result.state == AuthenticationState.REQUIRES_VALIDATION:
                 self.logger.error("August authentication requires 2FA validation")
                 self.logger.error("Please complete 2FA in the August app and try again")
+                self.pushover.send_message(
+                    "August requires 2FA — run: uv run python August/validate_2fa.py",
+                    title="August Auth Failure",
+                    priority=1,
+                )
                 return False
             else:
                 self.logger.error(f"August authentication failed: {auth_result.state}")
+                self.pushover.send_message(
+                    f"August auth failed: {auth_result.state}",
+                    title="August Auth Failure",
+                    priority=1,
+                )
                 return False
 
         except Exception as e:
             self.logger.error(f"Error during August authentication: {e}")
             self.logger.error(
                 "Make sure august.email and august.password are correct in config/local.yaml"
+            )
+            self.pushover.send_message(
+                f"August auth error: {e}",
+                title="August Auth Failure",
+                priority=1,
             )
             return False
 

--- a/Tesla/manage_power.py
+++ b/Tesla/manage_power.py
@@ -374,7 +374,8 @@ def main() -> None:
     except BaseException as e:
         # SystemExit / KeyboardInterrupt / asyncio.CancelledError / signals
         # bypass `except Exception`. Log full traceback + notify so silent
-        # exits stop being silent.
+        # exits stop being silent, then reraise so termination semantics
+        # (exit code, signal propagation) are preserved.
         import traceback
 
         tb_str = traceback.format_exc()
@@ -388,6 +389,7 @@ def main() -> None:
                 title="Powerwall Alert",
                 priority=2,
             )
+        raise
 
     finally:
         logger = get_logger(__name__)

--- a/Tesla/manage_power.py
+++ b/Tesla/manage_power.py
@@ -357,6 +357,18 @@ def main() -> None:
                 priority=2,
             )
 
+    except BaseException as e:
+        # SystemExit / KeyboardInterrupt / signals bypass `except Exception`.
+        # Notify explicitly so silent exits still page.
+        logger = get_logger(__name__)
+        logger.error(f"Powerwall monitoring exited via {type(e).__name__}: {e}")
+        if "manager" in locals():
+            manager.pushover.send_message(
+                f"Powerwall monitoring exited: {type(e).__name__}: {e}",
+                title="Powerwall Alert",
+                priority=2,
+            )
+
     finally:
         logger = get_logger(__name__)
         logger.error("Exiting after 1-hour delay to prevent respawn churn")

--- a/Tesla/manage_power.py
+++ b/Tesla/manage_power.py
@@ -277,7 +277,12 @@ class PowerwallManager:
             self.logger.info(f"Loop {self.loop_count}")
 
             try:
+                self.logger.debug("→ get_powerwall_data() start")
+                fetch_start = time.time()
                 data = self.get_powerwall_data(product)
+                self.logger.debug(
+                    f"← get_powerwall_data() done in {time.time() - fetch_start:.2f}s"
+                )
 
                 # Sanitize battery percentage
                 data["battery_percent"] = self.sanitize_battery_percentage(
@@ -297,13 +302,22 @@ class PowerwallManager:
 
             except Exception as e:
                 self.fail_count += 1
-                self.logger.warning(f"Attempt {self.fail_count} failed: {e}")
+                self.logger.warning(f"Attempt {self.fail_count} failed: {type(e).__name__}: {e}")
 
                 if self.fail_count > 10:
                     raise RuntimeError(f"Too many consecutive failures: {e}")
 
                 sleep_time = min(poll_time, 30)  # Quick retry
                 continue
+            except BaseException as e:
+                # Catch here too so we log context (loop_count, fail_count) before
+                # the outer handler in main() fires. Reraise so main() still pushes
+                # the P2 notification and finally-sleeps.
+                self.logger.error(
+                    f"BaseException in loop {self.loop_count} "
+                    f"(fail_count={self.fail_count}): {type(e).__name__}: {e}"
+                )
+                raise
 
 
 def main() -> None:
@@ -358,10 +372,16 @@ def main() -> None:
             )
 
     except BaseException as e:
-        # SystemExit / KeyboardInterrupt / signals bypass `except Exception`.
-        # Notify explicitly so silent exits still page.
+        # SystemExit / KeyboardInterrupt / asyncio.CancelledError / signals
+        # bypass `except Exception`. Log full traceback + notify so silent
+        # exits stop being silent.
+        import traceback
+
+        tb_str = traceback.format_exc()
         logger = get_logger(__name__)
-        logger.error(f"Powerwall monitoring exited via {type(e).__name__}: {e}")
+        logger.error(
+            f"Powerwall monitoring exited via {type(e).__name__}: {e}\nTraceback:\n{tb_str}"
+        )
         if "manager" in locals():
             manager.pushover.send_message(
                 f"Powerwall monitoring exited: {type(e).__name__}: {e}",


### PR DESCRIPTION
## Summary

Two notification gaps + debug instrumentation found while chasing silent Powerwall crashes on aibo.

### Tesla — silent exits (main investigation)

Log inspection on aibo showed 4 consecutive Powerwall crashes (Jul 1 13:09, 15:35, 22:07; Jul 3 01:00) with **no traceback, no error log, no Pushover** — just:

\`\`\`
INFO:manage_power.277:2026-07-03 01:00:43,966: Loop 514
ERROR:manage_power.362:2026-07-03 01:00:50,048: Exiting after 1-hour delay to prevent respawn churn
\`\`\`

Compare with the Jun 28 crash which DID log traceback + fire the P2 push. aibo has been up 5d 12h — not an OS reboot. The crash source is inside the Python process and must be \`BaseException\`-derived — those bypass \`except Exception\` at manage_power.py:347, jump straight to \`finally\`, and skip both the traceback log and the P2 push.

**Best hypothesis (unproven yet):** \`asyncio.CancelledError\` escapes tesla_client's per-call \`asyncio.run()\`. CancelledError is \`BaseException\`-derived in Py3.8+, so it bypasses both existing except-Exception layers. The next crash caught by the new handler will confirm.

Fixes:
- \`except BaseException\` in \`main()\` — logs full traceback + fires P2 push before the 1-hour sleep
- \`except BaseException\` inside \`run_monitoring_loop()\` — logs loop_count/fail_count/type before reraising, so if traceback capture in the outer handler fails, we still have context
- Timing bracket around \`get_powerwall_data()\` — narrows whether the crash is inside HTTP fetch vs. decision processing
- Regular \`except Exception\` in the loop now logs \`type(e).__name__: e\` (was just \`e\`) — easier triage

### August — auth failure silence

\`AugustClient.authenticate()\` had 4 failure paths (None result, REQUIRES_VALIDATION, other non-AUTHENTICATED states, outer except-Exception) that only logged locally and returned False. In monitor mode this becomes silent degradation.

Fix: added \`self.pushover\` to \`AugustClient\` and a P1 push on each failure branch with actionable content (e.g. \"run: uv run python August/validate_2fa.py\" for the 2FA case).

## Test plan
- [x] \`uv run python -m pytest August/ Tesla/\` → 29 passed
- [x] Pre-commit hooks (format, tests, secret scan) pass
- [ ] Deploy to aibo — next silent exit should produce P2 \"Powerwall Alert\" with type+message, revealing root cause
- [ ] Simulate August auth failure (bad password in \`config/local.yaml\`) — should receive P1 \"August Auth Failure\"

## References
- Predecessor PR #205 — pushover priority audit (this PR builds on that classification)