### PR TITLE
fix(NetworkCheck): route speedtest priority + shorten Rachio/Ring titles

### DIFF
--- a/NetworkCheck/test_uplink.py
+++ b/NetworkCheck/test_uplink.py
@@ -117,6 +117,12 @@ def run_speedtest() -> Tuple[Optional[SpeedTestResult], str]:
 
         return result, message
 
+    except subprocess.CalledProcessError as e:
+        # Preserve stderr (captured into e.output via stderr=STDOUT); str(e) drops it.
+        stderr_tail = (e.output or "").strip().splitlines()[-5:]
+        error_msg = f"Speedtest failed (exit {e.returncode}): {' | '.join(stderr_tail)}"
+        logger.error(error_msg)
+        return None, error_msg
     except Exception as e:
         error_msg = f"Speedtest failed: {e}"
         logger.error(error_msg)
@@ -148,12 +154,14 @@ def main() -> None:
     alert = True
     attempt = 0
     all_messages = []
+    last_result: Optional[SpeedTestResult] = None
 
     while alert and attempt < args.max_retries:
         attempt += 1
         logger.info(f"Speed test attempt {attempt}/{args.max_retries}")
 
         result, message = run_speedtest()
+        last_result = result
 
         print(message)
         logger.info(message)
@@ -185,7 +193,14 @@ def main() -> None:
         alert=alert,
     )
 
-    pushover.send_message(final_message, title="SpeedTest", priority=-1)
+    # Priority: good → -1 (silent), degraded → 0 (normal), failed/no-result → 1 (P1).
+    if last_result and last_result.is_good:
+        priority = -1
+    elif last_result and last_result.is_degraded:
+        priority = 0
+    else:
+        priority = 1
+    pushover.send_message(final_message, title="SpeedTest", priority=priority)
 
     logger.info("Speed test completed")
 

--- a/RachioFlume/README.md
+++ b/RachioFlume/README.md
@@ -9,7 +9,7 @@ A Python integration that connects Rachio irrigation controllers with Flume wate
 - **Data Correlation**: Match watering events with water usage patterns
 - **Smart Hose Timer support** (`rachio_hose_client.py`, `hose_timer_processor.py`): Rachio Smart Hose Timer base stations exposed via `cloud-rest.rach.io` alongside the controller. Runs detected via `lastWateringAction` state polling; flow stats from Flume.
 - **Usage Alerts** (`alert_engine.py`):
-  - **Single dispatch per zone end**: One Pushover per zone end — `RachioFlume: Zone Report` (P-1) below anomaly threshold, `RachioFlume: Zone Anomaly` (P2) above. Never both. Includes runtime, avg GPM, `(thresh X.XX)` (computed anomaly threshold), Total, and Deviation line on anomalies.
+  - **Single dispatch per zone end**: One Pushover per zone end — `Rachio Zone Report` (P-1) below anomaly threshold, `Rachio Zone Anomaly` (P2) above. Never both. Includes runtime, avg GPM, `(thresh X.XX)` (computed anomaly threshold), Total, and Deviation line on anomalies.
   - **Zone anomaly detection**: Per-zone baselines under `rachio_flume.alerts.zone_anomaly.zone_thresholds`, keyed by device label then zone identifier (controller: stringified `zone_number`; hose-timer: valve name). Threshold formula: `avg_gpm + max(absolute_gpm, percent_above/100 × avg_gpm)`.
   - **Default flow rules** (whole-house, Flume-only): Pipe Break / High Flow / Mid Flow / Leak — P2 (emergency), at most once per day per rule. CV-based variance filter rejects spiky noise on low-flow rules.
   - **Cross-source suppression**: Controller-active OR hose-timer-active state suppresses Flume rules for `max_rule_duration + 10min` slack. Symmetric.
@@ -144,8 +144,8 @@ Key behaviors:
 
 - **One Pushover per zone end** — `_send_zone_outcome` on both AlertEngine and
   HoseTimerProcessor picks `(title, priority)` based on whether measured flow
