### PR TITLE
refactor(RachioFlume): shared zone-outcome helper, compact_zone_label; fix raw SQL, README, format polish

### DIFF
--- a/RachioFlume/README.md
+++ b/RachioFlume/README.md
@@ -15,11 +15,8 @@ A Python integration that connects Rachio irrigation controllers with Flume wate
   - **Cross-source suppression**: Controller-active OR hose-timer-active state suppresses Flume rules for `max_rule_duration + 10min` slack. Symmetric.
   - **Stale-zone monitor** (`stale_zone_checker.py`): P-1 heads-up if any enabled zone hasn't run within `stale_zone_days` (default 7). Daily dedup; hourly evaluation gate.
   - Mute support; P0 "all clear" on active→clear transition for sustained-flow rules.
-- **Synthetic Simulator** (`simulate_alerts.py`): Replay a YAML-defined scenario through the alert engine without hitting real APIs or Pushover — see [TESTABILITY.md](TESTABILITY.md)
-- **Period Reports**: Generate detailed reports with:
-  - Average watering rate by zone
-  - Total duration each zone was watered
-  - Water efficiency analysis
+- **Synthetic Simulator** (`simulate_alerts.py`): Replay scenarios through the alert engine without hitting real APIs or Pushover; wired into `test_alert_simulation.py`. See [TESTABILITY.md](TESTABILITY.md).
+- **HTML Email Report**: Daily fixed-width table (via `<pre>` monospace) covering all zones — controllers and hose valves in one unified table. Per-zone anomaly threshold + alert-session count are surfaced alongside runtime / gallons / GPM.
 - **Continuous Monitoring**: Automated data collection service
 - **SQLite Storage**: Persistent data storage with session tracking
 
@@ -89,7 +86,7 @@ uv run python rfmanager.py collect --interval 120    # Every 2 minutes
 uv run python rfmanager.py collect --interval 600    # Every 10 minutes (default: 300)
 ```
 
-**💡 Pro Tip**: Let the collector run for at least a week to get meaningful reports and efficiency analysis!
+**💡 Pro Tip**: Let the collector run for at least a week before tuning zone thresholds — needs a distribution of runs per zone to be meaningful.
 
 ### 📊 System Status (Check Anytime)
 
@@ -122,13 +119,10 @@ uv run python rfmanager.py report
 # Custom period report with specific end date and lookback days
 uv run python rfmanager.py report --end-date 2023-07-15 --lookback 14
 
-# Send report via email
+# Send report via HTML email
 uv run python rfmanager.py report --email
 
-# Zone efficiency analysis (requires multiple watering sessions)
-uv run python rfmanager.py summary
-
-# Raw data report with 5-minute intervals
+# Raw data report with 5-minute intervals (Flume-only, no Rachio context)
 uv run python rfmanager.py raw --hours 48
 ```
 
@@ -344,9 +338,10 @@ beyond the threshold) the very first `Stale-zone alert sent: ...` message
    - Correlates watering events with usage data
 
 5. **WeeklyReporter** (`reporter.py`)
-   - Generates period-based reports with customizable date ranges
-   - Calculates zone efficiency metrics
-   - Supports email delivery and console output
+   - Generates period reports with customizable date ranges (default 7 days)
+   - Unified `ZoneStats` table covers controller zones and hose valves; hose entries sort after controllers via `HOSE_ZONE_SENTINEL=999`
+   - Per-zone anomaly `threshold_gpm` and `alert_sessions` count surfaced alongside the aggregate stats
+   - Supports HTML email delivery (via `<html><body><pre>` — auto-detected by `lib.Mailer`) and console output
 
 6. **AlertEngine** (`alert_engine.py`) + **AlertRule** (`alert_rules.py`)
    - Runs at the end of each collector cycle
@@ -358,10 +353,10 @@ beyond the threshold) the very first `Stale-zone alert sent: ...` message
    - Per-rule and per-zone reported-today state persisted as JSON in `collection_metadata`
 
 7. **SyntheticDataset** (`synthetic_data.py`) + **Simulator** (`simulate_alerts.py`)
-   - YAML-defined scenarios with household, irrigation, leak, and pipe-break events
+   - In-code scenarios (household, irrigation, leak, pipe-break) built via `SyntheticDataset.add_*` helpers
    - Plays back through `AlertEngine` with fake clients and a capturing Pushover
-   - Used by `test_alert_simulation.py` for regression assertions and by the
-     `simulate` CLI for ad-hoc tuning
+   - Used by `test_alert_simulation.py` for regression assertions
+   - Ad-hoc replay of historical DB uses `rfmanager.py alerts replay` (see § DB Replay)
 
 ### Database Schema
 
@@ -380,26 +375,33 @@ The collector is designed to respect these limits with configurable polling inte
 ## Example Output
 
 ### Period Report
