### PR TITLE
fix(august): restore lock auth after API key revocation + token expiry

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -59,9 +59,22 @@ jobs:
           tr -d '\000' < /tmp/diff.raw | iconv -f utf-8 -t utf-8 -c > /tmp/diff.txt
 
           SYSTEM_PROMPT='You are a senior code reviewer. Output ONLY a JSON object — no prose, no markdown, no reasoning text before or after. Begin your response with { and end with }.
+
+          You only see the diff (lines starting with "+" are new), not the whole codebase. Do not flag things that may be defined elsewhere — imports, variables, helpers — or suggest code that duplicates existing functionality.
+
+          What to flag:
+          - Be thorough on clear bugs and security holes. Do not skip a genuine problem because the trigger scenario is narrow.
+          - For lower-severity concerns, be certain before flagging: if you cannot give a concrete trigger scenario, do not flag it.
+          - Each issue must be discrete and actionable, not a vague concern about the codebase.
+          - Do not speculate that a change breaks other code unless you can point to the specific affected path from the diff.
+          - Do not flag intentional design choices or style. Skip nits, naming, and formatting.
+          - If confidence is low but impact is high (data loss, security), you may report it but state explicitly what remains uncertain. Otherwise, prefer silence over guessing.
+
+          Output schema:
           - summary: at most one sentence (kept for the schema; not shown to humans).
-          - issues: list ONLY real bugs, security holes, or design problems. Skip nits, style, and naming.
-          - For each issue: path is the file path; line is the 1-indexed line in the NEW file version (a "+" line in the diff); severity is one of bug, security, design; body is one or two sentences with the problem and a fix suggestion.
+          - issues: list per the rules above.
+          - For each issue: path is the file path; line is the 1-indexed line in the NEW file version (a "+" line in the diff); severity is one of bug, security, design; body is one or two sentences — the problem, the realistic scenario that triggers it, and a fix suggestion. Do not overstate impact; if it only triggers under specific inputs, say so.
+          - Tone: matter-of-fact, helpful. No praise, no filler, no accusations.
           - If no real issues, return an empty issues array.'
 
           SCHEMA='{

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -102,17 +102,20 @@ jobs:
 
           # GLM 5.2 is a reasoning model (Z.ai, industry-leading on SWE-bench
           # Verified 77.8%): it emits chain-of-thought before the actual output.
-          # Keep max_tokens generous and reasoning_effort=low so even verbose
-          # runs have room for the JSON tail, avoiding "unparseable JSON" skips.
+          # The review prompt demands concrete trigger scenarios and confidence
+          # calibration, so run reasoning_effort=medium for real judgment — and
+          # raise max_tokens to 16384 so the longer CoT still leaves room for the
+          # JSON tail, avoiding "unparseable JSON" skips. curl --max-time 300
+          # matches the higher latency budget.
           PAYLOAD=$(jq -n \
             --rawfile diff /tmp/diff.txt \
             --arg sys "$SYSTEM_PROMPT" \
             --argjson schema "$SCHEMA" \
             '{
               model: "accounts/fireworks/models/glm-5p2",
-              max_tokens: 8192,
+              max_tokens: 16384,
               temperature: 0.1,
-              reasoning_effort: "low",
+              reasoning_effort: "medium",
               response_format: {type: "json_object", schema: $schema},
               messages: [
                 {role: "system", content: $sys},
@@ -120,7 +123,7 @@ jobs:
               ]
             }')
 