-  exceeds the anomaly threshold. Either `RachioFlume: Zone Report` (P-1) OR
-  `RachioFlume: Zone Anomaly` (P2). Never both. Anomaly variant adds a
+  exceeds the anomaly threshold. Either `Rachio Zone Report` (P-1) OR
+  `Rachio Zone Anomaly` (P2). Never both. Anomaly variant adds a
   `Deviation: +X.XX GPM (Y%)` line. Both variants include `Total: N.N gal`.
 - **Unified threshold value** — the `(thresh X.XX)` shown on every zone-end
   report is the computed anomaly trigger value, matching what actually fires.

--- a/RachioFlume/alert_rules.py
+++ b/RachioFlume/alert_rules.py
@@ -183,9 +183,9 @@ def send_zone_outcome_pushover(
         lines.extend(line for line in extra_lines if line)
 
     if is_anomaly:
-        title, priority = "RachioFlume: Zone Anomaly", 2
+        title, priority = "Rachio Zone Anomaly", 2
     else:
-        title, priority = "RachioFlume: Zone Report", -1
+        title, priority = "Rachio Zone Report", -1
 
     pushover.send_message("\n".join(lines), title=title, priority=priority)
     logger.info(

--- a/RachioFlume/test_alert_rules_helpers.py
+++ b/RachioFlume/test_alert_rules_helpers.py
@@ -68,7 +68,7 @@ class TestSendZoneOutcomePushover:
         send_zone_outcome_pushover(**kw)
         kw["pushover"].send_message.assert_called_once()
         _, call_kwargs = kw["pushover"].send_message.call_args
-        assert call_kwargs["title"] == "RachioFlume: Zone Report"
+        assert call_kwargs["title"] == "Rachio Zone Report"
         assert call_kwargs["priority"] == -1
 
     def test_anomaly_above_threshold(self) -> None:
@@ -77,7 +77,7 @@ class TestSendZoneOutcomePushover:
         send_zone_outcome_pushover(**kw)
         kw["pushover"].send_message.assert_called_once()
         args, call_kwargs = kw["pushover"].send_message.call_args
-        assert call_kwargs["title"] == "RachioFlume: Zone Anomaly"
+        assert call_kwargs["title"] == "Rachio Zone Anomaly"
         assert call_kwargs["priority"] == 2
         # Deviation line appended for anomaly path
         assert "Deviation:" in args[0]

--- a/RachioFlume/test_hose_timer.py
+++ b/RachioFlume/test_hose_timer.py
@@ -220,7 +220,7 @@ class TestZoneOutcomeDispatch:
         )
         call = self._outcome_call(pushover)
         assert call[1]["priority"] == -1
-        assert call[1]["title"] == "RachioFlume: Zone Report"
+        assert call[1]["title"] == "Rachio Zone Report"
         assert "Deviation" not in call[0][0]
         assert "'Upper Deck Planters' @ Hose Drip Jasmine" in call[0][0]
 
@@ -233,7 +233,7 @@ class TestZoneOutcomeDispatch:
         )
         call = self._outcome_call(pushover)
         assert call[1]["priority"] == 2
-        assert call[1]["title"] == "RachioFlume: Zone Anomaly"
+        assert call[1]["title"] == "Rachio Zone Anomaly"
         body = call[0][0]
         assert "Deviation" in body
         assert "Total: 15.0 gal" in body

--- a/RingBeams/beams_manager.py
+++ b/RingBeams/beams_manager.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Optional
 
 from lib.config import RingBeamsConfig, get_config
+from lib.file_lock import LockTimeoutError, acquire_lock
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
 
@@ -200,10 +201,19 @@ def main() -> None:
     cfg = get_config()
     pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens[PUSHOVER_KEY])
     try:
-        devices, errors = run_sidecar(cfg.ring_beams, logger)
+        # Serialize against RingSecurity — both share cfg.ring_beams.token_file
+        # (== cfg.ring.token_file); Ring OAuth rotates the refresh_token on
+        # every use. Parent Python holds the flock across the Node sidecar
+        # spawn; the child inherits serialization implicitly.
+        with acquire_lock(cfg.ring_beams.token_file):
+            devices, errors = run_sidecar(cfg.ring_beams, logger)
         logger.info(f"Fetched {len(devices)} devices from sidecar ({len(errors)} location errors)")
         low, tamper = classify(devices, cfg.ring_beams.battery_threshold_pct)
         notify(pushover, low, tamper, errors, logger)