+
+Controllers and hose valves land in the same fixed-width table. `Thr` is the
+per-zone anomaly threshold (blank when unconfigured); `Alrt` is the count of
+sessions in the period whose per-session avg flow exceeded that threshold.
+Emailed variant wraps this body in `<html><body><pre>` so iOS Mail / Gmail
+render the whole table in monospace with no viewport wrap.
+
 ```
-======================================================================
 WATER USAGE REPORT
-Period: 2023-07-10 to 2023-07-17
-======================================================================
+Period: 2026-06-26 to 2026-07-03
+========================================
 
 SUMMARY:
-  Total watering sessions: 12
-  Total duration: 8.5 hours
-  Total water used: 425.3 gallons
-  Zones watered: 4
+  Total watering sessions: 36
+  Total duration: 465.0 min
+  Total water used: 1828 gallons
+  Zones watered: 13
 
 ZONE DETAILS:
-Zone Name                Sessions Duration(h) Water(gal) Rate(gpm)
---------------------------------------------------------------------
-1    Front Lawn          4        2.5         127.5      0.85
-2    Back Yard           3        2.0         98.2       0.82
-3    Side Garden         3        1.8         89.1       0.83
-4    Vegetable Garden    2        2.2         110.5      0.84
-======================================================================
+Name     Min    Gals  GPM   Thr   Alrt
+--------------------------------------
+Z1 FS    40.0   261   6.5   6.6   -
+Z2 FS    39.7   211   5.3   6.0   -
+...
+Z12 FDB  59.5   82    1.4   1.5   -
+Z13 FS   35.0   0     0.0   1.0   -
+========================================
 ```
 
 ### Status Check
@@ -434,8 +436,8 @@ uv run python -m pytest RachioFlume/test_zone_thresholds.py -v
 # Or standalone:
 python RachioFlume/test_zone_thresholds.py
 
-# Visual playback of a scenario (events to screen, no Pushover)
-uv run python -m RachioFlume.rfmanager simulate
+# Replay historical DB through the alert engine (no Pushover)
+uv run python RachioFlume/rfmanager.py alerts replay --hours 168
 ```
 
 ### Zone Threshold Integration Test
@@ -453,22 +455,19 @@ The `test_zone_thresholds.py` integration test validates the zone anomaly detect
 threshold = avg_gpm + max(absolute_gpm, percent_above/100 × avg_gpm)
 ```
 
-| Zone | Avg GPM | Threshold |
-|------|---------|-----------|
-| Z1   | 5.00    | 5.50      |
-| Z2   | 6.50    | 7.15      |
-| Z3   | 2.00    | 2.50      |
-| Z4   | 3.00    | 3.50      |
-| Z5   | 3.50    | 4.00      |
-| Z6   | 4.50    | 5.00      |
-| Z7   | 2.50    | 3.00      |
-| Z8   | 3.00    | 3.50      |
-| Z9   | 1.50    | 2.00      |
-| Z10  | 7.00    | 7.70      |
-| Z11  | 6.00    | 6.60      |
-| Z12  | 0.75    | 1.25      |
+Actual baselines live in `config/local.yaml` under
+`rachio_flume.alerts.zone_anomaly.zone_thresholds` — see the file for
+current per-zone `avg_gpm` values and their tuning notes. **Unknown zones**
+(not in config) default to `avg_gpm=0`, yielding a 0.5 GPM threshold — any
+flow triggers an alert.
 
-**Unknown zones** (not in config) default to `avg_gpm=0`, yielding a 0.5 GPM threshold — any flow triggers an alert.
+**Config key convention**: Controllers key by stringified `zone_number`
+(`"1"`, `"2"`, …) because that's what the Rachio API surfaces per run.
+Hose valves key by their raw API name (e.g. `"Z13 FS - Upper Deck Planters"`)
+for the same reason — the hose API has no zone number. Display strings for
+both come from `compact_zone_label()` (splits on `" - "` and takes the head),
+so `"Z13 FS - Upper Deck Planters"` shows as `"Z13 FS"` in the email and
+Pushover header. No separate `name:` field in config.
 
 **Requirements**: SSH access to prod controller (configured in `config/local.yaml`) must work without password prompt (key-based auth).
 

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
-from RachioFlume.alert_rules import AlertRule, ZoneThreshold
+from RachioFlume.alert_rules import AlertRule, ZoneThreshold, send_zone_outcome_pushover
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import FlumeClient, WaterReading
 from RachioFlume.rachio_client import RachioClient
@@ -228,52 +228,24 @@ class AlertEngine:
         total_gal: float,
         cycle: int,
     ) -> None:
-        """Emit at most one Pushover per zone end.
-
-        Short runs (≤ min_runtime_minutes, default 5) are silenced entirely —
-        they're test cycles, brief manual triggers, or noise, and emitting a
-        Pushover for each one floods the feed. Above the threshold, picks
-        (title, priority) based on whether the anomaly threshold is exceeded;
-        otherwise sends the routine Zone Report. The displayed `(thresh X.XX)`
-        is always the anomaly trigger value, and Total is included on both
-        paths.
+        """Controller zone-end notification. Delegates to the shared helper
+        in alert_rules so the format stays in lockstep with the hose path.
         """
-        if runtime_min <= self.min_runtime_minutes:
-            self.logger.info(
-                f"Skipping zone outcome for '{zone_name}' (cycle {cycle}): "
-                f"runtime {runtime_min:.0f}min ≤ min_runtime_minutes "
-                f"{self.min_runtime_minutes}min"
-            )
-            return
-
         threshold, baseline = self._get_zone_threshold(zone_number)
-        is_anomaly = baseline > 0 and avg_gpm > threshold
-
         cycle_label = f" (Cycle {cycle})" if cycle > 1 else ""
         header = f"'{zone_name}'{cycle_label}"
-        flow_line = (
-            f"Avg flow: {avg_gpm:.2f} GPM (thresh {threshold:.2f})"
-            if baseline > 0
-            else f"Avg flow: {avg_gpm:.2f} GPM"
-        )
-        lines = [
-            header,
-            f"Runtime: {runtime_min:.0f} min",
-            flow_line,
-            f"Total: {total_gal:.1f} gal",
-        ]
-        if is_anomaly:
-            deviation = avg_gpm - baseline
-            deviation_pct = (deviation / baseline * 100) if baseline > 0 else 0
-            lines.append(f"Deviation: +{deviation:.2f} GPM ({deviation_pct:.0f}%)")
-            title, priority = "RachioFlume: Zone Anomaly", 2
-        else:
-            title, priority = "RachioFlume: Zone Report", -1
 
-        self.pushover.send_message("\n".join(lines), title=title, priority=priority)
-        self.logger.info(
-            f"Zone outcome sent for '{zone_name}'{cycle_label}: "
-            f"{runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal, anomaly={is_anomaly}"
+        send_zone_outcome_pushover(
+            pushover=self.pushover,
+            logger=self.logger,
+            log_label=header,
+            header=header,
+            runtime_min=runtime_min,
+            avg_gpm=avg_gpm,
+            total_gal=total_gal,
+            baseline=baseline,
+            threshold=threshold,
+            min_runtime_minutes=self.min_runtime_minutes,
         )
 
     def _check_zone_end_report(

--- a/RachioFlume/alert_rules.py
+++ b/RachioFlume/alert_rules.py
@@ -1,8 +1,22 @@
-"""Alert rule model and config loader for RachioFlume usage alerts."""
+"""Alert rule model, config loader, and shared Pushover formatting for
+RachioFlume usage alerts.
+
+This module also owns two helpers used by both the controller-zone path
+(alert_engine) and the hose-timer path (hose_timer_processor):
+- `compact_zone_label` — drops the descriptive tail from a raw valve/zone
+  name so displays and Pushover headers stay short and consistent.
+- `send_zone_outcome_pushover` — the shared zone-end notification format,
+  so anomaly title/priority/message layout stays locked in one place.
+"""
+
+from __future__ import annotations
+
+import logging
 
 from pydantic import BaseModel, Field
 
 from lib.config import get_config
+from lib.MyPushover import Pushover
 
 
 class AlertRule(BaseModel):
@@ -28,13 +42,15 @@ class ZoneThreshold(BaseModel):
     """Per-zone flow baseline for anomaly detection.
 
     `zone_key` is the device-local identifier — stringified zone_number for
-    controllers (e.g. "1") or the valve name for hose timers
-    (e.g. "Upper Deck Planters"). Device scope is tracked separately by the
-    caller's keying strategy (see load_zone_thresholds_from_config).
+    controllers (e.g. "1") or the raw valve name for hose timers (e.g.
+    "Z13 FS - Upper Deck Planters"). Device scope is tracked separately by
+    the caller's keying strategy (see load_zone_thresholds_from_config).
+
+    Display names are derived from the raw key via `compact_zone_label` at
+    render time — the config no longer stores a separate display `name`.
     """
 
     zone_key: str
-    name: str
     avg_gpm: float
 
     def compute_threshold(self, absolute_gpm: float, percent_above: float) -> float:
@@ -44,6 +60,17 @@ class ZoneThreshold(BaseModel):
         """
         deviation = max(absolute_gpm, percent_above / 100.0 * self.avg_gpm)
         return self.avg_gpm + deviation
+
+
+def compact_zone_label(raw_name: str) -> str:
+    """Return the segment before " - " in a raw zone or valve name.
+
+    Controller names ("Z1 FS") pass through unchanged; hose valve names
+    ("Z13 FS - Upper Deck Planters") lose their descriptive tail so display
+    strings and Pushover headers stay short and consistent between the two
+    device families.
+    """
+    return raw_name.split(" - ", 1)[0].strip()
 
 
 def load_rules_from_config() -> list[AlertRule]:
@@ -87,17 +114,84 @@ def load_zone_thresholds_from_config() -> dict[str, dict[str, ZoneThreshold]]:
             # zt_cfg may be a dict (depth-2 OmegaConf) or a ZoneThresholdConfig
             # (if the loader was ever extended). Accept both.
             if isinstance(zt_cfg, dict):
