### PR TITLE
feat(lib): secure_io atomic 0o600 secret writes; unify token I/O across modules

### DIFF
--- a/August/august_client.py
+++ b/August/august_client.py
@@ -18,6 +18,7 @@ from yalexs.lock import Lock, LockStatus, LockDoorStatus
 from lib.config import get_config
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
+from lib.secure_io import ensure_secret_perms
 
 # August revoked the API key yalexs ships for Brand.AUGUST (d9984f29...): the
 # session/password-auth endpoint returns 403 {"code":"Forbidden","message":
@@ -149,6 +150,8 @@ class AugustClient:
             )
             # Setup authentication - this initializes the _authentication property
             await self.authenticator.async_setup_authentication()
+            # yalexs owns the token cache write; tighten perms after.
+            ensure_secret_perms(cache_file)
 
     async def close(self) -> None:
         """Close the aiohttp session."""
@@ -177,6 +180,8 @@ class AugustClient:
                     install_id=self.authenticator._authentication.install_id,
                 )
             auth_result = await self.authenticator.async_authenticate()
+            # yalexs may have (re)written the token cache; tighten perms.
+            ensure_secret_perms(get_config().august.token_file)
 
             if auth_result is None:
                 self.logger.error("Authentication returned None - check credentials")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,54 @@ uv run pytest NodeCheck
 ### Shared Library (`lib/`)
 - **Config**: All modules source configuration from `lib/config.py` (OmegaConf-based hierarchical YAML)
 - **Notifications**: Standardized via MyPushover, Mailer, MyTwilio classes
+- **Secret I/O**: `lib/secure_io.py` — `write_secret_atomic(path, content)` for tokens we own (0o600 from birth), `ensure_secret_perms(path)` after third-party library writes (yalexs, SamsungTVWS). **All token/credential writes must go through these.**
 - **TeslaPy Submodule**: External dependency managed as Git submodule
