### PR TITLE
refactor(Tesla,August): DI over patch()

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -67,8 +67,17 @@ jobs:
           
           echo '</body></html>' >> _site/index.html
           
+      # Per-run unique artifact name. Working around a GitHub upstream bug
+      # where actions/upload-pages-artifact@v3 sometimes uploads the same
+      # payload multiple times under the default name "github-pages", which
+      # then trips actions/deploy-pages@v4 with:
+      #   Multiple artifacts named "github-pages" were unexpectedly found
+      # for this workflow run. Artifact count is 3.
+      # Unique-per-run name sidesteps the collision entirely.
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
 
   deploy:
     environment:
@@ -81,3 +90,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}

--- a/August/august_client.py
+++ b/August/august_client.py
@@ -83,7 +83,14 @@ class LockState:
 
 
 class AugustClient:
-    def __init__(self, email: str, password: str, phone: Optional[str] = None):
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        phone: Optional[str] = None,
+        *,
+        pushover: Optional[Pushover] = None,
+    ):
         self.email = email
         self.password = password
         self.phone = phone
@@ -94,8 +101,13 @@ class AugustClient:
         self.authenticator: Optional[AuthenticatorAsync] = None
         self.access_token: Optional[str] = None
         self.locks: Dict[str, Lock] = {}
-        cfg = get_config()
-        self.pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["August"])
+        # Injectable Pushover so tests can pass a recording double instead of
+        # touching real config + production tokens. Matches the RingSecurity /
+        # RingBeams factory-injection pattern; see CLAUDE.md "NEVER use patch()".
+        if pushover is None:
+            cfg = get_config()
+            pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["August"])
+        self.pushover = pushover
 
     async def unlock_lock(self, lock_id: str) -> bool:
         """Unlock a specific lock."""
@@ -305,16 +317,29 @@ class AugustMonitor:
         battery_threshold_pct: int = 20,
         battery_alert_cooldown_minutes: int = 42 * 60,  # 1.75 days
         door_alert_cooldown_minutes: int = 2,
+        *,
+        client: Optional[AugustClient] = None,
+        pushover: Optional[Pushover] = None,
+        state_file: Optional[str] = None,
     ):
-        self.client = AugustClient(email, password, phone)
+        # Injectable client + pushover + state_file path so tests never touch
+        # real config or send real Pushover messages. See AugustClient.__init__.
+        if pushover is None or state_file is None:
+            cfg = get_config()
+            if pushover is None:
+                pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["August"])
+            if state_file is None:
+                state_file = f"{cfg.paths.logging_dir}/august_monitor_state.json"
+        if client is None:
+            client = AugustClient(email, password, phone, pushover=pushover)
+        self.client = client
         self.unlock_threshold = unlock_threshold_minutes * 60
         self.ajar_threshold = ajar_threshold_minutes * 60
         self.battery_threshold_pct = battery_threshold_pct
         self.battery_alert_cooldown = battery_alert_cooldown_minutes * 60
         self.door_alert_cooldown = door_alert_cooldown_minutes * 60
         self.logger = get_logger(__name__)
-        cfg = get_config()
-        self.pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["August"])
+        self.pushover = pushover
         self.unlock_start_times: Dict[str, float] = {}
         self.ajar_start_times: Dict[str, float] = {}
         self.last_unlock_alerts: Dict[str, float] = {}
@@ -324,7 +349,7 @@ class AugustMonitor:
         # Track unknown status for recovery
         self.unknown_status_start_times: Dict[str, float] = {}
         self.unknown_threshold = 30 * 60  # 30 minutes
-        self.state_file = f"{cfg.paths.logging_dir}/august_monitor_state.json"
+        self.state_file = state_file
         # Pending alerts for consolidation: (lock_name, alert_type, message)
         self.pending_alerts: list[tuple[str, str, str]] = []
         self._load_state()

--- a/August/test_august_client.py
+++ b/August/test_august_client.py
@@ -3,9 +3,10 @@
 
 import pytest
 from pathlib import Path
-from typing import Any, Generator
+from typing import Generator
 from unittest.mock import Mock, MagicMock, patch, AsyncMock
 from yalexs.lock import LockStatus, LockDoorStatus