-                name = zt_cfg["name"]
                 avg_gpm = zt_cfg["avg_gpm"]
             else:
-                name = zt_cfg.name
                 avg_gpm = zt_cfg.avg_gpm
-            out[device_label][zk] = ZoneThreshold(
-                zone_key=zk,
-                name=name,
-                avg_gpm=avg_gpm,
-            )
+            out[device_label][zk] = ZoneThreshold(zone_key=zk, avg_gpm=avg_gpm)
     return out
+
+
+def send_zone_outcome_pushover(
+    *,
+    pushover: Pushover,
+    logger: logging.Logger,
+    log_label: str,
+    header: str,
+    runtime_min: float,
+    avg_gpm: float,
+    total_gal: float,
+    baseline: float,
+    threshold: float,
+    min_runtime_minutes: float,
+    extra_lines: list[str] | None = None,
+) -> None:
+    """Emit at most one zone-end Pushover with the shared RachioFlume format.
+
+    Both the controller-zone path (alert_engine._send_zone_outcome) and the
+    hose-timer path (hose_timer_processor._send_zone_outcome) delegate here
+    so the message layout, anomaly title/priority routing, and short-run
+    silence gate stay locked in one place.
+
+    Short runs (`runtime_min <= min_runtime_minutes`) are silenced entirely
+    — they're test cycles, brief manual triggers, or noise, and firing a
+    Pushover for each floods the feed. Above the gate the routine sends
+    Zone Report (P-1) or Zone Anomaly (P2) depending on whether the flow
+    exceeded the configured baseline's anomaly threshold.
+
+    Args:
+        header: caller-formatted first line, e.g. "'Z1 FS' (Cycle 2)" for
+            controllers, "'Z13 FS' @ Hose Drip Jasmine" for hose valves.
+        log_label: string used only in the skip/success log lines.
+        baseline: 0 when the zone is not configured for anomaly detection;
+            disables the "(thresh X.XX)" suffix and anomaly routing.
+        extra_lines: appended after the anomaly deviation line, before send.
+    """
+    if runtime_min <= min_runtime_minutes:
+        logger.info(
+            f"Skipping zone outcome for {log_label}: "
+            f"runtime {runtime_min:.0f}min ≤ min_runtime_minutes {min_runtime_minutes}min"
+        )
+        return
+
+    is_anomaly = baseline > 0 and avg_gpm > threshold
+    flow_line = (
+        f"Avg flow: {avg_gpm:.2f} GPM (thresh {threshold:.2f})"
+        if baseline > 0
+        else f"Avg flow: {avg_gpm:.2f} GPM"
+    )
+    lines = [
+        header,
+        f"Runtime: {runtime_min:.0f} min",
+        flow_line,
+        f"Total: {total_gal:.1f} gal",
+    ]
+    if is_anomaly:
+        deviation = avg_gpm - baseline
+        deviation_pct = (deviation / baseline * 100) if baseline > 0 else 0
+        lines.append(f"Deviation: +{deviation:.2f} GPM ({deviation_pct:.0f}%)")
+    if extra_lines:
+        lines.extend(line for line in extra_lines if line)
+
+    if is_anomaly:
+        title, priority = "RachioFlume: Zone Anomaly", 2
+    else:
+        title, priority = "RachioFlume: Zone Report", -1
+
+    pushover.send_message("\n".join(lines), title=title, priority=priority)
+    logger.info(
+        f"Zone outcome sent for {log_label}: {runtime_min:.0f} min, "
+        f"{avg_gpm:.2f} GPM, {total_gal:.1f} gal, anomaly={is_anomaly}"
+    )
 
 
 def get_controller_zone_thresholds(

--- a/RachioFlume/data_storage.py
+++ b/RachioFlume/data_storage.py
@@ -1,7 +1,7 @@
 """Data storage for water tracking integration."""
 
 import sqlite3
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Generator
 from contextlib import contextmanager
@@ -412,33 +412,6 @@ class WaterTrackingDB:
             result = cursor.fetchone()
             return result["total"] or 0.0
 
-    def get_weekly_zone_stats(self, start_date: datetime) -> List[Dict[str, Any]]:
-        """Get weekly statistics by zone."""
-        end_date = start_date + timedelta(days=7)
-
-        with self.get_connection() as conn:
-            cursor = conn.cursor()
-
-            cursor.execute(
-                """
-                SELECT 
-                    zone_name,
-                    zone_number,
-                    COUNT(*) as session_count,
-                    SUM(duration_seconds) as total_duration_seconds,
-                    AVG(duration_seconds) as avg_duration_seconds,
-                    SUM(total_water_used) as total_water_used,
-                    AVG(average_flow_rate) as avg_flow_rate
-                FROM zone_sessions
-                WHERE start_time >= ? AND start_time < ?
-                GROUP BY zone_name, zone_number
-                ORDER BY zone_number
-            """,
-                (start_date, end_date),
-            )
-
-            return [dict(row) for row in cursor.fetchall()]
-
     def get_period_zone_stats(
         self, start_date: datetime, end_date: datetime
     ) -> List[Dict[str, Any]]:
@@ -484,12 +457,12 @@ class WaterTrackingDB:
                         (strftime('%s', timestamp) / (? * 60)) * (? * 60),
                         'unixepoch'
                     ) as interval_start,