-          HTTP_RESPONSE=$(curl -sS --max-time 180 -w "\n%{http_code}" https://api.fireworks.ai/inference/v1/chat/completions \
+          HTTP_RESPONSE=$(curl -sS --max-time 300 -w "\n%{http_code}" https://api.fireworks.ai/inference/v1/chat/completions \
             -H "Authorization: Bearer $FIREWORKS_API_KEY" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")

--- a/August/august_client.py
+++ b/August/august_client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import asyncio
+import logging
 import os
 import time
 from typing import Optional, Dict
@@ -11,11 +12,62 @@ from datetime import datetime
 
 from yalexs.api_async import ApiAsync
 from yalexs.authenticator_async import AuthenticatorAsync, AuthenticationState
+from yalexs.authenticator_common import Authentication
 from yalexs.lock import Lock, LockStatus, LockDoorStatus
 
 from lib.config import get_config
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
+
+# August revoked the API key yalexs ships for Brand.AUGUST (d9984f29...): the
+# session/password-auth endpoint returns 403 {"code":"Forbidden","message":
+# "API key is not valid"}. The legacy key yalexs also ships (7cab4bbd...) still
+# works. We override the global BrandConfig so AuthenticatorAsync/ApiAsync send
+# the working key. Only override when the current key is the known-revoked
+# value so a future yalexs fix is not clobbered.
+_REVOKED_AUGUST_API_KEY = "d9984f29-07a6-816e-e1c9-44ec9d1be431"
+_WORKING_AUGUST_API_KEY = "7cab4bbd-2693-4fc1-b99b-dec0fb20f9d4"
+
+
+def apply_working_api_key(logger: Optional[logging.Logger] = None) -> bool:
+    """Fall back to the legacy August API key if yalexs's current key is revoked.
+
+    Mutates the yalexs global BRAND_CONFIG[Brand.AUGUST].api_key in place so
+    that AuthenticatorAsync/ApiAsync send a key August still accepts. Returns
+    True if a fallback was applied, False if the shipped key is not the known
+    revoked value (e.g. yalexs shipped a fix).
+    """
+    from yalexs.const import BRAND_CONFIG, Brand
+
+    brand_config = BRAND_CONFIG[Brand.AUGUST]
+    if brand_config.api_key != _REVOKED_AUGUST_API_KEY:
+        return False
+    brand_config.api_key = _WORKING_AUGUST_API_KEY
+    if logger is not None:
+        logger.warning(
+            "August revoked yalexs API key %s; falling back to legacy key %s.",
+            _REVOKED_AUGUST_API_KEY,
+            _WORKING_AUGUST_API_KEY,
+        )
+    return True
+
+
+def load_cached_install_id(cache_file: str) -> Optional[str]:
+    """Return the install_id persisted in the August token cache, if any.
+
+    yalexs discards the cached install_id when the access token expires
+    (authenticator_async._read_access_token_file resets to self._install_id,
+    which is the constructor arg, not the cached value). That makes August see
+    a fresh device on every re-auth after expiry and forces 2FA. We feed the
+    cached install_id back through the AuthenticatorAsync constructor so the
+    validated device identity survives token expiry.
+    """
+    try:
+        with open(cache_file, "r") as f:
+            data = json.load(f)
+        return data.get("install_id")
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
 
 
 @dataclass
@@ -74,17 +126,24 @@ class AugustClient:
             self.session = aiohttp.ClientSession()
             from yalexs.const import Brand
 
+            # August revoked the current yalexs API key for Brand.AUGUST; fall
+            # back to the legacy key before any auth/session call uses it.
+            apply_working_api_key(self.logger)
             # Auth uses AUGUST brand, but API endpoints moved to YALE_AUGUST
             self.api_auth = ApiAsync(self.session, brand=Brand.AUGUST)
             self.api = ApiAsync(self.session, brand=Brand.YALE_AUGUST)
             # Use token caching to persist authentication across restarts
             cache_file = cfg.august.token_file
             os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+            # Re-feed the cached install_id so re-auth after token expiry does
+            # not look like a new device to August (which would force 2FA).
+            install_id = load_cached_install_id(cache_file)
             self.authenticator = AuthenticatorAsync(
                 self.api_auth,
                 "email",
                 self.email,
                 self.password,
+                install_id=install_id,
                 access_token_cache_file=cache_file,
             )
             # Setup authentication - this initializes the _authentication property
@@ -104,6 +163,18 @@ class AugustClient:
         try:
             assert self.authenticator is not None
             self.logger.debug("Attempting August authentication...")
+            # Proactively renew before expiry: yalexs only re-auths once the
+            # token is fully expired, which leaves a gap until the next cron
+            # run. When we are inside the renewal window (last 7 days) force a
+            # password re-auth so August issues a fresh 30-day token now. The
+            # cached install_id (fed via the constructor) is preserved so this
+            # does not trigger 2FA.
+            if self.authenticator.should_refresh():
+                self.logger.info("August token inside renewal window; renewing now")
+                self.authenticator._authentication = Authentication(
+                    AuthenticationState.REQUIRES_AUTHENTICATION,
+                    install_id=self.authenticator._authentication.install_id,
+                )
             auth_result = await self.authenticator.async_authenticate()
 
             if auth_result is None:

--- a/August/august_client.py
+++ b/August/august_client.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 import time
-from typing import Optional, Dict
+from typing import Any, Dict, Optional
 import json
 from dataclasses import dataclass
 import aiohttp
@@ -64,8 +64,9 @@ def load_cached_install_id(cache_file: str) -> Optional[str]:
     """
     try:
         with open(cache_file, "r") as f:
-            data = json.load(f)
-        return data.get("install_id")
+            data: dict[str, Any] = json.load(f)
+        install_id = data.get("install_id")
+        return install_id if isinstance(install_id, str) else None
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return None
 

--- a/August/test_august_client.py
+++ b/August/test_august_client.py
@@ -2,7 +2,8 @@
 """Tests for August smart lock client module."""
 
 import pytest
-from typing import Any
+from pathlib import Path
+from typing import Any, Generator
 from unittest.mock import Mock, MagicMock, patch, AsyncMock
 from yalexs.lock import LockStatus, LockDoorStatus
 from August.august_client import (
@@ -545,22 +546,22 @@ class TestAugustMonitor:
 class TestLoadCachedInstallId:
     """Test reading the persisted install_id from the token cache."""
 
-    def test_returns_install_id_when_present(self, tmp_path) -> None:
+    def test_returns_install_id_when_present(self, tmp_path: Path) -> None:
         cache = tmp_path / "token.json"
         cache.write_text('{"install_id": "abc-123", "access_token": "x"}')
 
         assert load_cached_install_id(str(cache)) == "abc-123"
 
-    def test_returns_none_when_file_missing(self, tmp_path) -> None:
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
         assert load_cached_install_id(str(tmp_path / "nope.json")) is None
 
-    def test_returns_none_when_invalid_json(self, tmp_path) -> None:
+    def test_returns_none_when_invalid_json(self, tmp_path: Path) -> None:
         cache = tmp_path / "token.json"
         cache.write_text("not json")
 
         assert load_cached_install_id(str(cache)) is None
 
-    def test_returns_none_when_no_install_id_key(self, tmp_path) -> None:
+    def test_returns_none_when_no_install_id_key(self, tmp_path: Path) -> None:
         cache = tmp_path / "token.json"
         cache.write_text('{"access_token": "x"}')
 
@@ -571,7 +572,7 @@ class TestApplyWorkingApiKey:
     """Test the August API key fallback helper."""
 
     @pytest.fixture(autouse=True)
-    def _restore_brand_config(self) -> None:
+    def _restore_brand_config(self) -> Generator[None, None, None]:
         """Restore the real BRAND_CONFIG[Brand.AUGUST].api_key after each test."""
         from yalexs.const import BRAND_CONFIG, Brand
 

--- a/August/test_august_client.py
+++ b/August/test_august_client.py
@@ -5,7 +5,13 @@ import pytest
 from typing import Any
 from unittest.mock import Mock, MagicMock, patch, AsyncMock
 from yalexs.lock import LockStatus, LockDoorStatus
-from August.august_client import AugustClient, AugustMonitor, LockState
+from August.august_client import (
+    AugustClient,
+    AugustMonitor,
+    LockState,
+    apply_working_api_key,
+    load_cached_install_id,
+)
 
 
 class TestLockState:
@@ -59,6 +65,7 @@ class TestAugustClient:
             patch("August.august_client.aiohttp.ClientSession") as mock_session,
             patch("August.august_client.ApiAsync") as mock_api,
             patch("August.august_client.AuthenticatorAsync") as mock_auth,
+            patch("August.august_client.load_cached_install_id", return_value="cached-install-id"),
             patch("August.august_client.get_config", return_value=mock_config),
         ):
             mock_session_instance = Mock()
@@ -74,7 +81,10 @@ class TestAugustClient:
             assert mock_api.call_count == 2
             mock_api.assert_any_call(mock_session_instance, brand=Brand.AUGUST)
             mock_api.assert_any_call(mock_session_instance, brand=Brand.YALE_AUGUST)
+            # The cached install_id is fed back through the constructor so
+            # re-auth after token expiry does not force 2FA.
             mock_auth.assert_called_once()
+            assert mock_auth.call_args.kwargs["install_id"] == "cached-install-id"
 
     @pytest.mark.asyncio
     async def test_close_session(self, client: AugustClient) -> None:
@@ -102,12 +112,70 @@ class TestAugustClient:
         ):
             mock_auth_state.AUTHENTICATED = "AUTHENTICATED"
             client.authenticator = AsyncMock()
+            client.authenticator.should_refresh = Mock(return_value=False)
             client.authenticator.async_authenticate.return_value = mock_auth_result
 
             result = await client.authenticate()
 
             assert result is True
             assert client.access_token == "token123"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_renews_proactively_when_in_renewal_window(
+        self, client: AugustClient
+    ) -> None:
+        """When the token is inside the renewal window, force a re-auth."""
+        mock_auth_result = Mock()
+        mock_auth_result.state = "AUTHENTICATED"
+        mock_auth_result.access_token = "fresh-token"
+
+        with (
+            patch.object(client, "_ensure_session"),
+            patch("August.august_client.AuthenticationState") as mock_auth_state,
+            patch("August.august_client.Authentication") as mock_auth_cls,
+        ):
+            mock_auth_state.AUTHENTICATED = "AUTHENTICATED"
+            mock_auth_state.REQUIRES_AUTHENTICATION = "REQUIRES_AUTHENTICATION"
+            client.authenticator = AsyncMock()
+            client.authenticator.should_refresh = Mock(return_value=True)
+            client.authenticator._authentication.install_id = "known-install-id"
+            client.authenticator.async_authenticate.return_value = mock_auth_result
+
+            result = await client.authenticate()
+
+            assert result is True
+            assert client.access_token == "fresh-token"
+            # State was reset to REQUIRES_AUTHENTICATION keeping the install_id
+            # so async_authenticate performs a password re-auth instead of
+            # returning the cached (soon-to-expire) token.
+            mock_auth_cls.assert_called_once_with(
+                mock_auth_state.REQUIRES_AUTHENTICATION,
+                install_id="known-install-id",
+            )
+            client.authenticator.async_authenticate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_authenticate_skips_renewal_when_token_fresh(self, client: AugustClient) -> None:
+        """When the token is well outside the renewal window, do not re-auth."""
+        mock_auth_result = Mock()
+        mock_auth_result.state = "AUTHENTICATED"
+        mock_auth_result.access_token = "token123"
+
+        with (
+            patch.object(client, "_ensure_session"),
+            patch("August.august_client.AuthenticationState") as mock_auth_state,
+            patch("August.august_client.Authentication") as mock_auth_cls,
+        ):
+            mock_auth_state.AUTHENTICATED = "AUTHENTICATED"
+            client.authenticator = AsyncMock()
+            client.authenticator.should_refresh = Mock(return_value=False)
+            client.authenticator.async_authenticate.return_value = mock_auth_result
+
+            result = await client.authenticate()
+
+            assert result is True
+            # No forced state reset.
+            mock_auth_cls.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_authenticate_requires_validation(self, client: AugustClient) -> None:
@@ -122,6 +190,7 @@ class TestAugustClient:
             mock_auth_state.AUTHENTICATED = "AUTHENTICATED"
             mock_auth_state.REQUIRES_VALIDATION = "REQUIRES_VALIDATION"
             client.authenticator = AsyncMock()
+            client.authenticator.should_refresh = Mock(return_value=False)
             client.authenticator.async_authenticate.return_value = mock_auth_result
 
             result = await client.authenticate()
@@ -471,6 +540,82 @@ class TestAugustMonitor:
             mock_pushover.assert_not_called()
             # Should have started tracking again
             assert lock_id in monitor.unknown_status_start_times
+
+
+class TestLoadCachedInstallId:
+    """Test reading the persisted install_id from the token cache."""
+
+    def test_returns_install_id_when_present(self, tmp_path) -> None:
+        cache = tmp_path / "token.json"
+        cache.write_text('{"install_id": "abc-123", "access_token": "x"}')
+
+        assert load_cached_install_id(str(cache)) == "abc-123"
+
+    def test_returns_none_when_file_missing(self, tmp_path) -> None:
+        assert load_cached_install_id(str(tmp_path / "nope.json")) is None
+
+    def test_returns_none_when_invalid_json(self, tmp_path) -> None:
+        cache = tmp_path / "token.json"
+        cache.write_text("not json")
+
+        assert load_cached_install_id(str(cache)) is None
+
+    def test_returns_none_when_no_install_id_key(self, tmp_path) -> None:
+        cache = tmp_path / "token.json"
+        cache.write_text('{"access_token": "x"}')
+
+        assert load_cached_install_id(str(cache)) is None
+
+
+class TestApplyWorkingApiKey:
+    """Test the August API key fallback helper."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_brand_config(self) -> None:
+        """Restore the real BRAND_CONFIG[Brand.AUGUST].api_key after each test."""
+        from yalexs.const import BRAND_CONFIG, Brand
+
+        original = BRAND_CONFIG[Brand.AUGUST].api_key
+        yield
+        BRAND_CONFIG[Brand.AUGUST].api_key = original
+
+    def test_applies_fallback_when_revoked_key_present(self) -> None:
+        """When yalexs ships the known-revoked key, fall back to the legacy key."""
+        from yalexs.const import BRAND_CONFIG, Brand
+
+        # Ensure the global starts at the revoked value (yalexs 9.0.1 ships it).
+        BRAND_CONFIG[Brand.AUGUST].api_key = "d9984f29-07a6-816e-e1c9-44ec9d1be431"
+
+        applied = apply_working_api_key()
+
+        assert applied is True
+        assert BRAND_CONFIG[Brand.AUGUST].api_key == "7cab4bbd-2693-4fc1-b99b-dec0fb20f9d4"
+
+    def test_does_not_clobber_unknown_key(self) -> None:
+        """If yalexs shipped a different (fixed) key, do not override it."""
+        from yalexs.const import BRAND_CONFIG, Brand
+
+        fixed_key = "11111111-2222-3333-4444-555555555555"
+        BRAND_CONFIG[Brand.AUGUST].api_key = fixed_key
+
+        applied = apply_working_api_key()
+
+        assert applied is False
+        assert BRAND_CONFIG[Brand.AUGUST].api_key == fixed_key
+
+    def test_logs_warning_when_fallback_applied(self) -> None:
+        """A warning is logged when the fallback is applied."""
+        from yalexs.const import BRAND_CONFIG, Brand
+
+        BRAND_CONFIG[Brand.AUGUST].api_key = "d9984f29-07a6-816e-e1c9-44ec9d1be431"
+        logger = MagicMock()
+
+        apply_working_api_key(logger)
+
+        logger.warning.assert_called_once()
+        args = logger.warning.call_args.args
+        assert "d9984f29-07a6-816e-e1c9-44ec9d1be431" in args[1]
+        assert "7cab4bbd-2693-4fc1-b99b-dec0fb20f9d4" in args[2]
 
 
 if __name__ == "__main__":

--- a/August/validate_2fa.py
+++ b/August/validate_2fa.py
@@ -7,6 +7,7 @@ import aiohttp
 from yalexs.authenticator_async import AuthenticatorAsync, AuthenticationState
 from yalexs.api_async import ApiAsync
 from lib.config import get_config
+from August.august_client import apply_working_api_key, load_cached_install_id
 
 
 async def complete_2fa() -> bool:
@@ -16,11 +17,15 @@ async def complete_2fa() -> bool:
         api = ApiAsync(session)
         cache_file = cfg.august.token_file
         os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+        # August revoked the current yalexs API key; fall back to the legacy key
+        # before authenticating.
+        apply_working_api_key()
         auth = AuthenticatorAsync(
             api,
             "email",
             cfg.august.email,
             cfg.august.password,
+            install_id=load_cached_install_id(cache_file),
             access_token_cache_file=cache_file,
         )
         await auth.async_setup_authentication()


### PR DESCRIPTION
## Why
August reported disconnected because every heartbeat since the cached token expired on 2026-06-30 failed authentication. Root cause was not an OAuth migration (initial hypothesis) — the raw 403 body showed August revoked the specific API key yalexs ships for `Brand.AUGUST` (`d9984f29...`): `{"code":"Forbidden","message":"API key is not valid"}`. Password auth itself still works.

## Impact
August lock monitoring resumes without manual intervention, and tokens renew proactively before expiry so the every-2-days cron no longer has a 1–2 day monitoring gap after each ~30-day token expiry.

## Changes
- **`apply_working_api_key()`** — overrides the yalexs global `BRAND_CONFIG[Brand.AUGUST].api_key` to the legacy key (`7cab4bbd...`) when the shipped key is the known-revoked value (so a future yalexs fix is not clobbered), with a warning log. Applied in `_ensure_session` and `validate_2fa`.
- **`load_cached_install_id()`** — feeds the cached install_id back through the `AuthenticatorAsync` constructor. yalexs discards the cached install_id when the token expires (`authenticator_async._read_access_token_file` resets to `self._install_id`, the constructor arg, not the cached value), so every re-auth after expiry looked like a new device and forced 2FA. Preserving the validated install_id avoids 2FA on routine expiry.
- **Proactive renewal** — `authenticate()` forces a password re-auth when `should_refresh()` is true (inside the 7-day renewal window) so August issues a fresh 30-day token before expiry. Verified re-auth while the token is still valid returns a fresh JWT (new signature, expiry extended to now+30d).
- Tests: 29 August tests (added coverage for the key fallback, install_id loader, and proactive renewal paths). Full suite: 277 passing.

## References
- yalexs 9.0.1 `authenticator_async.py` (expired-token install_id discard bug), `const.py` (revoked `HEADER_VALUE_API_KEY` vs working `HEADER_VALUE_API_KEY_OLD`)
- Home Assistant August integration `application_credentials.py` (OAuth endpoints — consulted to rule out the OAuth hypothesis): `https://auth.august.com/authorization`, `https://auth.august.com/access_token`
- aibo logs: `~/logs/august_manager.py.log` (failures from 2026-06-30 onward)
- Live verification on aibo creds: expired-token re-auth and renewal-window re-auth both succeed; both locks report (Front Door 67%, Garage Entrance 94%); token cache refreshed to 2026-08-03

## Also in this PR: tighten GLM 5.2 PR-review prompt
Riding this PR to get real review signal on the updated prompt rather than a standalone meta-PR. Grafts qodo-ai/pr-agent's "Determining what to flag" discipline into `agent-review.yml` SYSTEM_PROMPT — diff-blindness caveat, asymmetric confidence (thorough on real bugs, certain on low-severity), no cross-file speculation, uncertain-high-impact carve-out, tone discipline. JSON schema/output shape unchanged so extraction + inline-review POST still work. `reasoning_effort` stays `low`.

### References (agent-review prompt)
- qodo-ai/pr-agent `pr_reviewer_prompts.toml`: https://raw.githubusercontent.com/qodo-ai/pr-agent/main/pr_agent/settings/pr_reviewer_prompts.toml

## Also in this PR: raise GLM 5.2 reasoning budget (medium)
Follow-on to the prompt tightening above. The new prompt demands concrete trigger scenarios and confidence calibration — judgment a reasoning model only exercises with more than `low` thinking budget. `reasoning_effort` `low` → `medium`, `max_tokens` `8192` → `16384` (so the longer CoT still leaves room for the JSON tail), `curl --max-time` `180` → `300`.

🤖 Generated with [Pi](https://pi.dev)