+from lib.MyPushover import Pushover
 from August.august_client import (
     AugustClient,
     AugustMonitor,
@@ -41,20 +42,17 @@ class TestAugustClient:
     """Test AugustClient functionality"""
 
     @pytest.fixture
-    def client(self) -> Generator[AugustClient, None, None]:
-        # AugustClient.__init__ builds a real Pushover from real config unless we
-        # stub it here. Tests that mock authenticate() to REQUIRES_VALIDATION /
-        # error paths would otherwise send a real Pushover message to Amit's
-        # phone via the production August token. Mirror TestAugustMonitor's
-        # fixture-level patching.
-        mock_config = MagicMock()
-        mock_config.pushover.user = "user123"
-        mock_config.pushover.tokens = {"August": "token123"}
-        with (
-            patch("August.august_client.Pushover"),
-            patch("August.august_client.get_config", return_value=mock_config),
-        ):
-            yield AugustClient("test@example.com", "password123", "+1234567890")
+    def client(self) -> AugustClient:
+        # Inject a fake Pushover — AugustClient.__init__ has an optional
+        # pushover= kwarg for exactly this. Tests that hit auth error paths
+        # (REQUIRES_VALIDATION / unknown state / exception) would otherwise
+        # push real notifications to Amit's phone via the production token.
+        return AugustClient(
+            "test@example.com",
+            "password123",
+            "+1234567890",
+            pushover=MagicMock(spec=Pushover),
+        )
 
     def test_init(self, client: AugustClient) -> None:
         """Test AugustClient initialization"""
@@ -262,20 +260,17 @@ class TestAugustMonitor:
     """Test AugustMonitor functionality"""
 
     @pytest.fixture
-    def monitor(self) -> AugustMonitor:
-        # Mock the config to return test values
-        mock_config = MagicMock()
-        mock_config.pushover.user = "user123"
-        mock_config.pushover.tokens = {"August": "token123"}
-        mock_config.august.token_file = "/tmp/august_auth_token.json"
-        mock_config.paths.logging_dir = "/tmp"
-
-        with (
-            patch("August.august_client.AugustClient"),
-            patch("August.august_client.Pushover"),
-            patch("August.august_client.get_config", return_value=mock_config),
-        ):
-            return AugustMonitor("test@example.com", "password123")
+    def monitor(self, tmp_path: Path) -> AugustMonitor:
+        # DI: pass fakes directly. No patch() on production symbols. The
+        # AugustClient is a bare Mock (we exercise Monitor behavior; the
+        # client is only touched by tests that reassign monitor.client).
+        return AugustMonitor(
+            "test@example.com",
+            "password123",
+            client=MagicMock(spec=AugustClient),
+            pushover=MagicMock(spec=Pushover),
+            state_file=str(tmp_path / "august_monitor_state.json"),
+        )
 
     def test_init(self, monitor: AugustMonitor) -> None:
         """Test AugustMonitor initialization"""
@@ -293,40 +288,28 @@ class TestAugustMonitor:
         assert monitor.last_unlock_alerts == {}
         assert monitor.last_ajar_alerts == {}
 
-    @patch("August.august_client.json.load")
-    @patch("builtins.open")
-    def test_load_state_with_file(self, mock_open: Any, mock_json_load: Any) -> None:
-        """Test loading state from existing file"""
-        mock_state = {
-            "unlock_start_times": {"lock1": 1234567890.0},
-            "ajar_start_times": {"lock2": 1234567900.0},
-            "last_unlock_alerts": {"lock1": 1234567800.0},
-            "last_ajar_alerts": {"lock2": 1234567850.0},
-            "last_battery_alerts": {},
-            "last_lock_failure_alerts": {},
-        }
-        mock_json_load.return_value = mock_state
-
-        # Mock config
-        mock_config = MagicMock()
-        mock_config.pushover.user = "user123"
-        mock_config.pushover.tokens = {"August": "token123"}
-        mock_config.august.token_file = "/tmp/august_auth_token.json"
-        mock_config.paths.logging_dir = "/tmp"
-
-        with (
-            patch("August.august_client.AugustClient"),
-            patch("August.august_client.Pushover"),
-            patch("August.august_client.get_config", return_value=mock_config),
-        ):
-            monitor = AugustMonitor("test@example.com", "password123")
-
-            # Verify the file was opened
-            mock_open.assert_called_once()
-            assert monitor.unlock_start_times == {"lock1": 1234567890.0}
-            assert monitor.ajar_start_times == {"lock2": 1234567900.0}
-            assert monitor.last_unlock_alerts == {"lock1": 1234567800.0}
-            assert monitor.last_ajar_alerts == {"lock2": 1234567850.0}
+    def test_load_state_with_file(self, tmp_path: Path) -> None:
+        """State file is read on construction."""
+        state_file = tmp_path / "state.json"
+        state_file.write_text(
+            '{"unlock_start_times": {"lock1": 1234567890.0}, '
+            '"ajar_start_times": {"lock2": 1234567900.0}, '
+            '"last_unlock_alerts": {"lock1": 1234567800.0}, '
+            '"last_ajar_alerts": {"lock2": 1234567850.0}, '
+            '"last_battery_alerts": {}, '
+            '"last_lock_failure_alerts": {}}'
+        )
+        monitor = AugustMonitor(
+            "test@example.com",
+            "password123",
+            client=MagicMock(spec=AugustClient),
+            pushover=MagicMock(spec=Pushover),
+            state_file=str(state_file),
+        )
+        assert monitor.unlock_start_times == {"lock1": 1234567890.0}
+        assert monitor.ajar_start_times == {"lock2": 1234567900.0}
+        assert monitor.last_unlock_alerts == {"lock1": 1234567800.0}
+        assert monitor.last_ajar_alerts == {"lock2": 1234567850.0}
 
     @pytest.mark.asyncio
     async def test_process_lock_status_locked(self, monitor: AugustMonitor) -> None:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,11 +162,6 @@ uv run pytest NodeCheck
 
 ## Component-Specific Guidance
 
-### Tesla Module (`Tesla/`)
-- **Authentication**: Uses TeslaPy library, requires OAuth setup via `lib/TeslaPy/gui.py`
-- **Main Features**: Powerwall monitoring, intelligent power management, battery history tracking
-- **Key Classes**: PowerwallManager, BatteryHistory, DecisionPoint
-
 ### August Module (`August/`)
 - **Authentication**: Requires 2FA via phone/email, tokens cached for ~7 days
 - **Main Features**: Smart lock monitoring, unlock duration alerts, door ajar detection, battery warnings, lock failure detection
@@ -174,13 +169,17 @@ uv run pytest NodeCheck
 - **Key Classes**: AugustManager with state persistence for alert tracking
 - **Alert Thresholds**: Configurable via CLI (default: 5min unlock, 10min ajar, 20% battery)
 
-### SamsungFrame Module (`SamsungFrame/`)
-- **Authentication**: WebSocket token-based auth, saved to `config samsung_frame.token_file`
-- **Main Features**: Image upload to Frame TV, matte/border management, slideshow control, art inventory management
-- **Initial Setup**: First upload command triggers TV pairing prompt, token auto-saved for future use
-- **Key Classes**: SamsungFrameClient, UploadResult (Pydantic), ImageUploadSummary
-- **CLI Commands**: upload, status, list-art, list-mattes, download-thumbnails, update-mattes, cycle-images
-- **Image Requirements**: JPG/PNG format, <10MB, validated before upload
+### BimpopAI Module (`BimpopAI/`)
+- **Architecture**: FastAPI backend + Streamlit frontend
+- **Features**: RAG system with document indexing, conversational AI
+- **Optional Dependencies**: Uses streamlit extra (`uv sync --extra streamlit`)
+
+### lib/ (shared library)
+- **Config**: All modules source configuration from `lib/config.py` (OmegaConf-based hierarchical YAML)
+- **Notifications**: Standardized via MyPushover, Mailer, MyTwilio classes
+- **Secret I/O**: `lib/secure_io.py` — `write_secret_atomic(path, content)` for tokens we own (0o600 from birth), `ensure_secret_perms(path)` after third-party library writes (yalexs, SamsungTVWS). **All token/credential writes must go through these.**
+- **File lock**: `lib/file_lock.py` — POSIX `fcntl.flock` context manager for cross-process serialization on shared resources (e.g. Ring token file used by RingSecurity + RingBeams).
+- **TeslaPy Submodule**: External dependency managed as Git submodule
 
 ### NodeCheck Module (`NodeCheck/`)
 - **Purpose**: System node monitoring with continuous heartbeat tracking and automated device management
@@ -192,10 +191,28 @@ uv run pytest NodeCheck
 - **Architecture**: RachioClient, FlumeClient, WaterTrackingDB (SQLite), collector/reporter pattern
 - **Usage**: `rfmanager.py` CLI with collect/status/report commands
 
-### BimpopAI Module (`BimpopAI/`)
-- **Architecture**: FastAPI backend + Streamlit frontend
-- **Features**: RAG system with document indexing, conversational AI
-- **Optional Dependencies**: Uses streamlit extra (`uv sync --extra streamlit`)
+### RingBeams Module (`RingBeams/`)
+- **Purpose**: Daily battery + tamper health check for Ring Beams motion sensors and Ring Alarm sensors via Node sidecar (ring-client-api over socket.io).
+- **Sidecar**: `fetch_status.js` — exit-code contract documented at top of file (0/1/2/3/4/5). Python parent maps 3 and 5 to `BeamsAuthError`; other non-zero codes raise `RuntimeError` (so a Node module-load crash never gets misclassified as "auth required").
+- **Token sharing**: reads/writes the same `config/tokens/ring_auth_token.json` as RingSecurity; a POSIX flock (`lib.file_lock`) serializes the two runs so overlapping refreshes don't produce `invalid_grant`.
+
+### RingSecurity Module (`RingSecurity/`)
+- **Purpose**: Daily battery + offline health check for Ring cameras and doorbells via REST.
+- **Authentication**: 2FA via `ring_manager.py auth`; token stored in `config/tokens/ring_auth_token.json`.
+- **Token sharing**: see RingBeams — shared token, POSIX flock.
+
+### SamsungFrame Module (`SamsungFrame/`)
+- **Authentication**: WebSocket token-based auth, saved to `config samsung_frame.token_file`
+- **Main Features**: Image upload to Frame TV, matte/border management, slideshow control, art inventory management
+- **Initial Setup**: First upload command triggers TV pairing prompt, token auto-saved for future use
+- **Key Classes**: SamsungFrameClient, UploadResult (Pydantic), ImageUploadSummary
+- **CLI Commands**: upload, status, list-art, list-mattes, download-thumbnails, update-mattes, cycle-images
+- **Image Requirements**: JPG/PNG format, <10MB, validated before upload
+
+### Tesla Module (`Tesla/`)
+- **Authentication**: Fleet API OAuth (previously TeslaPy — migrated in PR #178)
+- **Main Features**: Powerwall monitoring, intelligent power management, battery history tracking, retry on transient Fleet API errors
+- **Key Classes**: PowerwallManager, BatteryHistory, DecisionPoint, TeslaAPIClient
 
 ### VSCodeSidebarNotes Module (`VSCodeSidebarNotes/`)
 - **Stack**: TypeScript VS Code / Cursor extension (NOT Python — does not use uv, pytest, or the rest of the repo's Python tooling).
@@ -203,12 +220,6 @@ uv run pytest NodeCheck
 - **Build**: `cd VSCodeSidebarNotes && npm install && npm run compile` (esbuild → `dist/extension.js`). `npm run package-vsix` produces an installable `.vsix`.
 - **Marketplace**: published under the `deviationlabs` publisher; see the module README for the publish flow.
 - **Layout**: `package.json` (extension manifest), `src/` (TS source), `media/` (webview assets).
-
-### Shared Library (`lib/`)
-- **Config**: All modules source configuration from `lib/config.py` (OmegaConf-based hierarchical YAML)
-- **Notifications**: Standardized via MyPushover, Mailer, MyTwilio classes
-- **Secret I/O**: `lib/secure_io.py` — `write_secret_atomic(path, content)` for tokens we own (0o600 from birth), `ensure_secret_perms(path)` after third-party library writes (yalexs, SamsungTVWS). **All token/credential writes must go through these.**
-- **TeslaPy Submodule**: External dependency managed as Git submodule
 
 ## Best Practices
 

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,10 @@ colima: ## Start colima if not already running
 
 test: ## Run the tests
 	@echo "🧪 Running the tests"
-	@echo "📦 Running main test suite..."
-	@uv run pytest
+	@echo "📦 Running main test suite (all testpaths except NodeCheck)..."
+	@uv run pytest --ignore=NodeCheck
 	@echo "🔧 Running NodeCheck tests in isolation..."
 	@uv run pytest NodeCheck
-	@echo "🚗 Running Tesla tests in isolation (Tesla clobbers sys.modules['lib.*'])..."
-	@uv run pytest Tesla
 	@echo "${GREEN}All tests completed successfully.${RESET}"
 
 coverage: ## Run the tests with coverage

--- a/Tesla/manage_power.py
+++ b/Tesla/manage_power.py
@@ -67,8 +67,15 @@ class BatteryHistory:
 class PowerwallManager:
     """Manages Tesla Powerwall operations."""
 
-    def __init__(self, email: str, send_notifications: bool = False):
-        cfg = get_config()
+    def __init__(
+        self,
+        email: str,
+        send_notifications: bool = False,
+        *,
+        pushover: Optional["Pushover"] = None,
+    ):
+        # Injectable Pushover so tests can pass a recording double and never
+        # touch real config or Amit's phone. See CLAUDE.md "NEVER use patch()".
         self.email = email
         self.send_notifications = send_notifications
         self.battery_history = BatteryHistory()
@@ -78,7 +85,10 @@ class PowerwallManager:
             None  # APB: 5/25/23 seems we are no longer getting this data from the query
         )
         self.logger = get_logger(__name__)
-        self.pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["Powerwall"])
+        if pushover is None:
+            cfg = get_config()
+            pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["Powerwall"])
+        self.pushover = pushover
 
     def sanitize_battery_percentage(self, pct: float, time_sampling: float) -> float:
         """Sanitize battery percentage using history and extrapolation."""

