### PR TITLE
fix(Tesla): retry transient Fleet API errors instead of exiting

### DIFF
--- a/Tesla/tesla_client.py
+++ b/Tesla/tesla_client.py
@@ -21,6 +21,8 @@ import threading
 from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
 import aiohttp
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
+from tesla_fleet_api.exceptions import TeslaFleetError
 from tesla_fleet_api.tesla import EnergySite, TeslaFleetOAuth
 
 from lib.config import get_config
@@ -132,8 +134,24 @@ class TeslaAPIClient:
 
             return result
 
-    def _run(self, fn: Callable[[TeslaFleetOAuth], Awaitable[T]]) -> T:
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(2),
+        retry=retry_if_exception_type(TeslaFleetError),
+        reraise=True,
+    )
+    def _run_once(self, fn: Callable[[TeslaFleetOAuth], Awaitable[T]]) -> T:
         return asyncio.run(self._with_oauth(fn))
+
+    def _run(self, fn: Callable[[TeslaFleetOAuth], Awaitable[T]]) -> T:
+        # tesla_fleet_api's TeslaFleetError subclasses BaseException, not Exception,
+        # so upstream 5xx/etc bypass normal `except Exception` retry blocks. Retry
+        # transient failures up to 3x, then rewrap so callers get a regular
+        # Exception subclass.
+        try:
+            return self._run_once(fn)
+        except TeslaFleetError as e:
+            raise TeslaAPIError(f"{type(e).__name__}: {e}") from e
 
     def get_energy_sites(self) -> List[Dict[str, Any]]:
         async def call(oauth: TeslaFleetOAuth) -> List[Dict[str, Any]]:

--- a/Tesla/test_tesla_client.py
+++ b/Tesla/test_tesla_client.py
@@ -3,14 +3,23 @@
 
 import sys
 import unittest
+from typing import Any, Awaitable, Callable
 from unittest.mock import MagicMock, patch
 
 sys.modules.setdefault("lib", MagicMock())
 sys.modules.setdefault("lib.logger", MagicMock())
 
 from tesla_fleet_api.exceptions import InternalServerError, TeslaFleetError  # noqa: E402
+from tesla_fleet_api.tesla import TeslaFleetOAuth  # noqa: E402
 
 from Tesla.tesla_client import TeslaAPIClient, TeslaAPIError  # noqa: E402
+
+
+async def _noop(_oauth: TeslaFleetOAuth) -> Any:  # placeholder for the Callable type
+    return None
+
+
+_FN: Callable[[TeslaFleetOAuth], Awaitable[Any]] = _noop
 
 
 def _make_client() -> TeslaAPIClient:
@@ -20,31 +29,31 @@ def _make_client() -> TeslaAPIClient:
 
 
 class TestRetryAndRewrap(unittest.TestCase):
-    def test_success_no_retry(self):
+    def test_success_no_retry(self) -> None:
         client = _make_client()
         with patch("Tesla.tesla_client.asyncio.run", return_value="ok") as run:
-            self.assertEqual(client._run(lambda oauth: None), "ok")
+            self.assertEqual(client._run(_FN), "ok")
             self.assertEqual(run.call_count, 1)
 
-    def test_transient_then_success(self):
+    def test_transient_then_success(self) -> None:
         client = _make_client()
         side_effects = [InternalServerError({"error": "boom"}), "ok"]
         with patch("Tesla.tesla_client.asyncio.run", side_effect=side_effects) as run:
             with patch("time.sleep"):  # tenacity uses time.sleep
-                self.assertEqual(client._run(lambda oauth: None), "ok")
+                self.assertEqual(client._run(_FN), "ok")
         self.assertEqual(run.call_count, 2)
 
-    def test_gives_up_after_three_and_rewraps(self):
+    def test_gives_up_after_three_and_rewraps(self) -> None:
         client = _make_client()
         boom = InternalServerError({"error": "boom"})
         with patch("Tesla.tesla_client.asyncio.run", side_effect=[boom, boom, boom]) as run:
             with patch("time.sleep"):
                 with self.assertRaises(TeslaAPIError) as ctx:
-                    client._run(lambda oauth: None)
+                    client._run(_FN)
         self.assertEqual(run.call_count, 3)
         self.assertIsInstance(ctx.exception.__cause__, TeslaFleetError)
 