-                    AVG(flow_rate) as avg_flow_rate,
-                    MAX(flow_rate) as max_flow_rate,
-                    MIN(flow_rate) as min_flow_rate,
+                    AVG(value) as avg_flow_rate,
+                    MAX(value) as max_flow_rate,
+                    MIN(value) as min_flow_rate,
                     COUNT(*) as data_points,
-                    AVG(CASE WHEN flow_rate > 0.1 THEN flow_rate END) as avg_active_flow_rate
-                FROM flume_readings
+                    AVG(CASE WHEN value > 0.1 THEN value END) as avg_active_flow_rate
+                FROM water_readings
                 WHERE timestamp >= ? AND timestamp <= ?
                 GROUP BY interval_start
                 ORDER BY interval_start

--- a/RachioFlume/hose_timer_processor.py
+++ b/RachioFlume/hose_timer_processor.py
@@ -11,7 +11,11 @@ import json
 from datetime import datetime, timedelta
 from typing import Optional
 
-from RachioFlume.alert_rules import ZoneThreshold
+from RachioFlume.alert_rules import (
+    ZoneThreshold,
+    compact_zone_label,
+    send_zone_outcome_pushover,
+)
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import FlumeClient
 from RachioFlume.rachio_hose_client import HoseValve, RachioHoseClient
@@ -237,64 +241,33 @@ class HoseTimerProcessor:
         total_gal: float,
         flow_detected: Optional[bool],
     ) -> None:
-        """Emit at most one Pushover per valve run.
-
-        Short runs (≤ min_runtime_minutes, default 5) are silenced entirely —
-        same gate as the controller path so test/quick-run pulses don't flood
-        the feed. Above the threshold, routes to Zone Anomaly (P2) when flow
-        exceeds the configured baseline's anomaly threshold; otherwise sends
-        Zone Report (P-1). The trimmed first line clusters visually with
-        controller zone entries in the Pushover feed.
+        """Hose valve zone-end notification. Delegates to the shared helper
+        in alert_rules so the format stays in lockstep with the controller
+        path. The trimmed header clusters visually with controller Pushover
+        entries.
         """
-        runtime_min = duration_sec / 60.0
-        if runtime_min <= self.min_runtime_minutes:
-            self.logger.info(
-                f"Skipping hose zone outcome for "
-                f"'{valve.base_station_label}/{valve.name}': "
-                f"runtime {runtime_min:.0f}min ≤ min_runtime_minutes "
-                f"{self.min_runtime_minutes}min"
-            )
-            return
-
         zt = self.thresholds.get(valve.name)
         baseline = zt.avg_gpm if zt else 0.0
         threshold = (
             zt.compute_threshold(self.absolute_gpm, self.percent_above) if zt else self.absolute_gpm
         )
-        is_anomaly = baseline > 0 and avg_gpm > threshold
 
-        header = f"'{valve.name}' @ {valve.base_station_label}"
-        flow_line = (
-            f"Avg flow: {avg_gpm:.2f} GPM (thresh {threshold:.2f})"
-            if baseline > 0
-            else f"Avg flow: {avg_gpm:.2f} GPM"
-        )
         sensor_line = (
             "Flow sensor: detected"
             if flow_detected
             else ("Flow sensor: NOT detected" if flow_detected is False else "")
         )
-        lines = [
-            header,
-            f"Runtime: {runtime_min:.0f} min",
-            flow_line,
-            f"Total: {total_gal:.1f} gal",
-        ]
-        if is_anomaly:
-            deviation = avg_gpm - baseline
-            deviation_pct = (deviation / baseline * 100) if baseline > 0 else 0
-            lines.append(f"Deviation: +{deviation:.2f} GPM ({deviation_pct:.0f}%)")
-        if sensor_line:
-            lines.append(sensor_line)
 
-        if is_anomaly:
-            title, priority = "RachioFlume: Zone Anomaly", 2
-        else:
-            title, priority = "RachioFlume: Zone Report", -1
-
-        self.pushover.send_message("\n".join(lines), title=title, priority=priority)
-        self.logger.info(
-            f"Hose zone outcome sent for '{valve.base_station_label}/{valve.name}': "
-            f"{runtime_min:.0f} min, {avg_gpm:.2f} GPM, {total_gal:.1f} gal, "
-            f"anomaly={is_anomaly}, flow_detected={flow_detected}"
+        send_zone_outcome_pushover(
+            pushover=self.pushover,
+            logger=self.logger,
+            log_label=f"'{valve.base_station_label}/{valve.name}'",
+            header=f"'{compact_zone_label(valve.name)}' @ {valve.base_station_label}",
+            runtime_min=duration_sec / 60.0,
+            avg_gpm=avg_gpm,
+            total_gal=total_gal,
+            baseline=baseline,
+            threshold=threshold,
+            min_runtime_minutes=self.min_runtime_minutes,
+            extra_lines=[sensor_line] if sensor_line else None,
         )

--- a/RachioFlume/reporter.py
+++ b/RachioFlume/reporter.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import Dict, Any, List
 from pathlib import Path
 
-from RachioFlume.alert_rules import load_zone_thresholds_from_config
+from RachioFlume.alert_rules import compact_zone_label, load_zone_thresholds_from_config
 from RachioFlume.data_storage import WaterTrackingDB
 from lib.config import get_config
 from lib.logger import get_logger
@@ -162,12 +162,11 @@ class WeeklyReporter:
 
         for (label, name), v in hose_agg.items():
             zt = all_thresholds.get(label, {}).get(name)
-            display_name = zt.name if zt else name
             threshold_gpm = round(zt.compute_threshold(abs_gpm, pct_above), 2) if zt else 0.0
             formatted_zones.append(
                 ZoneStats(
                     zone_number=HOSE_ZONE_SENTINEL,
-                    zone_name=display_name,
+                    zone_name=compact_zone_label(name),
                     sessions=v["sessions"],
                     total_duration_minutes=round(v["duration_sec_total"] / 60.0, 1),
                     average_duration_minutes=round(
@@ -229,7 +228,6 @@ class WeeklyReporter:
 
         lines.append("")
         lines.append("SUMMARY:")
-        lines.append(f"  Total watering sessions: {report.summary.total_watering_sessions}")
         lines.append(f"  Total duration: {report.summary.total_duration_minutes} min")
         lines.append(
             f"  Total water used: {int(round(report.summary.total_water_used_gallons))} gallons"
@@ -239,9 +237,11 @@ class WeeklyReporter:
         if report.zones:
             lines.append("")
             lines.append("ZONE DETAILS:")
+            # Numeric columns are right-aligned so decimals and thousands align
+            # visually down the column. Name stays left-aligned.
             # Thr = anomaly threshold GPM (blank if zone not configured).
             # Alrt = # sessions in period where session avg flow > threshold.
-            header = f"{'Name':<8} {'Min':<6} {'Gals':<5} {'GPM':<5} {'Thr':<5} {'Alrt':<4}"
+            header = f"{'Name':<8} {'Min':>6} {'Gals':>5} {'GPM':>5} {'Thr':>5} {'Alrt':>4}"
             lines.append(header)
             lines.append("-" * len(header))
 
@@ -250,11 +250,11 @@ class WeeklyReporter:
                 alrt = str(zone.alert_sessions) if zone.alert_sessions else "-"
                 lines.append(
                     f"{zone.zone_name[:8]:<8} "
-                    f"{zone.total_duration_minutes:<6.1f} "
-                    f"{int(round(zone.total_water_gallons)):<5d} "
-                    f"{zone.average_flow_rate_gpm:<5.1f} "
-                    f"{thr:<5} "
-                    f"{alrt:<4}"
+                    f"{zone.total_duration_minutes:>6.1f} "
+                    f"{int(round(zone.total_water_gallons)):>5d} "
+                    f"{zone.average_flow_rate_gpm:>5.1f} "
+                    f"{thr:>5} "
+                    f"{alrt:>4}"
                 )
 
         lines.append("")

--- a/RachioFlume/test_alert_engine.py
+++ b/RachioFlume/test_alert_engine.py
@@ -41,9 +41,9 @@ def engine(db: WaterTrackingDB, rule: AlertRule) -> AlertEngine:
     pushover.send_message.return_value = True
     # Provide zone thresholds high enough that test flow rates don't trigger anomalies
     zone_thresholds = {
-        1: ZoneThreshold(zone_key="1", name="Z1*", avg_gpm=10.0),
-        2: ZoneThreshold(zone_key="2", name="Z2*", avg_gpm=10.0),
-        3: ZoneThreshold(zone_key="3", name="Z3*", avg_gpm=10.0),
+        1: ZoneThreshold(zone_key="1", avg_gpm=10.0),
+        2: ZoneThreshold(zone_key="2", avg_gpm=10.0),
+        3: ZoneThreshold(zone_key="3", avg_gpm=10.0),
     }
     return AlertEngine(
         flume_client=flume,

--- a/RachioFlume/test_alert_rules_helpers.py
+++ b/RachioFlume/test_alert_rules_helpers.py
@@ -40,9 +40,9 @@ class TestCompactZoneLabel:
 class TestSendZoneOutcomePushover:
     """The shared helper the controller and hose paths delegate to."""
 
-    def _kwargs(self, **overrides):
+    def _kwargs(self, **overrides: object) -> dict:
         """Base kwargs matching a typical controller zone-end fire."""
-        base = dict(
+        base: dict = dict(
             pushover=MagicMock(),
             logger=logging.getLogger("test"),
             log_label="'Z1 FS'",

--- a/RachioFlume/test_alert_rules_helpers.py
+++ b/RachioFlume/test_alert_rules_helpers.py
@@ -1,0 +1,104 @@
+"""Unit tests for the two shared helpers in alert_rules.
+
+- `compact_zone_label` — display-name normalization used by both the
+  reporter and the hose Pushover header.
+- `send_zone_outcome_pushover` — the shared zone-end notification format
+  that alert_engine and hose_timer_processor both delegate to.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from RachioFlume.alert_rules import (
+    compact_zone_label,
+    send_zone_outcome_pushover,
+)
+
+
+class TestCompactZoneLabel:
+    """Header/display normalization is shared across the controller and hose paths."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Z1 FS", "Z1 FS"),  # controller name — pass through
+            ("Z13 FS - Upper Deck Planters", "Z13 FS"),  # hose valve — drop tail
+            ("Simple", "Simple"),  # no dash — pass through
+            ("  Z2 FS  - Front Yard  ", "Z2 FS"),  # whitespace stripped
+            ("Z9 - A - B", "Z9"),  # only first " - " is the split point
+            ("Z-1 FS", "Z-1 FS"),  # dash without surrounding spaces — no split
+        ],
+    )
+    def test_variants(self, raw: str, expected: str) -> None:
+        assert compact_zone_label(raw) == expected
+
+
+class TestSendZoneOutcomePushover:
+    """The shared helper the controller and hose paths delegate to."""
+
+    def _kwargs(self, **overrides):
+        """Base kwargs matching a typical controller zone-end fire."""
+        base = dict(
+            pushover=MagicMock(),
+            logger=logging.getLogger("test"),
+            log_label="'Z1 FS'",
+            header="'Z1 FS'",
+            runtime_min=30.0,
+            avg_gpm=5.0,
+            total_gal=150.0,
+            baseline=4.0,
+            threshold=4.5,
+            min_runtime_minutes=5,
+        )
+        base.update(overrides)
+        return base
+
+    def test_short_run_is_silenced(self) -> None:
+        kw = self._kwargs(runtime_min=3.0)
+        send_zone_outcome_pushover(**kw)
+        kw["pushover"].send_message.assert_not_called()
+
+    def test_report_below_threshold(self) -> None:
+        # avg_gpm 5.0 < threshold 6.0 → Zone Report at P-1
+        kw = self._kwargs(threshold=6.0)
+        send_zone_outcome_pushover(**kw)
+        kw["pushover"].send_message.assert_called_once()
+        _, call_kwargs = kw["pushover"].send_message.call_args
+        assert call_kwargs["title"] == "RachioFlume: Zone Report"
+        assert call_kwargs["priority"] == -1
+
+    def test_anomaly_above_threshold(self) -> None:
+        # avg_gpm 5.0 > threshold 4.5 with baseline > 0 → Zone Anomaly at P2
+        kw = self._kwargs()
+        send_zone_outcome_pushover(**kw)
+        kw["pushover"].send_message.assert_called_once()
+        args, call_kwargs = kw["pushover"].send_message.call_args
+        assert call_kwargs["title"] == "RachioFlume: Zone Anomaly"
+        assert call_kwargs["priority"] == 2
+        # Deviation line appended for anomaly path
+        assert "Deviation:" in args[0]
+
+    def test_no_baseline_hides_threshold_annotation(self) -> None:
+        kw = self._kwargs(baseline=0.0, threshold=0.5)
+        send_zone_outcome_pushover(**kw)
+        args, _ = kw["pushover"].send_message.call_args
+        # No "(thresh X.XX)" suffix when baseline is unknown
+        assert "thresh" not in args[0]
+
+    def test_extra_lines_appended(self) -> None:
+        # Hose path passes a sensor status line via extra_lines
+        kw = self._kwargs(extra_lines=["Flow sensor: detected"])
+        send_zone_outcome_pushover(**kw)
+        args, _ = kw["pushover"].send_message.call_args
+        assert "Flow sensor: detected" in args[0]
+
+    def test_empty_extra_line_filtered(self) -> None:
+        # Falsy strings in extra_lines shouldn't produce trailing blank lines
+        kw = self._kwargs(extra_lines=[""])
+        send_zone_outcome_pushover(**kw)
+        args, _ = kw["pushover"].send_message.call_args
+        assert not args[0].endswith("\n")

--- a/RachioFlume/test_hose_timer.py
+++ b/RachioFlume/test_hose_timer.py
@@ -50,11 +50,7 @@ def _make_processor(
     client.label = "Hose Drip Jasmine"
     client.list_valves.return_value = [valve]
     pushover = MagicMock()
-    thresholds = {
-        "Upper Deck Planters": ZoneThreshold(
-            zone_key="Upper Deck Planters", name="UDP", avg_gpm=0.5
-        )
-    }
+    thresholds = {"Upper Deck Planters": ZoneThreshold(zone_key="Upper Deck Planters", avg_gpm=0.5)}
     proc = HoseTimerProcessor(client=client, pushover=pushover, db=tmp_db, thresholds=thresholds)
     return proc, pushover
 

--- a/RachioFlume/test_zone_thresholds.py
+++ b/RachioFlume/test_zone_thresholds.py
@@ -83,10 +83,7 @@ def zone_thresholds() -> dict[int, ZoneThreshold]:
     Built inline rather than loaded from config so the test is hermetic and
     does not depend on local.yaml (which is gitignored and absent in CI).
     """