--- a/Tesla/test_manage_power.py
+++ b/Tesla/test_manage_power.py
@@ -1,187 +1,134 @@
 #!/usr/bin/env python3
-"""Unit tests for manage_power_clean.py"""
+"""Unit tests for Tesla/manage_power.py.
 
-import sys
+Uses dependency injection (pushover=MagicMock(spec=Pushover)) rather than
+`sys.modules[...] = MagicMock()`. The old approach clobbered the real `lib`
+namespace globally at collection time and broke unrelated tests (RingSecurity,
+RingBeams, lib.file_lock, lib.secure_io) whenever they ran in the same
+process. See CLAUDE.md "NEVER use patch()" — inject dependencies through
+the production API instead.
+"""
+
 import unittest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
-# Mock external modules before importing our code
-mock_pushover_class = MagicMock()
-mock_pushover_module = MagicMock()
-mock_pushover_module.Pushover = mock_pushover_class
-
-sys.modules["lib"] = MagicMock()
-sys.modules["lib.MyPushover"] = mock_pushover_module
-sys.modules["lib.logger"] = MagicMock()
-sys.modules["TeslaPy"] = MagicMock()
-sys.modules["TeslaPy.teslapy"] = MagicMock()
-sys.modules["lib.TeslaPy"] = MagicMock()
-sys.modules["lib.TeslaPy.teslapy"] = MagicMock()
-
-from Tesla.manage_power import BatteryHistory, PowerwallManager, DecisionPoint
+from lib.MyPushover import Pushover
+from Tesla.manage_power import BatteryHistory, DecisionPoint, PowerwallManager
 
 
 class TestBatteryHistory(unittest.TestCase):
     """Test cases for BatteryHistory class."""
 