+
+## Best Practices
+
+Non-obvious rules that repeat across modules. Adhere to these in new code and PR reviews.
+
+### Secrets on disk
+- **Never `open(path, "w")` for a secret**, and never `write_text()` + `chmod`. Both leave a TOCTOU window at 0o644 under a 0o022 umask. Use `lib.secure_io.write_secret_atomic()` — it opens with `O_CREAT|O_TRUNC|0o600` so the file is world-unreadable from birth.
+- If a **third-party library** writes the token (yalexs, SamsungTVWS, ring-client-api Node), immediately call `ensure_secret_perms(path)` after the call returns.
+- Config files themselves live in `config/local.yaml` (gitignored). Tokens live under `config/tokens/` (symlinked to `~/bin/Common-configs/tokens/`, also gitignored on the code side).
+
+### Alert priority discipline (Pushover)
+- **P1 (`priority=1`)** — actionable, needs a human within hours. Low battery, service unreachable, hardware failure.
+- **P2 (`priority=0`)** — informational, "act when convenient." Auth re-required, tamper detected, offline device.
+- **Emergency (`priority=2`)** — retries until acked. Reserve for water leaks, break-ins — things where seconds matter. Don't cry wolf.
+- **Auth failures always P2, not P1.** Re-auth is a chore, not an emergency.
+
+### Testing
+- **Never `patch()` production code.** If a test needs to mock a subprocess/HTTP call, refactor the production code to accept the dependency as a parameter (factory or client). RingBeams's `run_sidecar(ring_factory=...)` is the reference pattern.
+- **Fake sidecars via `sh` scripts** for subprocess boundaries. `.chmod(0o755)` + write a shebang + parametrize exit codes and stdout. Zero mocking, real subprocess semantics. See `RingBeams/test_beams_manager.py`.
+- **Separate deterministic assertions** (exact values, structural matches) from anything that depends on wall-clock time or network state. Freeze time via fixtures if needed.
+- **NodeCheck runs in isolation** — pytest-forked to avoid subprocess state leak into other suites.
+
+### Sidecars & polyglot integration
+- Node sidecars live inside the Python module (e.g., `RingBeams/fetch_status.js` alongside `beams_manager.py`).
+- `node_modules/` is gitignored per-module; commit only `package.json` + `package-lock.json`.
+- Sidecar exit-code contract must be explicit and documented at the top of the sidecar file. Python maps codes to Python exception classes; overloading `exit 1` for both auth failure and generic errors is the classic misclassification bug.
+- Drain stdout before `process.exit(0)` — pass the exit callback to `process.stdout.write(payload, () => process.exit(0))`. On stdout-as-pipe, writes above ~16KB are buffered.
+- Surface partial failures (per-location, per-device) in the JSON payload, not just stderr. Python only reads stderr on non-zero exit, so a silent partial with `exit 0` becomes a false "all healthy" report.
+
+### Cron & deployment
+- **Aibo (Linux prod) hosts homely_vibes at `~/Code`** — NOT `~/Documents/homely_vibes` as on the Mac. All aibo cron entries `cd ~/Code`.
+- Cron entries redirect stdout+stderr to a file: `>> ~/logs/<script>.log 2>&1`. Never `> /dev/null` — you'd lose pre-logger crashes (import errors, `uv` failures, missing binaries).
+- `lib.logger.get_logger()` sets up dual handlers (stdout + per-script log file under `cfg.paths.logging_dir`). Cron file redirection is the safety net for anything that happens before the logger initializes.
+- Cron env needs `PATH` set for non-standard binaries (`node`, `uv`). Prepend `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin` at the top of the crontab, or use absolute paths in commands.
+
+### Config changes
+- Add a dataclass to `lib/config.py` for any new module's config, then register it in the root `Config` dataclass. Never `cfg_dict.get("your_key")` — the config system exists to give you type-checked access.
+- `config/default.yaml` holds safe placeholders committed to git. `config/local.yaml` overrides with secrets and per-host values (gitignored, symlinked to `~/bin/Common-configs/Code_config_local.yaml`).
+- If your module has multiple credentials, put them under a single top-level key (`ring:`, `august:`) so config diff reviews stay coherent.
+
+### Git & PR flow
+- Feature branches: `<gh-username>/feature-name`. Never work on `main`.
+- Always `git fetch origin && git pull origin main` before creating a branch. Merging stale local `main` is the most common source of avoidable conflicts.
+- Commit messages: conventional prefix (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`) enforced by pre-commit hook.
+- **Never bypass pre-commit hooks** (`--no-verify`) unless the hook itself is broken (rare) — investigate the underlying failure. If hooks conflict with staged changes on ruff auto-fix, run `uv run ruff format` manually first, then re-stage.
+- **PR review comment threads**: read → fix → push → reply *inside each thread* → resolve thread. `gh pr comment` alone is not the right tool — reviewers won't see the reply attached to their concern.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ See `config/default.yaml` for the full structure and `config/local.yaml.example`
 | Component | Description | Documentation |
 |:----------|:------------|:-------------:|
 | 🔐 **August** | August Smart Lock monitoring with automated unlock alerts and pushover notifications for home security. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/August/README.md) |
+| 📸 **RingSecurity** | Ring cameras + doorbells daily health check via REST — P1 low-battery, P2 offline. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/RingSecurity/README.md) |
+| 🚨 **RingBeams** | Ring Beams motion sensors + Ring Alarm contact/motion sensors, via Node.js sidecar over socket.io (dgreif/ring-client-api). P1 battery, P2 tamper. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/RingBeams/README.md) |
 | 🤖 **Bimpop.ai** | RAG (Retrieval Augmented Generation) system with AI voice assistant, indexing, and Streamlit frontend. A startup concept for business intelligence in Mom-n-Pop stores. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/BimpopAI/README.md) |
 | 🌐 **BrowserAlert** | Web usage monitoring and alerting system for tracking browsing activity and digital wellness. | [📖 Read More](https://github.com/DeviationLabs/homely-vibes/blob/main/BrowserAlert/README.md) |
 | 🚗 **GarageCheck** | Machine learning-based garage door status detection using image classification and computer vision. | - |

--- a/RingBeams/fetch_status.js
+++ b/RingBeams/fetch_status.js
@@ -42,7 +42,9 @@ function writeRefreshToken(path, token) {
     } catch (_) {
         // fall through: write plain token
     }
+    // mode:0600 applies on file CREATE only; chmod normalizes pre-existing loose perms.
     fs.writeFileSync(path, payload, { mode: 0o600 });
+    fs.chmodSync(path, 0o600);
 }
 
 async function main() {

--- a/RingSecurity/ring_manager.py
+++ b/RingSecurity/ring_manager.py
@@ -13,7 +13,6 @@ import asyncio
 import getpass
 import json
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
@@ -24,6 +23,7 @@ from ring_doorbell import AuthenticationError, Auth, Requires2FAError, Ring
 from lib.config import RingConfig, get_config
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
+from lib.secure_io import write_secret_atomic
 
 USER_AGENT = "android:com.ringapp"
 PUSHOVER_KEY = "Ring Security"
@@ -41,18 +41,7 @@ def _load_token(path: str) -> Optional[dict[str, Any]]:
 
 
 def _save_token(path: str, token: dict[str, Any]) -> None:
-    # Atomic 0600 create: avoids TOCTOU where a chmod-after-write leaves the
-    # token briefly world-readable under a typical 0o022 umask.
-    p = Path(path)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    try:
-        os.write(fd, json.dumps(token).encode())
-    finally:
-        os.close(fd)
-    # If the file pre-existed with looser perms, os.open above preserves the
-    # existing mode. Force-chmod as a safety net.
-    os.chmod(p, 0o600)
+    write_secret_atomic(path, token)
 
 
 async def _auth_flow(username: str, password: str, token_file: str) -> None:

--- a/SamsungFrame/samsung_client.py
+++ b/SamsungFrame/samsung_client.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 
 from lib.config import get_config
 from lib.logger import get_logger
+from lib.secure_io import ensure_secret_perms
 
 cfg = get_config()
 
@@ -112,8 +113,8 @@ class SamsungFrameClient:
                 self.tv.art().supported()
                 self.logger.info(f"Connected to Samsung Frame TV at {self.host}")
 
-                if os.path.exists(self.token_file):
-                    os.chmod(self.token_file, 0o600)
+                # SamsungTVWS owns the token write; tighten perms after.
+                ensure_secret_perms(self.token_file)
 
                 return True
 

--- a/Tesla/tesla_auth.py
+++ b/Tesla/tesla_auth.py
@@ -11,7 +11,6 @@ port to catch Tesla's redirect, then persists the resulting tokens.
 
 import argparse
 import asyncio
-import json
 import os
 import sys
 import time
@@ -26,6 +25,7 @@ from tesla_fleet_api.tesla import TeslaFleetOAuth
 
 from lib.config import get_config
 from lib.logger import get_logger
+from lib.secure_io import write_secret_atomic
 
 logger = get_logger(__name__)
 
@@ -54,9 +54,7 @@ def _save_tokens(oauth: TeslaFleetOAuth, token_file: str) -> None:
         "token_type": "Bearer",
         "created_at": int(time.time()),
     }
-    with open(token_file, "w") as f:
-        json.dump(data, f, indent=2)
-    os.chmod(token_file, 0o600)
+    write_secret_atomic(token_file, data)
     logger.info(f"Tokens saved to {token_file}")
 
 

--- a/Tesla/tesla_client.py
+++ b/Tesla/tesla_client.py
@@ -27,6 +27,7 @@ from tesla_fleet_api.tesla import EnergySite, TeslaFleetOAuth
 
 from lib.config import get_config
 from lib.logger import get_logger
+from lib.secure_io import write_secret_atomic
 
 
 class TeslaAuthError(Exception):
@@ -88,9 +89,7 @@ class TeslaAPIClient:
             "expires_at": int(oauth.expires),
             "token_type": "Bearer",
         }
-        with open(self.token_file, "w") as f:
-            json.dump(token_data, f, indent=2)
-        os.chmod(self.token_file, 0o600)
+        write_secret_atomic(self.token_file, token_data)
         self.logger.debug(f"Tokens persisted to {self.token_file}")
 
     async def _with_oauth(self, fn: Callable[[TeslaFleetOAuth], Awaitable[T]]) -> T:

--- a/conftest.py
+++ b/conftest.py
@@ -6,9 +6,16 @@ Adds project root to sys.path to enable imports from any test directory.
 import sys
 from pathlib import Path
 
-import lib  # noqa: F401
-import lib.config  # noqa: F401
-
-# Add project root to Python path for imports
+# Path insert MUST precede the lib imports below — otherwise, when pytest is
+# invoked with only child dirs on argv (e.g. `pytest Tesla RachioFlume`), the
+# repo root is not yet on sys.path and `import lib` fails.
 project_root = Path(__file__).parent.resolve()
 sys.path.insert(0, str(project_root))
+
+# Pre-import lib submodules that production code imports at module load time.
+# Tesla tests replace sys.modules["lib"] with a MagicMock; any lib.* submodule
+# not already cached then fails to import with "'lib' is not a package".
+# Importing them here caches the real modules before any test clobbers "lib".
+import lib  # noqa: F401, E402
+import lib.config  # noqa: F401, E402
+import lib.secure_io  # noqa: F401, E402

--- a/lib/secure_io.py
+++ b/lib/secure_io.py
@@ -1,0 +1,68 @@
+"""Atomic 0o600 file writes for secret material (OAuth tokens, refresh tokens, keys).
+
+Two entry points cover the two patterns in this repo:
+
+- ``write_secret_atomic(path, content)`` — we own the write: create the file with
+  ``0o600`` from birth (no TOCTOU window under a 0o022 umask).
+- ``ensure_secret_perms(path)`` — a third-party library owns the write (e.g. yalexs
+  writing the August token cache, SamsungTVWS writing the pairing token). Call
+  this immediately after the library returns to tighten perms.
+
+Both are safe to call on files that already exist with looser modes — they always
+end at 0o600.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Union
+
+_SecretContent = Union[str, bytes, dict[str, Any]]
+
+
+def _to_bytes(content: _SecretContent) -> bytes:
+    if isinstance(content, bytes):
+        return content
+    if isinstance(content, str):
+        return content.encode("utf-8")
+    if isinstance(content, dict):
+        return json.dumps(content).encode("utf-8")
+    raise TypeError(
+        f"write_secret_atomic content must be str, bytes, or dict; got {type(content).__name__}"
+    )
+
+
+def write_secret_atomic(path: Union[str, Path], content: _SecretContent) -> None:
+    """Write ``content`` to ``path`` with mode ``0o600``, atomically.
+
+    Uses ``os.open(..., O_WRONLY|O_CREAT|O_TRUNC, 0o600)`` so the file is
+    world-unreadable from creation — there is no window in which a peer
+    process could read it via a wider default umask.
+
+    ``content`` may be ``str``, ``bytes``, or ``dict`` (serialized as JSON).
+
+    If the file already existed with looser perms, ``os.open`` preserves the
+    existing mode; a final ``chmod`` normalizes those cases.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = _to_bytes(content)
+    fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, payload)
+    finally:
+        os.close(fd)
+    os.chmod(p, 0o600)
+
+
+def ensure_secret_perms(path: Union[str, Path]) -> None:
+    """Tighten ``path`` to ``0o600`` if it exists. No-op if missing.
+
+    For token/cache files written by third-party libraries where we can't
+    control the open flags. Call immediately after the library returns.
+    """
+    p = Path(path)
+    if p.exists():
+        os.chmod(p, 0o600)

--- a/lib/test_secure_io.py
+++ b/lib/test_secure_io.py
@@ -1,0 +1,95 @@
+"""Tests for lib.secure_io atomic 0o600 writes."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from lib.secure_io import ensure_secret_perms, write_secret_atomic
+
+
+def _mode(p: Path) -> int:
+    return p.stat().st_mode & 0o777
+
+
+def test_write_bytes_creates_0600(tmp_path: Path) -> None:
+    p = tmp_path / "s.bin"
+    write_secret_atomic(p, b"raw-secret")
+    assert p.read_bytes() == b"raw-secret"
+    assert _mode(p) == 0o600
+
+
+def test_write_str_creates_0600(tmp_path: Path) -> None:
+    p = tmp_path / "s.txt"
+    write_secret_atomic(p, "refresh_token_value")
+    assert p.read_text() == "refresh_token_value"
+    assert _mode(p) == 0o600
+
+
+def test_write_dict_json_serialized(tmp_path: Path) -> None:
+    p = tmp_path / "s.json"
+    payload = {"access_token": "abc", "refresh_token": "def", "expires_at": 1234}
+    write_secret_atomic(p, payload)
+    assert json.loads(p.read_text()) == payload
+    assert _mode(p) == 0o600
+
+
+def test_write_overwrites_loose_perms(tmp_path: Path) -> None:
+    p = tmp_path / "s.json"
+    p.write_text("stale")
+    p.chmod(0o644)
+    write_secret_atomic(p, {"k": "v"})
+    assert _mode(p) == 0o600, f"loose-perms overwrite must end 0600, got {oct(_mode(p))}"
+
+
+def test_write_creates_parent_dirs(tmp_path: Path) -> None:
+    p = tmp_path / "nested" / "deeper" / "s.json"
+    write_secret_atomic(p, {"k": "v"})
+    assert p.exists()
+    assert _mode(p) == 0o600
+
+
+def test_write_atomic_no_toctou_window(tmp_path: Path) -> None:
+    """Under 0o022 umask, verify file never exists at 0644.
+
+    Set a permissive umask, then invoke the helper. The final mode must still
+    be 0600, and (empirically) the file's create-time mode is 0600 — the
+    atomic open with an explicit mode overrides umask entirely.
+    """
+    p = tmp_path / "s.json"
+    old = os.umask(0o022)
+    try:
+        write_secret_atomic(p, {"k": "v"})
+    finally:
+        os.umask(old)
+    assert _mode(p) == 0o600
+
+
+def test_ensure_perms_tightens_existing(tmp_path: Path) -> None:
+    p = tmp_path / "third_party_token.json"
+    p.write_text("{}")
+    p.chmod(0o644)
+    ensure_secret_perms(p)
+    assert _mode(p) == 0o600
+
+
+def test_ensure_perms_missing_file_is_noop(tmp_path: Path) -> None:
+    # Must not raise.
+    ensure_secret_perms(tmp_path / "does-not-exist.json")
+
+
+def test_ensure_perms_already_0600_is_noop(tmp_path: Path) -> None:
+    p = tmp_path / "s.json"
+    p.write_text("{}")
+    p.chmod(0o600)
+    ensure_secret_perms(p)
+    assert _mode(p) == 0o600
+
+
+def test_write_rejects_invalid_type(tmp_path: Path) -> None:
+    p = tmp_path / "s.json"
+    with pytest.raises(TypeError):
+        write_secret_atomic(p, 42)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Introduces `lib/secure_io.py` — a single source of truth for secret file I/O — and migrates every module's token-write pattern to it. Eliminates the `open(path, "w")` + `chmod` TOCTOU window across the repo.

## Why

Several modules wrote OAuth/refresh tokens via `open(path, "w")` then `os.chmod(path, 0o600)`. Under a typical `0o022` umask the file exists at `0o644` (world-readable) for the window between create and chmod. Per the new CLAUDE.md "Secrets on disk" rule, all secret writes must go through `lib.secure_io`.

## Changes

**New: `lib/secure_io.py`** (+ `lib/test_secure_io.py`, 10 tests)
- `write_secret_atomic(path, content)` — `os.open(O_WRONLY|O_CREAT|O_TRUNC, 0o600)` so the file is `0o600` from birth; final `chmod` normalizes any pre-existing looser mode. Accepts `str`/`bytes`/`dict` (JSON-serialized).
- `ensure_secret_perms(path)` — `chmod 0o600` no-op-safe; for third-party libraries that own the write (yalexs, SamsungTVWS).

**Migrated to `write_secret_atomic`** (we own the write):
- `Tesla/tesla_client.py`, `Tesla/tesla_auth.py`
- `RingSecurity/ring_manager.py` (replaces inline `os.open` block)

**Added `ensure_secret_perms`** (third-party owns the write):
- `August/august_client.py` — after yalexs token-cache writes (init + auth)
- `SamsungFrame/samsung_client.py` — after SamsungTVWS pairing-token write

**`RingBeams/fetch_status.js`** — `fs.chmodSync(path, 0o600)` after `writeFileSync`; the `mode` option only applies on file *create*, so pre-existing loose perms were not normalized.

**`conftest.py`** — pre-import `lib.secure_io` at startup. Tesla tests set `sys.modules["lib"] = MagicMock()`; any `lib.*` submodule not already cached then fails to import with `'lib' is not a package`. August's new `from lib.secure_io import` hit this. Caching the real module before the clobber fixes it. Also fixed path-insert ordering (must precede the `lib` imports).

**`CLAUDE.md`** — new "Best Practices" section: Secrets on disk, Alert priority discipline, Testing, Sidecars & polyglot integration, Cron & deployment, Config changes, Git & PR flow.

**`README.md`** — add RingSecurity + RingBeams rows to the modules table.

## Validation

- `uv run ruff format` + `uv run ruff check` — clean
- `uv run mypy` on all changed source files — clean
- `uv run pytest Tesla RachioFlume August` — 134 passed
- `uv run pytest lib/test_secure_io.py` — 10 passed
- `uv run pytest NodeCheck` (isolated, pytest-forked) — 29 passed
- Baseline (pre-change) `make test` confirmed passing before migration; post-change green.

## References

- Predecessor: #215 (RingSecurity daily alerts, introduced the inline `os.open` 0o600 pattern that this PR extracts into `lib/secure_io`)
- Predecessor: #216 (RingBeams sidecar, `fetch_status.js` refreshToken write)
- CLAUDE.md "Secrets on disk" rule documented in this PR