-    return {
-        n: ZoneThreshold(zone_key=str(n), name=f"Z{n}*", avg_gpm=avg)
-        for n, avg in _FIXTURE_ZONE_AVGS.items()
-    }
+    return {n: ZoneThreshold(zone_key=str(n), avg_gpm=avg) for n, avg in _FIXTURE_ZONE_AVGS.items()}
 
 
 @pytest.fixture

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -250,7 +250,9 @@ rachio_flume:
       # Outer key = device label (matches rachio.devices[].label).
       # Inner key = zone identifier:
       #   - Controllers: stringified zone_number (e.g. "1")
-      #   - Hose timers: valve name (e.g. "Upper Deck Planters")
+      #   - Hose timers: raw valve name (e.g. "Z13 FS - Upper Deck Planters")
+      # Value: {avg_gpm: <float>}. Display labels derive from the raw key via
+      # compact_zone_label(); no display `name:` field needed.
       zone_thresholds: {}
 
     # === Whole-house sustained-flow rules (Flume only; no Rachio context) ===


### PR DESCRIPTION
## Summary

Follow-up to #209. Amit reviewed the shipped email and asked for the hose valve to carry the two-token prefix (\"Z13 FS\") like controller zones do, plus reduce drift between the two paths through code reuse — via helpers, not an abstract class hierarchy. Also delete dead code, fix the RachioFlume README, right-align numeric columns, and drop the redundant \"Total watering sessions\" summary line.