-    def setUp(self):
-        """Set up test fixtures."""
+    def setUp(self) -> None:
         self.history = BatteryHistory()
 
-    def test_init(self):
-        """Test BatteryHistory initialization."""
+    def test_init(self) -> None:
         self.assertEqual(len(self.history.percentages), 0)
         self.assertEqual(self.history.MAX_HISTORY, 5)
 
-    def test_add_percentage(self):
-        """Test adding percentages to history."""
+    def test_add_percentage(self) -> None:
         self.history.add_percentage(85.5)
         self.assertEqual(len(self.history.percentages), 1)
         self.assertEqual(self.history.percentages[0], 85.5)
 
-        # Add more percentages
         self.history.add_percentage(84.2)
         self.history.add_percentage(83.1)
         self.assertEqual(len(self.history.percentages), 3)
         self.assertEqual(self.history.percentages, [83.1, 84.2, 85.5])
 
-    def test_max_history_limit(self):
-        """Test that history doesn't exceed MAX_HISTORY."""
-        # Add more than MAX_HISTORY items
+    def test_max_history_limit(self) -> None:
         for i in range(7):
             self.history.add_percentage(80.0 + i)
-
         self.assertEqual(len(self.history.percentages), 5)
-        # Should contain the 5 most recent values
-        expected = [86.0, 85.0, 84.0, 83.0, 82.0]
-        self.assertEqual(self.history.percentages, expected)
+        self.assertEqual(self.history.percentages, [86.0, 85.0, 84.0, 83.0, 82.0])
 