+    except LockTimeoutError as e:
+        logger.error(f"Ring token lock timeout: {e}")
+        pushover.send_message(str(e), title="Ring: Token Lock Timeout", priority=1)
+        sys.exit(1)
     except BeamsAuthError as e:
         logger.error(f"Ring Beams auth failure: {e}")
         pushover.send_message(str(e), title="Ring: Auth Required", priority=0)

--- a/RingBeams/beams_manager.py
+++ b/RingBeams/beams_manager.py
@@ -100,13 +100,23 @@ def run_sidecar(
         except Exception:
             msg = proc.stderr.strip() or "sidecar failed with no stderr"
         # Sidecar exit-code contract (see fetch_status.js):
-        #   1  auth/list-locations failure (bad or missing token)
-        #   3  token file unreadable
-        #   4  post-auth unhandled exception (parsing bug, etc.)
-        # 1 and 3 → auth class; 4 is generic (must not misroute to "re-auth").
-        if proc.returncode in (1, 3):
+        #   1  uncaught Node crash / module-load (reserved for Node itself)
+        #   2  missing env var
+        #   3  token file unreadable          → auth class
+        #   4  post-auth unhandled exception
+        #   5  auth/list-locations failure    → auth class
+        # Only 3 and 5 are auth. Exit 1 is a Node crash (e.g. undici requiring
+        # global `File` on Node <20) and MUST NOT route to "Auth Required".
+        if proc.returncode in (3, 5):
             raise BeamsAuthError(msg)
         raise RuntimeError(f"sidecar exit={proc.returncode}: {msg}")
+
+    # Sidecar succeeded but may have emitted structured warnings on stderr
+    # (e.g. TOKEN_WRITE_FAILED — server rotated refresh_token but our write
+    # threw, leaving the file with an already-consumed token). Log them so
+    # the next RingSecurity invalid_grant is traceable.
+    if proc.stderr.strip():
+        logger.warning(f"sidecar stderr on success: {proc.stderr.strip()}")
 
     try:
         payload = json.loads(proc.stdout)

--- a/RingBeams/beams_manager.py
+++ b/RingBeams/beams_manager.py
@@ -164,16 +164,16 @@ def notify(
     if low:
         body = "\n".join(low)
         logger.info(f"Low battery alert: {body}")
-        pushover.send_message(body, title="Ring Beams/Alarm: Low Battery", priority=1)
+        pushover.send_message(body, title="Ring: Low Battery", priority=1)
     if tamper:
         body = "\n".join(tamper)
         logger.info(f"Tamper alert: {body}")
-        pushover.send_message(body, title="Ring Beams/Alarm: Tamper", priority=0)
+        pushover.send_message(body, title="Ring: Tamper", priority=0)
     if errors:
         # Partial-location failure — coverage was incomplete, mustn't look healthy.
         body = "\n".join(errors)
         logger.error(f"Sidecar partial failure: {body}")
-        pushover.send_message(body, title="Ring Beams/Alarm: Partial Sidecar Failure", priority=1)
+        pushover.send_message(body, title="Ring: Partial Sidecar Failure", priority=1)
     if not low and not tamper and not errors:
         logger.info("All Ring Beams/Alarm sensors healthy.")
 
@@ -196,11 +196,11 @@ def main() -> None:
         notify(pushover, low, tamper, errors, logger)
     except BeamsAuthError as e:
         logger.error(f"Ring Beams auth failure: {e}")
-        pushover.send_message(str(e), title="Ring Beams: Auth Required", priority=0)
+        pushover.send_message(str(e), title="Ring: Auth Required", priority=0)
         sys.exit(1)
     except Exception as e:
         logger.error(f"Ring Beams check failed: {e}")
-        pushover.send_message(str(e), title="Ring Beams: Error", priority=1)
+        pushover.send_message(str(e), title="Ring: Error", priority=1)
         sys.exit(1)
 
 

--- a/RingBeams/fetch_status.js
+++ b/RingBeams/fetch_status.js
@@ -9,7 +9,18 @@
 //
 // stdout: {"devices": [{zid, name, deviceType, categoryId, batteryLevel,
 //                       batteryStatus, tamperStatus, faulted, locationName}, ...]}
-// stderr: {"error": "<msg>"} on failure; exit code 1..3 signals class of error.
+// Exit-code contract (stderr carries a JSON {"error": "..."} on 2/3/4/5; on
+// exit 1 stderr is a raw Node stack trace with no JSON envelope):
+//   0  success
+//   1  uncaught Node crash / module-load failure (reserved for Node itself)
+//   2  missing RING_BEAMS_TOKEN_FILE env var
+//   3  token file unreadable / malformed         → auth-class
+//   4  post-auth unhandled JS exception
+//   5  auth / list-locations failure (bad token) → auth-class
+// Python (beams_manager.run_sidecar) maps 3 and 5 to BeamsAuthError; every
+// other non-zero code is a generic RuntimeError so a Node-version drift (e.g.
+// undici requiring global File on Node <20) does NOT get misclassified as
+// "Ring: Auth Required".
 import { RingApi } from 'ring-client-api';
 import fs from 'node:fs';
 
@@ -42,9 +53,12 @@ function writeRefreshToken(path, token) {
     } catch (_) {
         // fall through: write plain token
     }
-    // mode:0600 applies on file CREATE only; chmod normalizes pre-existing loose perms.
-    fs.writeFileSync(path, payload, { mode: 0o600 });
-    fs.chmodSync(path, 0o600);
+    // Atomic write: tmp file with 0o600 from birth, then rename over. Matches
+    // lib/secure_io.write_secret_atomic — a partial or crashed write can never
+    // leave the token file empty and page RingSecurity with invalid_grant.
+    const tmp = `${path}.tmp.${process.pid}`;
+    fs.writeFileSync(tmp, payload, { mode: 0o600 });
+    fs.renameSync(tmp, path);
 }
 
 async function main() {
@@ -65,8 +79,17 @@ async function main() {
         if (newRefreshToken) {
             try {
                 writeRefreshToken(tokenFile, newRefreshToken);
-            } catch (_) {
-                // best effort; next run will retry
+            } catch (e) {
+                // Ring rotated server-side but our write failed — the file now
+                // holds an already-consumed token. Surface loudly so the next
+                // invalid_grant is diagnosable (Python's run_sidecar tees this
+                // to stderr → cron log). Don't exit non-zero: we still have a
+                // valid in-memory session and returning devices is more useful
+                // than paging on a token-write hiccup.
+                console.error(JSON.stringify({
+                    warn: `TOKEN_WRITE_FAILED: ${e.message}`,
+                    path: tokenFile,
+                }));
             }
         }
     });
@@ -76,7 +99,7 @@ async function main() {
         locations = await ring.getLocations();
     } catch (e) {
         console.error(JSON.stringify({ error: `auth/list-locations failed: ${e.message}` }));
-        process.exit(1);
+        process.exit(5);
     }
 
     const devices = [];

--- a/RingBeams/test_beams_manager.py
+++ b/RingBeams/test_beams_manager.py
@@ -133,14 +133,14 @@ def test_missing_token_raises_auth_error(tmp_path: Path, logger: logging.Logger)
         run_sidecar(cfg, logger)
 
 
-def test_sidecar_json_error_treated_as_auth(tmp_path: Path, logger: logging.Logger) -> None:
-    """Simulate a fake sidecar that exits 1 with JSON error — auth-class failure."""
+def test_sidecar_auth_failure_exit5_treated_as_auth(tmp_path: Path, logger: logging.Logger) -> None:
+    """Sidecar exit=5 with JSON error is the auth/list-locations failure class."""
     tok = tmp_path / "tok.json"
     tok.write_text('{"refresh_token": "fake"}')
     script = tmp_path / "fake_sidecar.js"
     # Not a real node file — we pass /bin/sh and pretend it's node.
     fake = tmp_path / "fake.sh"
-    fake.write_text('#!/bin/sh\necho \'{"error":"bad token"}\' >&2\nexit 1\n')
+    fake.write_text('#!/bin/sh\necho \'{"error":"bad token"}\' >&2\nexit 5\n')
     fake.chmod(0o755)
     cfg = RingBeamsConfig(
         token_file=str(tok),
@@ -149,6 +149,31 @@ def test_sidecar_json_error_treated_as_auth(tmp_path: Path, logger: logging.Logg
     )
     with pytest.raises(BeamsAuthError, match="bad token"):
         run_sidecar(cfg, logger, node_path=str(fake), script_path=str(script))
+
+
+def test_sidecar_exit1_node_crash_not_auth(tmp_path: Path, logger: logging.Logger) -> None:
+    """Node crash-at-load (exit=1 with raw stack, no JSON envelope) MUST route
+    to RuntimeError, not BeamsAuthError. This is the aibo 2026-07-04 case:
+    undici + Node 18 ReferenceError got misclassified as "Auth Required"."""
+    tok = tmp_path / "tok.json"
+    tok.write_text('{"refresh_token": "fake"}')
+    fake = tmp_path / "fake.sh"
+    # Raw stack trace on stderr, no {"error": "..."} envelope, exit 1.
+    fake.write_text(
+        "#!/bin/sh\n"
+        "echo 'ReferenceError: File is not defined' >&2\n"
+        "echo '    at Object.<anonymous>' >&2\n"
+        "exit 1\n"
+    )
+    fake.chmod(0o755)
+    cfg = RingBeamsConfig(
+        token_file=str(tok),
+        battery_threshold_pct=25,
+        sidecar_timeout_seconds=5,
+    )
+    with pytest.raises(RuntimeError, match="sidecar exit=1") as exc:
+        run_sidecar(cfg, logger, node_path=str(fake), script_path=str(tmp_path / "x.js"))
+    assert not isinstance(exc.value, BeamsAuthError)
 
 
 def test_sidecar_generic_error_not_misclassified_as_auth(
@@ -217,3 +242,36 @@ def test_sidecar_surfaces_partial_errors(tmp_path: Path, logger: logging.Logger)
     devs, errs = run_sidecar(cfg, logger, node_path=str(fake), script_path=str(tmp_path / "x.js"))
     assert len(devs) == 1
     assert errs == ["getDevices(Second Home): oops"]
+
+
+def test_sidecar_token_write_warn_on_stderr_is_logged_not_raised(
+    tmp_path: Path, logger: logging.Logger, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Sidecar exit=0 with a TOKEN_WRITE_FAILED warn on stderr: parse normally
+    and log the warning. Regression guard for the 2026-07-05 invalid_grant
+    scenario — the ring-client-api rotates refresh_token; if our write fails
+    silently, the next RingSecurity run gets invalid_grant. Surfacing the
+    warn line lets us diagnose the chain."""
+    tok = tmp_path / "tok.json"
+    tok.write_text('{"refresh_token": "fake"}')
+    fake = tmp_path / "fake.sh"
+    fake.write_text(
+        "#!/bin/sh\n"
+        'echo \'{"warn":"TOKEN_WRITE_FAILED: EACCES","path":"/tmp/tok"}\' >&2\n'
+        "cat <<EOF\n"
+        '{"devices":[{"name":"Mailbox","batteryLevel":90,"batteryStatus":"ok",'
+        '"tamperStatus":"ok"}]}\nEOF\n'
+    )
+    fake.chmod(0o755)
+    cfg = RingBeamsConfig(
+        token_file=str(tok),
+        battery_threshold_pct=25,
+        sidecar_timeout_seconds=5,
+    )
+    with caplog.at_level(logging.WARNING):
+        devs, errs = run_sidecar(
+            cfg, logger, node_path=str(fake), script_path=str(tmp_path / "x.js")
+        )
+    assert len(devs) == 1
+    assert errs == []
+    assert any("TOKEN_WRITE_FAILED" in r.message for r in caplog.records)

--- a/RingSecurity/ring_manager.py
+++ b/RingSecurity/ring_manager.py
@@ -21,6 +21,7 @@ import aiohttp
 from ring_doorbell import AuthenticationError, Auth, Requires2FAError, Ring
 
 from lib.config import RingConfig, get_config
+from lib.file_lock import LockTimeoutError, acquire_lock
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
 from lib.secure_io import write_secret_atomic
@@ -153,8 +154,17 @@ def main() -> None:
 
     pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens[PUSHOVER_KEY])
     try:
-        low, offline = asyncio.run(check_devices(cfg.ring, logger))
+        # Serialize against RingBeams (Node sidecar via beams_manager) — both
+        # read/write cfg.ring.token_file and Ring OAuth rotates refresh_token
+        # on every use. Held for the whole ring session (refresh happens
+        # inside ring-doorbell, not at a call site we control).
+        with acquire_lock(cfg.ring.token_file):
+            low, offline = asyncio.run(check_devices(cfg.ring, logger))
         notify(pushover, low, offline, logger)
+    except LockTimeoutError as e:
+        logger.error(f"Ring token lock timeout: {e}")
+        pushover.send_message(str(e), title="Ring: Token Lock Timeout", priority=1)
+        sys.exit(1)
     except RingAuthError as e:
         logger.error(f"Ring auth failure: {e}")
         pushover.send_message(str(e), title="Ring: Auth Required", priority=0)

--- a/lib/file_lock.py
+++ b/lib/file_lock.py
@@ -1,0 +1,71 @@
+"""POSIX advisory file lock for cross-process critical sections.
+
+Used to serialize Ring token refresh across RingSecurity (Python, ring-doorbell)
+and RingBeams (Node sidecar spawned by Python parent) — both read/write the
+same token file at config/tokens/ring_auth_token.json. Ring OAuth rotates the
+refresh_token on every use, so overlapping refreshes race the server and one
+side gets `invalid_grant`.
+
+Design notes:
+
+- ``fcntl.flock`` (POSIX BSD flock, LOCK_EX) is auto-released on process exit
+  including crash — no staleness detection or PID sentinels needed. Works on
+  both dev macOS and aibo Linux.
+- Locks a sibling ``<path>.lock`` file, NOT the resource itself. The resource
+  gets rewritten via tmp+rename (secure_io); an fd on the pre-rename inode
+  would point to a deleted file and the lock would silently dangle. The
+  sidecar ``.lock`` file is never renamed, so its inode stays stable.
+- Blocking acquire with a wall-clock timeout (default 60s). The daily cron
+  cadence is 5 min apart, so anything longer than 60s means something is
+  genuinely stuck — surface as ``TimeoutError`` rather than paging silently.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Union
+
+
+class LockTimeoutError(TimeoutError):
+    """Advisory lock was not acquired within the timeout window."""
+
+
+@contextmanager
+def acquire_lock(
+    resource_path: Union[str, Path],
+    *,
+    timeout_s: float = 60.0,
+    poll_interval_s: float = 0.5,
+) -> Iterator[None]:
+    """Acquire an exclusive advisory flock on ``<resource_path>.lock``.
+
+    Held for the ``with`` block; auto-released on exit (including exceptions
+    and process crash). Blocking acquire; raises ``LockTimeoutError`` if the
+    lock isn't obtained within ``timeout_s``.
+    """
+    lock_path = Path(str(resource_path) + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout_s
+    fd = None
+    try:
+        fd = lock_path.open("w")
+        while True:
+            try:
+                fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise LockTimeoutError(
+                        f"Could not acquire {lock_path} within {timeout_s}s"
+                    ) from None
+                time.sleep(poll_interval_s)
+        yield
+    finally:
+        if fd is not None:
+            try:
+                fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+            finally:
+                fd.close()

--- a/lib/test_file_lock.py
+++ b/lib/test_file_lock.py
@@ -1,0 +1,109 @@
+"""Tests for lib.file_lock — POSIX advisory flock for cross-process serialization.
+
+Uses real subprocesses (no patch()) to exercise actual flock semantics — a
+mocked flock would let the tests pass even if the real primitive was wrong.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from lib.file_lock import LockTimeoutError, acquire_lock
+
+
+def test_lock_creates_sibling_lockfile(tmp_path: Path) -> None:
+    resource = tmp_path / "token.json"
+    with acquire_lock(resource):
+        assert (tmp_path / "token.json.lock").exists()
+
+
+def test_lock_released_after_context_exit(tmp_path: Path) -> None:
+    resource = tmp_path / "token.json"
+    with acquire_lock(resource, timeout_s=1.0):
+        pass
+    # A second acquire should succeed immediately.
+    with acquire_lock(resource, timeout_s=1.0):
+        pass
+
+
+def test_lock_released_after_exception(tmp_path: Path) -> None:
+    resource = tmp_path / "token.json"
+    with pytest.raises(RuntimeError, match="boom"):
+        with acquire_lock(resource, timeout_s=1.0):
+            raise RuntimeError("boom")
+    # Lock must be released even after exception.
+    with acquire_lock(resource, timeout_s=1.0):
+        pass
+
+
+def test_second_holder_times_out(tmp_path: Path) -> None:
+    """A second process holding the lock blocks us; we time out cleanly."""
+    resource = tmp_path / "token.json"
+    holder_script = tmp_path / "holder.py"
+    holder_script.write_text(
+        "import sys, time\n"
+        "sys.path.insert(0, '" + str(Path(__file__).resolve().parent.parent) + "')\n"
+        "from lib.file_lock import acquire_lock\n"
+        f"with acquire_lock('{resource}', timeout_s=5.0):\n"
+        "    print('ACQUIRED', flush=True)\n"
+        "    time.sleep(3)\n"
+    )
+    holder = subprocess.Popen(
+        [sys.executable, str(holder_script)],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        # Wait for the holder to acquire.
+        assert holder.stdout is not None
+        line = holder.stdout.readline().strip()
+        assert line == "ACQUIRED", f"unexpected holder output: {line!r}"
+
+        start = time.monotonic()
+        with pytest.raises(LockTimeoutError):
+            with acquire_lock(resource, timeout_s=0.5, poll_interval_s=0.05):
+                pass
+        elapsed = time.monotonic() - start
+        # Should time out roughly at the timeout, not block forever.
+        assert 0.4 < elapsed < 2.0, f"timeout deviated: {elapsed:.2f}s"
+    finally:
+        holder.terminate()
+        holder.wait(timeout=5)
+
+
+def test_lock_released_when_holder_crashes(tmp_path: Path) -> None:
+    """POSIX flock auto-releases on process exit including SIGKILL — this is
+    why we use it instead of a PID sentinel. Regression guard for that
+    guarantee (would fail on any switch to mkdir/pidfile without cleanup)."""
+    resource = tmp_path / "token.json"
+    holder_script = tmp_path / "holder.py"
+    holder_script.write_text(
+        "import sys, time\n"
+        "sys.path.insert(0, '" + str(Path(__file__).resolve().parent.parent) + "')\n"
+        "from lib.file_lock import acquire_lock\n"
+        f"with acquire_lock('{resource}'):\n"
+        "    print('ACQUIRED', flush=True)\n"
+        "    time.sleep(60)\n"
+    )
+    holder = subprocess.Popen(
+        [sys.executable, str(holder_script)],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "ACQUIRED"
+        holder.kill()
+        holder.wait(timeout=5)
+        # Now we should be able to acquire quickly.
+        with acquire_lock(resource, timeout_s=2.0):
+            pass
+    finally:
+        if holder.poll() is None:
+            holder.terminate()
+            holder.wait(timeout=5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ DEP002 = [
 DEP003 = ["google", "streamlit", "BimpopAI", "PyObjCTools"]  # PyObjCTools comes via rumps → pyobjc
 
 [tool.pytest.ini_options]
-testpaths = ["Tesla", "RachioFlume", "NodeCheck", "August", "SamsungFrame", "VoiceNotes", "LaunchJobs", "RingSecurity", "RingBeams"]
+testpaths = ["Tesla", "RachioFlume", "NodeCheck", "August", "SamsungFrame", "VoiceNotes", "LaunchJobs", "RingSecurity", "RingBeams", "lib"]
 addopts = "-v --tb=short"
 asyncio_mode = "auto"
 


### PR DESCRIPTION
## Summary

Four related notification-quality fixes, all rooted in aibo cron alerts from 2026-07-04/05:

**1. SpeedTest priority routing + stderr capture** ([NetworkCheck/test_uplink.py](NetworkCheck/test_uplink.py))
- Was: `priority=-1` (silent) for every outcome. 5/5 speedtest failures on aibo produced no actionable alert.
- Now: outcome-driven — good → -1, degraded → 0, failed/no-result → 1 (P1).
- Also: `CalledProcessError.output` (Ookla stderr, captured via `stderr=STDOUT`) is now logged instead of dropped.

**2. Pushover title renames** (no behavior change, just shorter phone banners)
- `RachioFlume: Zone Report` → `Rachio Zone Report`
- `RachioFlume: Zone Anomaly` → `Rachio Zone Anomaly`
- `Ring Beams/Alarm: <X>` → `Ring: <X>`
- `Ring Beams: <X>` → `Ring: <X>`

**3. RingBeams sidecar: exit-code contract + atomic token write** ([RingBeams/fetch_status.js](RingBeams/fetch_status.js), [RingBeams/beams_manager.py](RingBeams/beams_manager.py))
- **Node crash misclassified as "Auth Required":** Node 18.19.1 + undici (`ReferenceError: File is not defined`) crashed the sidecar at module-load, and our contract used exit 1 for both "auth failure" and Node's default uncaught-crash exit. Moved auth to exit 5, reserved exit 1 for Node itself.
- **Silent token-write → next-run invalid_grant:** the Node sidecar swallowed `writeRefreshToken` errors with `catch (_)`. Now: atomic tmp+rename, and on failure emit a structured `TOKEN_WRITE_FAILED` warn on stderr. Python's `run_sidecar` now surfaces any stderr on the success path so it appears in the cron log.

**4. Cross-process flock on the shared Ring refresh_token** ([lib/file_lock.py](lib/file_lock.py))

The atomic writes in (3) close partial-write races, but they don't help if RingSecurity and RingBeams *overlap* — Ring OAuth rotates the refresh_token server-side on every use, so whichever process hits the endpoint first invalidates the other's token, and the second gets `invalid_grant`. This is the actual root cause of the 2026-07-05 05:05 "Ring: Auth Required" alert.

- New `lib.file_lock.acquire_lock()` — POSIX `fcntl.flock` on a sibling `<path>.lock` file, held for the full ring session lifetime.
- **RingSecurity** acquires around `asyncio.run(check_devices(...))`.
- **RingBeams** acquires around `run_sidecar(...)`; the Python parent holds the lock across the Node subprocess, so the Node child inherits serialization for free (Node stdlib has no `flock(2)`, so this avoids needing an npm dep).

Design notes:
- Lock a sibling `.lock` file, not the token itself — `secure_io` writes via tmp+rename which invalidates any fd on the old inode.
- 60s blocking timeout → `LockTimeoutError` → `Ring: Token Lock Timeout` P1. Daily cron is 5min apart, so hitting this means something is stuck; surface as error, not silence.
- POSIX flock auto-releases on process exit **including SIGKILL** — no staleness detection or pidfile cleanup. Regression-guarded by a test that kills a holder and re-acquires.

## Sidecar exit-code contract

| Exit | Meaning | Python maps to |
|------|---------|----------------|
| 0 | success | (returns) |
| 1 | uncaught Node crash / module-load | `RuntimeError` → `Ring: Error` P1 |
| 2 | missing env var | `RuntimeError` → `Ring: Error` P1 |
| 3 | token file unreadable | `BeamsAuthError` → `Ring: Auth Required` P2 |
| 4 | post-auth unhandled JS exception | `RuntimeError` → `Ring: Error` P1 |
| 5 | auth / list-locations failure | `BeamsAuthError` → `Ring: Auth Required` P2 |

## Test plan

- [x] `uv run ruff format` + `ruff check` — clean
- [x] `uv run mypy` on all touched Python files — clean
- [x] `uv run pytest lib RingSecurity RingBeams RachioFlume -q` — **144 passed**, including:
  - 5 new `file_lock` tests (sibling `.lock`, clean release, exception release, second-process timeout, holder-SIGKILL recovery)
  - 3 new `beams_manager` tests (exit=5 auth, exit=1 Node crash NOT auth, `TOKEN_WRITE_FAILED` warn logged)
- [ ] Watch aibo 2026-07-06 05:05 + 05:10 cron cycle — verify no "Auth Required" and, if a lock timeout ever fires, the new `Ring: Token Lock Timeout` P1 appears
- [ ] Verify next SpeedTest failure on aibo emits P1 (not silent P-1) and logs Ookla stderr

## Follow-up work (not in this PR)

- **Separate token files** for RingSecurity vs RingBeams would fully decouple rotations. Not needed if the flock stops the recurring alerts, but revisit if any race remains.
- **RingSecurity: single retry on `invalid_grant`** after re-reading the token file — cheap protection against any residual race.

## References

- aibo `~/logs/test_uplink.log` 2026-07-05 06:00–06:04 — 5/5 speedtest failures, silent Pushover
- aibo `~/logs/beams_manager.py.log` 2026-07-04 17:06 — undici / Node 18 `File is not defined` crash
- aibo `~/logs/ring_manager.py.log` 2026-07-05 05:05 — invalid_grant, source of the actual "Auth Required" alert
- CLAUDE.md — alert-priority discipline, sidecar exit-code contract, `lib/secure_io` atomic writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)