-    def test_teslaapierror_is_exception_not_baseexception_only(self):
+    def test_teslaapierror_is_exception_not_baseexception_only(self) -> None:
         # Guard against regression where callers can't catch Tesla errors with
         # `except Exception`.
         self.assertTrue(issubclass(TeslaAPIError, Exception))

--- a/Tesla/test_tesla_client.py
+++ b/Tesla/test_tesla_client.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Unit tests for Tesla/tesla_client.py — retry + TeslaFleetError rewrap."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("lib", MagicMock())
+sys.modules.setdefault("lib.logger", MagicMock())
+
+from tesla_fleet_api.exceptions import InternalServerError, TeslaFleetError  # noqa: E402
+
+from Tesla.tesla_client import TeslaAPIClient, TeslaAPIError  # noqa: E402
+
+
+def _make_client() -> TeslaAPIClient:
+    client = TeslaAPIClient.__new__(TeslaAPIClient)
+    client.logger = MagicMock()
+    return client
+
+
+class TestRetryAndRewrap(unittest.TestCase):
+    def test_success_no_retry(self):
+        client = _make_client()
+        with patch("Tesla.tesla_client.asyncio.run", return_value="ok") as run:
+            self.assertEqual(client._run(lambda oauth: None), "ok")
+            self.assertEqual(run.call_count, 1)
+
+    def test_transient_then_success(self):
+        client = _make_client()
+        side_effects = [InternalServerError({"error": "boom"}), "ok"]
+        with patch("Tesla.tesla_client.asyncio.run", side_effect=side_effects) as run:
+            with patch("time.sleep"):  # tenacity uses time.sleep
+                self.assertEqual(client._run(lambda oauth: None), "ok")
+        self.assertEqual(run.call_count, 2)
+
+    def test_gives_up_after_three_and_rewraps(self):
+        client = _make_client()
+        boom = InternalServerError({"error": "boom"})
+        with patch("Tesla.tesla_client.asyncio.run", side_effect=[boom, boom, boom]) as run:
+            with patch("time.sleep"):
+                with self.assertRaises(TeslaAPIError) as ctx:
+                    client._run(lambda oauth: None)
+        self.assertEqual(run.call_count, 3)
+        self.assertIsInstance(ctx.exception.__cause__, TeslaFleetError)
+
+    def test_teslaapierror_is_exception_not_baseexception_only(self):
+        # Guard against regression where callers can't catch Tesla errors with
+        # `except Exception`.
+        self.assertTrue(issubclass(TeslaAPIError, Exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Powerwall monitor was restarting ~every few hours. Root cause: `tesla_fleet_api.exceptions.TeslaFleetError` subclasses **`BaseException`**, not `Exception`, so every upstream 5xx from Tesla's cloud bypassed the `except Exception` retry ladder in `manage_power.py:303` and fell through to the fatal reraise. The script then exited, slept 1h (churn guard), and got respawned. ~21 such events across the current + 2 rotated logs.

## Change

Wrap the sync boundary in `Tesla/tesla_client.py`:

- **Retry 3x with 2s fixed backoff** on `TeslaFleetError` via tenacity.
- **Rewrap** as `TeslaAPIError` (which is `Exception`-derived) so `manage_power.py`'s existing `except Exception` retry block catches persistent failures normally instead of the process dying.

The change is localized to `Tesla/tesla_client.py` — no changes needed in `manage_power.py`.

## Test plan

- [x] `uv run pytest Tesla/test_tesla_client.py Tesla/test_manage_power.py -v` — 13/13 pass
  - New tests cover: (1) success no retry, (2) transient-then-success on attempt 2, (3) gives up after 3 attempts and rewraps as `TeslaAPIError`, (4) `TeslaAPIError` is `Exception`-derived
- [x] `make ruff` — clean
- [ ] Deploy to aibo, tail `~/logs/manage_power.py.log`, verify no more `Exiting after 1-hour delay` events on transient 500s

## References

- Plan: `~/.claude/plans/check-on-why-powerwall-federated-zebra.md`
- Sample restart trace: `Tesla/manage_power.py:316` → `:383` → `:396` (see aibo `~/logs/manage_power.py.log`)
- Upstream quirk: `.venv/lib/python3.13/site-packages/tesla_fleet_api/exceptions.py:6` — `class TeslaFleetError(BaseException)`