-    def test_get_average_gradient(self):
-        """Test average gradient calculation."""
-        # Test empty history
+    def test_get_average_gradient(self) -> None:
         self.assertEqual(self.history.get_average_gradient(), 0.0)
 
-        # Test single value
         self.history.add_percentage(85.0)
         self.assertEqual(self.history.get_average_gradient(), 0.0)
 
-        # Test declining battery (negative gradient)
         self.history.percentages = [80.0, 85.0, 90.0]  # Most recent first
         gradient = self.history.get_average_gradient()
         expected = ((80.0 - 85.0) + (85.0 - 90.0)) / 2  # (-5 + -5) / 2 = -5
         self.assertEqual(gradient, expected)
 
-        # Test charging battery (positive gradient)
-        self.history.percentages = [90.0, 85.0, 80.0]  # Most recent first
+        self.history.percentages = [90.0, 85.0, 80.0]
         gradient = self.history.get_average_gradient()
         expected = ((90.0 - 85.0) + (85.0 - 80.0)) / 2  # (5 + 5) / 2 = 5
         self.assertEqual(gradient, expected)
 
-    def test_extrapolate(self):
-        """Test battery percentage extrapolation."""
-        # Test empty history
+    def test_extrapolate(self) -> None:
         self.assertIsNone(self.history.extrapolate())
 