## Reuse via helpers, not inheritance

- \`compact_zone_label(raw_name)\` in \`alert_rules.py\`: splits on \" - \" and takes the head. Controllers (\"Z1 FS\") pass through; hose valves (\"Z13 FS - Upper Deck Planters\") lose the descriptive tail. Used by reporter and hose Pushover header.
- \`send_zone_outcome_pushover()\` in \`alert_rules.py\`: shared zone-end notification format. Both \`_send_zone_outcome\` sites (was 54 + 69 lines) collapse to header + one delegated call. **~80 net LOC gone**; anomaly title/priority/message layout locked in one place.
- Dropped \`name\` field from \`ZoneThreshold\` model + config; display name derives from raw key every time. \`zone_thresholds\` entries need only \`{avg_gpm: X}\`. Controller inline comments now name each zone_number.

## Dead code + real bug

- Deleted \`WaterTrackingDB.get_weekly_zone_stats\` — no callers.
- Fixed \`WaterTrackingDB.get_raw_data_intervals\`: SQL queried \`FROM flume_readings\` (nonexistent) and \`flow_rate\` columns (nonexistent). Actual table is \`water_readings\`, column is \`value\`. \`rfmanager raw\` crashed on first call; not caught because it isn't in cron. Live-verified fix returns rows.

## Email format polish

- Right-align Min / Gals / GPM / Thr / Alrt columns.
- Drop \"Total watering sessions\" from SUMMARY.

## Sample output (live dry-run against aibo DB)

\`\`\`
SUMMARY:
  Total duration: 470.0 min
  Total water used: 1818 gallons
  Zones watered: 13

ZONE DETAILS:
Name        Min  Gals   GPM   Thr Alrt
--------------------------------------
Z1 FS      40.0   261   6.5   6.6    -
...
Z12 FDB    59.5    82   1.4   1.5    -
Z13 FS     45.0     0   0.0   1.0    -
\`\`\`

## README

- Removed references to deleted \`summary\` subcommand + \"efficiency analysis\" (deleted in #208).
- Fixed simulator entrypoint (\`alerts replay\`, not \`simulate\`).
- New Period Report example uses current unified HTML shape.
- Documented config key convention (controllers key by stringified zone_number; hose valves by raw API name) and the compact_zone_label display path.

## Test plan
- [x] \`uv run python -m pytest RachioFlume -q\` → 92 passed (80 → 92; +12 new helper tests).
- [x] Live smoke on aibo DB: \`get_raw_data_intervals\` returns 72 rows over 6h (was crashing pre-fix).
- [x] Live dry-run: \"Z13 FS\" compact label, right-aligned columns visible.
- [ ] After merge + deploy: fire report --email; iOS screenshot confirms new format.

## References
- Predecessor #209 (unified table + HTML wrapper).