-        # Test single value (no gradient available)
         self.history.add_percentage(85.0)
         self.assertEqual(self.history.extrapolate(), 85.0)
 
-        # Test declining battery
         self.history.percentages = [80.0, 85.0, 90.0]
-        extrapolated = self.history.extrapolate(1.0)  # 1 time unit
-        expected = round(80.0 + (-5.0 * 1.0), 2)  # 80 - 5 = 75
-        self.assertEqual(extrapolated, expected)
-
-        # Test with different time sampling
-        extrapolated = self.history.extrapolate(0.5)  # 0.5 time units
-        expected = round(80.0 + (-5.0 * 0.5), 2)  # 80 - 2.5 = 77.5
-        self.assertEqual(extrapolated, expected)
+        self.assertEqual(self.history.extrapolate(1.0), round(80.0 + (-5.0 * 1.0), 2))
+        self.assertEqual(self.history.extrapolate(0.5), round(80.0 + (-5.0 * 0.5), 2))
 
 
 class TestPowerwallManager(unittest.TestCase):
     """Test cases for PowerwallManager class."""
 
-    def setUp(self):
-        """Set up test fixtures."""
-        self.manager = PowerwallManager("test@example.com", send_notifications=False)
+    def setUp(self) -> None:
+        # DI: fake Pushover so we never touch real config or Amit's phone.
+        self.manager = PowerwallManager(
+            "test@example.com",
+            send_notifications=False,
+            pushover=MagicMock(spec=Pushover),
+        )
 
-    def test_init(self):
-        """Test PowerwallManager initialization."""
+    def test_init(self) -> None:
         self.assertEqual(self.manager.email, "test@example.com")
         self.assertEqual(self.manager.send_notifications, False)
         self.assertIsInstance(self.manager.battery_history, BatteryHistory)
         self.assertEqual(self.manager.loop_count, 0)
         self.assertEqual(self.manager.fail_count, 0)
 
-    def test_evaluate_condition(self):
-        """Test condition evaluation for triggering actions."""
-        # Test direction_up = True (drain condition)
-        self.assertTrue(self.manager.evaluate_condition(85.0, 80.0, True))  # 85 > 80
-        self.assertFalse(self.manager.evaluate_condition(75.0, 80.0, True))  # 75 < 80
+    def test_evaluate_condition(self) -> None:
+        # direction_up=True → drain condition, trigger when actual > threshold
+        self.assertTrue(self.manager.evaluate_condition(85.0, 80.0, True))
+        self.assertFalse(self.manager.evaluate_condition(75.0, 80.0, True))
 
-        # Test direction_up = False (charge condition)
-        self.assertTrue(self.manager.evaluate_condition(75.0, 80.0, False))  # 75 < 80
-        self.assertFalse(self.manager.evaluate_condition(85.0, 80.0, False))  # 85 > 80
+        # direction_up=False → charge condition, trigger when actual < threshold
+        self.assertTrue(self.manager.evaluate_condition(75.0, 80.0, False))
+        self.assertFalse(self.manager.evaluate_condition(85.0, 80.0, False))
 
-        # Test edge cases
-        self.assertFalse(self.manager.evaluate_condition(80.0, 80.0, True))  # Equal, up
-        self.assertFalse(self.manager.evaluate_condition(80.0, 80.0, False))  # Equal, down
+        # Equal on either side → no trigger
+        self.assertFalse(self.manager.evaluate_condition(80.0, 80.0, True))
+        self.assertFalse(self.manager.evaluate_condition(80.0, 80.0, False))
 
-    def test_sanitize_battery_percentage(self):
-        """Test battery percentage sanitization."""
-        # Test normal percentage
+    def test_sanitize_battery_percentage(self) -> None:
         result = self.manager.sanitize_battery_percentage(85.5, 1.0)
         self.assertEqual(result, 85.5)
         self.assertEqual(len(self.manager.battery_history.percentages), 1)
 
-        # Test zero percentage with history - should use extrapolation
-        self.manager.battery_history.percentages = [
-            80.0,
-            82.0,
-            84.0,
-            86.0,
-            88.0,
-        ]  # Full history
+        # Zero with full history → extrapolate
+        self.manager.battery_history.percentages = [80.0, 82.0, 84.0, 86.0, 88.0]
         with patch.object(self.manager.battery_history, "extrapolate", return_value=78.5):
-            result = self.manager.sanitize_battery_percentage(0.0, 1.0)
-            self.assertEqual(result, 78.5)
+            self.assertEqual(self.manager.sanitize_battery_percentage(0.0, 1.0), 78.5)
 
-        # Test duplicate percentage with full history - should use extrapolation
-        self.manager.battery_history.percentages = [
-            80.0,
-            82.0,
-            84.0,
-            86.0,
-            88.0,
-        ]
+        # Duplicate with full history → extrapolate
+        self.manager.battery_history.percentages = [80.0, 82.0, 84.0, 86.0, 88.0]
         with patch.object(self.manager.battery_history, "extrapolate", return_value=79.0):
-            result = self.manager.sanitize_battery_percentage(80.0, 1.0)  # Duplicate
-            self.assertEqual(result, 79.0)
+            self.assertEqual(self.manager.sanitize_battery_percentage(80.0, 1.0), 79.0)
 
-        # Test percentage > 100 gets clamped
-        self.manager.battery_history.percentages = [
-            95.0,
-            96.0,
-            97.0,
-            98.0,
-            99.0,
-        ]
+        # Clamp above 100
+        self.manager.battery_history.percentages = [95.0, 96.0, 97.0, 98.0, 99.0]
         with patch.object(self.manager.battery_history, "extrapolate", return_value=105.0):
-            result = self.manager.sanitize_battery_percentage(0.0, 1.0)
-            self.assertEqual(result, 100.0)  # Should be clamped to 100
+            self.assertEqual(self.manager.sanitize_battery_percentage(0.0, 1.0), 100.0)
 
-        # Test percentage < 0 gets clamped
+        # Clamp below 0
         self.manager.battery_history.percentages = [5.0, 4.0, 3.0, 2.0, 1.0]
         with patch.object(self.manager.battery_history, "extrapolate", return_value=-5.0):
-            result = self.manager.sanitize_battery_percentage(0.0, 1.0)
-            self.assertEqual(result, 0.0)  # Should be clamped to 0
+            self.assertEqual(self.manager.sanitize_battery_percentage(0.0, 1.0), 0.0)
 
-    def test_calculate_trigger_percentages(self):
-        """Test trigger percentage calculations."""
-        # Create a test decision point
+    def test_calculate_trigger_percentages(self) -> None:
         decision_point = DecisionPoint(
-            time_start=800,  # 08:00
-            time_end=1200,  # 12:00
+            time_start=800,
+            time_end=1200,
             pct_thresh=50.0,
             pct_gradient_per_hr=5.0,
             iff_higher=True,
@@ -191,23 +138,20 @@ class TestPowerwallManager(unittest.TestCase):
             reason="test rule",
         )
 
-        # Mock current time: 10:30:00 (10.5 hours, 30 minutes, 0 seconds)
+        # 10:30:00
         mock_time = Mock()
         mock_time.tm_hour = 10
         mock_time.tm_min = 30
         mock_time.tm_sec = 0
 
-        sleep_time = 300  # 5 minutes = 300 seconds
+        sleep_time = 300  # 5 min
 
         trigger_now, trigger_next = self.manager.calculate_trigger_percentages(
             decision_point, mock_time, sleep_time
         )
 
-        # Calculate expected values
-        # Hours to end: (12 - 10) + (0 - 30)/60 - 0/3600 = 2 - 0.5 = 1.5 hours
-        # trigger_now = 50.0 - (5.0 * 1.5) = 50.0 - 7.5 = 42.5
-        # trigger_next = 42.5 + (5.0 * (300/3600)) = 42.5 + 0.42 = 42.92
-
+        # Hours to end: 1.5. trigger_now = 50 - 5*1.5 = 42.5.
+        # trigger_next = 42.5 + 5*(300/3600) ≈ 42.92.
         self.assertEqual(trigger_now, 42.5)
         self.assertAlmostEqual(trigger_next, 42.92, places=2)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,13 +160,7 @@ DEP002 = [
 DEP003 = ["google", "streamlit", "BimpopAI", "PyObjCTools"]  # PyObjCTools comes via rumps → pyobjc
 
 [tool.pytest.ini_options]
-## Tesla is excluded here and run in its own pytest invocation via `make test`.
-## Tesla/test_manage_power.py:13 clobbers sys.modules["lib.*"] with MagicMock at
-## import time (pre-existing CLAUDE.md "no patch()" violation). Reordering
-## within a single process is not enough — on Linux, pytest's plugin discovery
-## revisits already-collected modules and trips on the MagicMock. Same isolation
-## pattern as NodeCheck (pytest-forked).
-testpaths = ["RachioFlume", "August", "SamsungFrame", "VoiceNotes", "LaunchJobs", "RingSecurity", "RingBeams", "lib"]
+testpaths = ["Tesla", "RachioFlume", "August", "SamsungFrame", "VoiceNotes", "LaunchJobs", "RingSecurity", "RingBeams", "lib"]
 addopts = "-v --tb=short"
 asyncio_mode = "auto"
 


### PR DESCRIPTION
**DRAFT — do not merge yet.**

## Summary

Three separate but related cleanups:

### 1. Tesla — DI, remove sys.modules clobber

\`Tesla/test_manage_power.py\` started with:

\`\`\`python
sys.modules["lib"] = MagicMock()
sys.modules["lib.MyPushover"] = mock_pushover_module
sys.modules["lib.logger"] = MagicMock()
sys.modules["TeslaPy"] = MagicMock()
...
\`\`\`

at module load time. Any test running after Tesla was collected saw MagicMock as \`lib\`. Previous PR isolated Tesla in its own pytest invocation. Real fix: add \`pushover=None\` kwarg to \`PowerwallManager.__init__\`; tests pass \`MagicMock(spec=Pushover)\`. Rewritten test file uses real imports + DI.

### 2. August — DI, stop live Pushover sends

\`AugustClient.__init__\` / \`AugustMonitor.__init__\` read real config and built a real Pushover at construction. Tests hitting \`REQUIRES_VALIDATION\` / auth-error branches sent real Pushover pings to Amit's phone via the production August token. Fix: DI kwargs (\`pushover=\`, \`client=\`, \`state_file=\`). \`test_august_client.py\` fixtures now inject fakes directly — no more \`patch("August.august_client.Pushover")\`.

### 3. GitHub Pages — fix multi-artifact deploy collision

Site https://homely-vibes.deviationlabs.com/ has been stuck on the 2026-07-04 deploy. Root cause: \`actions/upload-pages-artifact@v3\` uploaded three identical artifacts (verified on run 28751194910 — same sha256, same second) under the default name \`github-pages\`. \`actions/deploy-pages@v4\` then aborted with "Multiple artifacts named 'github-pages' were unexpectedly found for this workflow run."

Fix in \`.github/workflows/pages.yml\`: name the artifact \`github-pages-\$run_id-\$run_attempt\` and reference it in \`deploy-pages\`. Per-run namespace means the collision can't happen regardless of upstream duplication behaviour.

Interim: I pruned the duplicate artifacts on the stuck run and re-ran the failed deploy — that unsticks the current site to fc96af3 (PR #219 content) without waiting for this PR.

### Bonus

- Restore \`make test\` to a single \`pytest --ignore=NodeCheck\` invocation (Tesla no longer needs isolation).
- Re-add Tesla to \`pyproject.toml testpaths\`.
- Sort CLAUDE.md \`## Component-Specific Guidance\` alphabetically; fold in the missing RingBeams / RingSecurity sections.

## Test plan

- [x] \`uv run pytest --ignore=NodeCheck\` — **290 passed** (includes Tesla in the unified process)
- [x] \`uv run pytest NodeCheck\` — **29 passed**
- [x] \`uv run ruff format\` + \`ruff check\` — clean
- [x] \`uv run mypy Tesla/manage_power.py August/august_client.py\` — clean
- [x] Manually pruned duplicate artifacts on run 28751194910; re-ran deploy job

## References

- PR #219 flagged Tesla + August DI as follow-up work.
- Pages workflow failure: run 28751194910 (fc96af3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)