### PR TITLE
feat(Rheem): add EcoNet water heater monitor with low-hot-water alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ See `config/default.yaml` for the full structure and `config/local.yaml.example`
 | 📵 **NoShorts** | iOS app that wraps YouTube and strips all Shorts content via JS injection — clean YouTube without vertical video. | [📖 README](NoShorts/README.md) |
 | 📅 **PersonalCalSync** | Google Apps Script that syncs personal calendar events to enterprise calendar as private busy-blockers, preserving real event titles visible only to you. | [📖 README](PersonalCalSync/README.md) |
 | 💧 **RachioFlume** | Water usage tracking integration between Rachio irrigation systems and Flume water monitoring. | [📖 README](RachioFlume/README.md) |
+| 🚿 **Rheem** | Rheem/EcoNet water heater monitor — P2 when the tank is empty, P1 at 1/3rd full, silent clear at 2/3rds. Cron run-once via the unofficial pyeconet (ClearBlade) API. | [📖 README](Rheem/README.md) |
 | 🚨 **RingBeams** | Ring Beams motion sensors + Ring Alarm contact/motion sensors, via Node.js sidecar over socket.io (ring-client-api). P1 battery, P0 tamper. | [📖 README](RingBeams/README.md) |
 | 📸 **RingSecurity** | Ring cameras + doorbells daily health check via REST — P1 low-battery, P0 offline. | [📖 README](RingSecurity/README.md) |
 | 🖼️ **SamsungFrame** | Samsung Frame TV art manager with batch upload, HEIC conversion, and slideshow control. | [📖 README](SamsungFrame/README.md) |

--- a/Rheem/README.md
+++ b/Rheem/README.md
@@ -8,13 +8,13 @@ The tank reports hot water availability as discrete levels via the unofficial Ec
 
 | Level | Meaning          | Action                          |
 |-------|------------------|---------------------------------|
-| 0     | empty            | 🔴 fire **P1** alert             |
+| 0     | empty            | 🚨 fire **P2** alert (emergency) |
 | 33    | "1/3rd full"     | 🔴 fire **P1** alert             |
 | 66    | "2/3rd full"     | 🟢 send **P-1** clear, reset     |
 | 100   | full             | no-op (already cleared at 66)   |
 | None  | not supported    | skip silently                    |
 
-Hysteresis with persisted state (`{logging_dir}/rheem_monitor_state.json`) prevents re-alerting every poll and flapping between adjacent levels. State is keyed by heater serial number, so multiple heaters are tracked independently.
+Hysteresis with persisted state (`{logging_dir}/rheem_monitor_state.json`) prevents re-alerting every poll and flapping between adjacent levels. State is keyed by heater serial number, so multiple heaters are tracked independently. A tank that drops from 1/3rd (P1) to empty (P2) **escalates** — a second, higher-priority alert fires. Recovering from empty back to 1/3rd does NOT re-alert (still in the low zone); only recovery to ≥ mid clears the alert.
 
 ## Setup
 
@@ -29,8 +29,9 @@ rheem:
   email: your_econet_email@example.com
   password: your_econet_password
   poll_seconds: 300          # check interval (monitor command)
-  low_threshold: 33          # alert at/below this level
-  mid_threshold: 66          # clear at/above this level
+  empty_threshold: 0         # <= this -> P2 emergency (retries until acked)
+  low_threshold: 33          # <= this -> P1 high (bypasses quiet hours)
+  mid_threshold: 66          # >= this -> P-1 clear, reset alert state
 ```
 
 Add a Pushover app token:
@@ -60,7 +61,8 @@ uv run python Rheem/rheem_manager.py monitor --poll-secs 120
 
 Per the repo convention (`P{N}` = Pushover `priority=N`):
 
-- **P1** — low hot water (empty or 1/3rd full). Actionable within hours.
+- **P2** — empty tank (emergency, retries until acked). Seconds matter — no hot water at all.
+- **P1** — low hot water (1/3rd full). Actionable within hours.
 - **P-1** — recovery clear (silent, informational).
 - **P0** — auth/comms failure (a chore, not an emergency).
 

--- a/Rheem/README.md
+++ b/Rheem/README.md
@@ -1,0 +1,79 @@
+# Rheem EcoNet Water Heater Monitor
+
+Monitor Rheem/EcoNet-connected water heaters and alert when available hot water is low, clearing the alert when it recovers to mid.
+
+## How it works
+
+The tank reports hot water availability as discrete levels via the unofficial EcoNet (ClearBlade) API:
+
+| Level | Meaning          | Action                          |
+|-------|------------------|---------------------------------|
+| 0     | empty            | 🔴 fire **P1** alert             |
+| 33    | "1/3rd full"     | 🔴 fire **P1** alert             |
+| 66    | "2/3rd full"     | 🟢 send **P-1** clear, reset     |
+| 100   | full             | no-op (already cleared at 66)   |
+| None  | not supported    | skip silently                    |
+
+Hysteresis with persisted state (`{logging_dir}/rheem_monitor_state.json`) prevents re-alerting every poll and flapping between adjacent levels. State is keyed by heater serial number, so multiple heaters are tracked independently.
+
+## Setup
+
+```bash
+uv sync   # installs pyeconet (unofficial EcoNet client)
+```
+
+Add credentials to `config/local.yaml`:
+
+```yaml
+rheem:
+  email: your_econet_email@example.com
+  password: your_econet_password
+  poll_seconds: 300          # check interval (monitor command)
+  low_threshold: 33          # alert at/below this level
+  mid_threshold: 66          # clear at/above this level
+```
+
+Add a Pushover app token:
+
+```yaml
+pushover:
+  tokens:
+    Rheem: your_pushover_app_token
+```
+
+> **Auth**: EcoNet uses plain email/password → bearer `user_token`. No 2FA.
+
+## Usage
+
+```bash
+# One-shot status check + Pushover summary
+uv run python Rheem/rheem_manager.py test
+
+# Continuous monitoring (interval from config)
+uv run python Rheem/rheem_manager.py monitor
+
+# Custom poll interval
+uv run python Rheem/rheem_manager.py monitor --poll-secs 120
+```
+
+## Alert priorities
+
+Per the repo convention (`P{N}` = Pushover `priority=N`):
+
+- **P1** — low hot water (empty or 1/3rd full). Actionable within hours.
+- **P-1** — recovery clear (silent, informational).
+- **P0** — auth/comms failure (a chore, not an emergency).
+
+## Caveats
+
+- **Unofficial API.** `pyeconet` reverse-engineers Rheem's ClearBlade cloud (`rheem.clearblade.com`). Rheem can change endpoints without notice; the library could break at any time.
+- **Discrete levels only.** The tank exposes 0/33/66/100, not a continuous percentage. Thresholds must align to these levels (defaults: low=33, mid=66).
+- **Some tanks don't report `@HOTWATER`.** Availability is `None`; the monitor skips them with a debug log. No alert is fired for unsupported tanks.
+
+## Testing
+
+```bash
+uv run python -m pytest Rheem/ -v
+```
+
+Tests use injected fakes (fake EcoNet api, fake notifier) — no `patch()`, per repo convention.

--- a/Rheem/rheem_client.py
+++ b/Rheem/rheem_client.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Rheem EcoNet water heater client.
+
+Wraps the unofficial `pyeconet` library (ClearBlade cloud at
+rheem.clearblade.com) in a small sync-friendly surface for the monitor.
+Auth is plain email/password -> bearer `user_token` (no 2FA).
+
+The API factory is injectable so tests can supply a fake EcoNet api without
+patching production code.
+
+Hot water availability is reported by the tank as discrete levels:
+    0   = empty
+    33  = "1/3rd full"
+    66  = "2/3rd full"
+    100 = full
+Some tanks do not report `@HOTWATER` at all, in which case availability is None.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+from pyeconet import EcoNetApiInterface
+from pyeconet.errors import InvalidCredentialsError, PyeconetError
+from pyeconet.equipment import EquipmentType
+
+from lib.logger import get_logger
+
+
+class RheemAuthError(Exception):
+    """EcoNet authentication failed."""
+
+
+class RheemAPIError(Exception):
+    """EcoNet API request error."""
+
+
+@dataclass
+class WaterHeaterStatus:
+    """Snapshot of one water heater's relevant telemetry."""
+
+    serial_number: str
+    name: str
+    availability: Optional[int]
+    running: bool
+    set_point: Optional[int]
+    connected: bool
+
+
+# A factory that returns an already-logged-in EcoNet api instance.
+ApiFactory = Callable[[], Awaitable[EcoNetApiInterface]]
+
+
+class RheemClient:
+    """EcoNet client exposing water heater telemetry."""
+
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        api_factory: Optional[ApiFactory] = None,
+    ) -> None:
+        self.email = email
+        self.password = password
+        self._api: Optional[EcoNetApiInterface] = None
+        self._api_factory: ApiFactory = api_factory or self._default_factory
+        self.logger = get_logger(__name__)
+
+    def _default_factory(self) -> Awaitable[EcoNetApiInterface]:
+        return EcoNetApiInterface.login(self.email, self.password)  # type: ignore[no-any-return]
+
+    async def _ensure_api(self) -> EcoNetApiInterface:
+        if self._api is not None:
+            return self._api
+        try:
+            self._api = await self._api_factory()
+        except InvalidCredentialsError as e:
+            raise RheemAuthError(f"EcoNet login failed (invalid credentials): {e}") from e
+        except PyeconetError as e:
+            raise RheemAPIError(f"EcoNet login error: {e}") from e
+        return self._api
+
+    async def get_water_heaters(self) -> list[WaterHeaterStatus]:
+        """Return telemetry for all water heaters on the account."""
+        api = await self._ensure_api()
+        try:
+            equipment = await api.get_equipment_by_type([EquipmentType.WATER_HEATER])
+        except PyeconetError as e:
+            raise RheemAPIError(f"EcoNet equipment fetch failed: {e}") from e
+
+        heaters = equipment.get(EquipmentType.WATER_HEATER, [])
+        return [self._to_status(h) for h in heaters]
+
+    @staticmethod
+    def _to_status(heater: Any) -> WaterHeaterStatus:
+        avail = heater.tank_hot_water_availability
+        set_point: Optional[int] = None
+        try:
+            set_point = heater.set_point
+        except (KeyError, TypeError):
+            pass
+        return WaterHeaterStatus(
+            serial_number=heater.serial_number,
+            name=heater.device_name,
+            availability=avail,
+            running=bool(heater.running),
+            set_point=set_point,
+            connected=bool(heater.connected),
+        )
+
+
+__all__ = [
+    "RheemClient",
+    "WaterHeaterStatus",
+    "RheemAuthError",
+    "RheemAPIError",
+]

--- a/Rheem/rheem_manager.py
+++ b/Rheem/rheem_manager.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Rheem EcoNet water heater monitor.
+
+Alerts when available hot water is low and clears the alert when it recovers
+to mid. Uses hysteresis with persisted state so we don't re-alert every poll
+or flap between adjacent levels.
+
+Availability levels (from the tank):
+    0   = empty
+    33  = "1/3rd full"   -> LOW  (fire P1 alert)
+    66  = "2/3rd full"   -> MID  (send P-1 clear, reset alert state)
+    100 = full
+
+State is persisted to {logging_dir}/rheem_monitor_state.json as
+    {"alerted": {"<serial>": true/false}}
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from typing import Protocol
+
+from Rheem.rheem_client import RheemAPIError, RheemAuthError, RheemClient, WaterHeaterStatus
+from lib.config import Config, get_config
+from lib.logger import get_logger
+from lib.MyPushover import Pushover
+
+
+_AVAILABILITY_LABEL = {0: "empty", 33: "1/3rd full", 66: "2/3rd full", 100: "full"}
+
+
+class Notifier(Protocol):
+    """Send-only notification surface (satisfied by Pushover or test fakes)."""
+
+    def send_message(self, message: str, title: str | None = None, priority: int = 0) -> bool: ...
+
+
+def _label(avail: int) -> str:
+    return _AVAILABILITY_LABEL.get(avail, f"{avail}%")
+
+
+class RheemMonitor:
+    """Polls water heaters and fires/clears low-hot-water alerts."""
+
+    def __init__(
+        self,
+        client: RheemClient,
+        pushover: Notifier,
+        logger: logging.Logger,
+        state_file: str,
+        low_threshold: int = 33,
+        mid_threshold: int = 66,
+    ) -> None:
+        self.client = client
+        self.pushover = pushover
+        self.logger = logger
+        self.state_file = state_file
+        self.low_threshold = low_threshold
+        self.mid_threshold = mid_threshold
+        self.alerted: dict[str, bool] = {}
+        self._load_state()
+
+    def _load_state(self) -> None:
+        try:
+            with open(self.state_file, "r") as f:
+                state = json.load(f)
+                self.alerted = state.get("alerted", {})
+            self.logger.debug("Loaded Rheem monitor state from %s", self.state_file)
+        except (FileNotFoundError, json.JSONDecodeError):
+            self.logger.debug("No existing Rheem state file; starting fresh")
+
+    def _save_state(self) -> None:
+        try:
+            with open(self.state_file, "w") as f:
+                json.dump({"alerted": self.alerted}, f)
+            self.logger.debug("Saved Rheem monitor state to %s", self.state_file)
+        except OSError as e:
+            self.logger.error("Error saving Rheem state: %s", e)
+
+    async def check_once(self) -> list[WaterHeaterStatus]:
+        """Run one polling cycle. Returns the statuses observed this cycle."""
+        try:
+            heaters = await self.client.get_water_heaters()
+        except RheemAuthError as e:
+            self.pushover.send_message(
+                f"Rheem auth failed: {e}",
+                title="Rheem Auth",
+                priority=0,
+            )
+            self.logger.error("Rheem auth failed: %s", e)
+            return []
+        except RheemAPIError as e:
+            self.pushover.send_message(
+                f"Rheem API error: {e}",
+                title="Rheem Error",
+                priority=0,
+            )
+            self.logger.error("Rheem API error: %s", e)
+            return []
+
+        current_serials = {h.serial_number for h in heaters}
+        for status in heaters:
+            self._process(status)
+
+        # Prune devices that no longer appear.
+        self.alerted = {s: v for s, v in self.alerted.items() if s in current_serials}
+        self._save_state()
+        return heaters
+
+    def _process(self, status: WaterHeaterStatus) -> None:
+        if not status.connected:
+            self.logger.debug("%s disconnected; skipping", status.name)
+            return
+        if status.availability is None:
+            self.logger.debug("%s does not report availability; skipping", status.name)
+            return
+
+        is_alerted = self.alerted.get(status.serial_number, False)
+
+        if status.availability <= self.low_threshold and not is_alerted:
+            msg = (
+                f"Hot water low: {status.name} at {_label(status.availability)} "
+                f"({status.availability}%)"
+            )
+            self.pushover.send_message(msg, title="Rheem Low Hot Water", priority=1)
+            self.alerted[status.serial_number] = True
+            self.logger.warning("Fired low-hot-water alert: %s", msg)
+
+        elif status.availability >= self.mid_threshold and is_alerted:
+            msg = (
+                f"Hot water recovered: {status.name} at {_label(status.availability)} "
+                f"({status.availability}%)"
+            )
+            self.pushover.send_message(msg, title="Rheem Hot Water Recovered", priority=-1)
+            self.alerted[status.serial_number] = False
+            self.logger.info("Cleared low-hot-water alert: %s", msg)
+
+    async def run_continuous(self, poll_seconds: int) -> None:
+        self.logger.info("Starting continuous Rheem monitoring (interval: %ds)", poll_seconds)
+        while True:
+            await self.check_once()
+            await asyncio.sleep(poll_seconds)
+
+
+def _build_monitor(cfg: Config, logger: logging.Logger) -> RheemMonitor:
+    client = RheemClient(cfg.rheem.email, cfg.rheem.password)
+    pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["Rheem"])
+    state_file = f"{cfg.paths.logging_dir}/rheem_monitor_state.json"
+    return RheemMonitor(
+        client=client,
+        pushover=pushover,
+        logger=logger,
+        state_file=state_file,
+        low_threshold=cfg.rheem.low_threshold,
+        mid_threshold=cfg.rheem.mid_threshold,
+    )
+
+
+async def _monitor(args: argparse.Namespace, cfg: Config, logger: logging.Logger) -> None:
+    monitor = _build_monitor(cfg, logger)
+    await monitor.run_continuous(args.poll_secs)
+
+
+async def _test(args: argparse.Namespace, cfg: Config, logger: logging.Logger) -> None:
+    monitor = _build_monitor(cfg, logger)
+    heaters = await monitor.check_once()
+    if not heaters:
+        logger.warning("No water heaters reported this cycle")
+        return
+    lines = []
+    for h in heaters:
+        avail = "N/A" if h.availability is None else f"{h.availability}% ({_label(h.availability)})"
+        lines.append(
+            f"{h.name}: avail={avail}, running={h.running}, "
+            f"set_point={h.set_point}, connected={h.connected}"
+        )
+    summary = "\n".join(lines)
+    logger.info("Rheem status:\n%s", summary)
+    monitor.pushover.send_message(summary, title="Rheem Status", priority=-1)
+
+
+async def _run_command(args: argparse.Namespace, cfg: Config, logger: logging.Logger) -> None:
+    if args.command == "monitor":
+        await _monitor(args, cfg, logger)
+    elif args.command == "test":
+        await _test(args, cfg, logger)
+
+
+def main() -> None:
+    logger = get_logger(__name__)
+    logger.info("=" * 50)
+    logger.info("Starting Rheem EcoNet Water Heater Monitoring")
+
+    parser = argparse.ArgumentParser(
+        description="Rheem EcoNet water heater monitoring and alerting"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    monitor_parser = subparsers.add_parser("monitor", help="Continuous monitoring")
+    monitor_parser.add_argument(
+        "--poll-secs",
+        type=int,
+        default=None,
+        help="Check interval in seconds (default: from config)",
+    )
+
+    _ = subparsers.add_parser("test", help="One-shot status check + Pushover summary")
+
+    args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    cfg = get_config()
+    if not cfg.rheem.email or not cfg.rheem.password:
+        logger.error("Rheem credentials not found in config")
+        logger.error("Add rheem.email and rheem.password to config/local.yaml")
+        sys.exit(1)
+
+    if args.command == "monitor" and args.poll_secs is None:
+        args.poll_secs = cfg.rheem.poll_seconds
+
+    try:
+        asyncio.run(_run_command(args, cfg, logger))
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+        sys.exit(0)
+    except Exception as e:
+        logger.error("Unexpected error: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Rheem/rheem_manager.py
+++ b/Rheem/rheem_manager.py
@@ -141,19 +141,23 @@ class RheemMonitor:
             self.logger.debug("%s does not report availability; skipping", status.name)
             return
 
-        current_tier = self._tier_for(avail)
         active_tier = self.alerted.get(status.serial_number)
 
-        if current_tier is None and active_tier is not None:
-            # Recovered to >= mid_threshold: clear.
+        # Clear only on explicit recovery to >= mid_threshold (not merely
+        # "above low" — that would let a level between low and mid prematurely
+        # clear an active alert). mid_threshold is the configured recovery gate.
+        if active_tier is not None and avail >= self.mid_threshold:
             msg = f"Hot water recovered: {status.name} at {_label(avail)} ({avail}%)"
             self.pushover.send_message(msg, title="Rheem Hot Water Recovered", priority=-1)
             del self.alerted[status.serial_number]
             self.logger.info("Cleared hot-water alert: %s", msg)
             return
 
+        current_tier = self._tier_for(avail)
         if current_tier is None:
-            return  # healthy, no active alert
+            # In the dead zone (low_threshold < avail < mid_threshold): hold
+            # any active alert without re-firing; no-op if not alerted.
+            return
 
         # In a low zone (empty or 1/3rd). Decide whether to fire/escalate.
         if active_tier is None:

--- a/Rheem/rheem_manager.py
+++ b/Rheem/rheem_manager.py
@@ -17,8 +17,10 @@ State is persisted to {logging_dir}/rheem_monitor_state.json as
 
 import argparse
 import asyncio
+import contextlib
 import json
 import logging
+import os
 import sys
 from typing import Protocol
 
@@ -76,12 +78,19 @@ class RheemMonitor:
             self.logger.debug("No existing Rheem state file; starting fresh")
 
     def _save_state(self) -> None:
+        # Atomic write via tmp + os.replace so an interrupt mid-write can't
+        # truncate the state file (which would silently reset all alert state
+        # and re-fire P1/P2 alerts on the next cycle).
+        tmp_path = self.state_file + ".tmp"
         try:
-            with open(self.state_file, "w") as f:
+            with open(tmp_path, "w") as f:
                 json.dump({"alerted": self.alerted}, f)
+            os.replace(tmp_path, self.state_file)
             self.logger.debug("Saved Rheem monitor state to %s", self.state_file)
         except OSError as e:
             self.logger.error("Error saving Rheem state: %s", e)
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
 
     async def check_once(self) -> list[WaterHeaterStatus]:
         """Run one polling cycle. Returns the statuses observed this cycle."""
@@ -102,6 +111,12 @@ class RheemMonitor:
                 priority=0,
             )
             self.logger.error("Rheem API error: %s", e)
+            return []
+        except Exception as e:
+            # pyeconet only wraps PyeconetError subclasses; transient network
+            # errors (aiohttp.ClientError, asyncio.TimeoutError, OSError) are
+            # re-raised raw. Don't let them kill the run_continuous loop.
+            self.logger.error("Transient error during Rheem check: %s", e)
             return []
 
         current_serials = {h.serial_number for h in heaters}
@@ -164,7 +179,12 @@ class RheemMonitor:
     async def run_continuous(self, poll_seconds: int) -> None:
         self.logger.info("Starting continuous Rheem monitoring (interval: %ds)", poll_seconds)
         while True:
-            await self.check_once()
+            try:
+                await self.check_once()
+            except Exception as e:
+                # Safety net: check_once handles known/transient errors, but a
+                # bug in _process/_save_state must not kill the monitor either.
+                self.logger.error("Unexpected error in Rheem poll cycle: %s", e)
             await asyncio.sleep(poll_seconds)
 
 

--- a/Rheem/rheem_manager.py
+++ b/Rheem/rheem_manager.py
@@ -50,6 +50,7 @@ class RheemMonitor:
         pushover: Notifier,
         logger: logging.Logger,
         state_file: str,
+        empty_threshold: int = 0,
         low_threshold: int = 33,
         mid_threshold: int = 66,
     ) -> None:
@@ -57,9 +58,12 @@ class RheemMonitor:
         self.pushover = pushover
         self.logger = logger
         self.state_file = state_file
+        self.empty_threshold = empty_threshold
         self.low_threshold = low_threshold
         self.mid_threshold = mid_threshold
-        self.alerted: dict[str, bool] = {}
+        # Per-device current alert tier: "p1" (low) or "p2" (empty).
+        # Absent key = not alerted. Cleared only on recovery to >= mid_threshold.
+        self.alerted: dict[str, str] = {}
         self._load_state()
 
     def _load_state(self) -> None:
@@ -113,29 +117,49 @@ class RheemMonitor:
         if not status.connected:
             self.logger.debug("%s disconnected; skipping", status.name)
             return
-        if status.availability is None:
+        avail = status.availability
+        if avail is None:
             self.logger.debug("%s does not report availability; skipping", status.name)
             return
 
-        is_alerted = self.alerted.get(status.serial_number, False)
+        current_tier = self._tier_for(avail)
+        active_tier = self.alerted.get(status.serial_number)
 
-        if status.availability <= self.low_threshold and not is_alerted:
-            msg = (
-                f"Hot water low: {status.name} at {_label(status.availability)} "
-                f"({status.availability}%)"
-            )
-            self.pushover.send_message(msg, title="Rheem Low Hot Water", priority=1)
-            self.alerted[status.serial_number] = True
-            self.logger.warning("Fired low-hot-water alert: %s", msg)
-
-        elif status.availability >= self.mid_threshold and is_alerted:
-            msg = (
-                f"Hot water recovered: {status.name} at {_label(status.availability)} "
-                f"({status.availability}%)"
-            )
+        if current_tier is None and active_tier is not None:
+            # Recovered to >= mid_threshold: clear.
+            msg = f"Hot water recovered: {status.name} at {_label(avail)} ({avail}%)"
             self.pushover.send_message(msg, title="Rheem Hot Water Recovered", priority=-1)
-            self.alerted[status.serial_number] = False
-            self.logger.info("Cleared low-hot-water alert: %s", msg)
+            del self.alerted[status.serial_number]
+            self.logger.info("Cleared hot-water alert: %s", msg)
+            return
+
+        if current_tier is None:
+            return  # healthy, no active alert
+
+        # In a low zone (empty or 1/3rd). Decide whether to fire/escalate.
+        if active_tier is None:
+            self._fire(status, avail, current_tier)
+        elif current_tier == "p2" and active_tier == "p1":
+            # Escalate low -> empty.
+            self._fire(status, avail, current_tier)
+        # Same tier, or recovering empty->low: no re-alert (clear at mid resets).
+
+    def _tier_for(self, availability: int) -> str | None:
+        """Return the alert tier for an availability level, or None if healthy."""
+        if availability <= self.empty_threshold:
+            return "p2"
+        if availability <= self.low_threshold:
+            return "p1"
+        return None
+
+    def _fire(self, status: WaterHeaterStatus, avail: int, tier: str) -> None:
+        priority = 2 if tier == "p2" else 1
+        label = "empty" if tier == "p2" else "low"
+        msg = f"Hot water {label}: {status.name} at {_label(avail)} ({avail}%)"
+        title = "Rheem Hot Water Empty" if tier == "p2" else "Rheem Low Hot Water"
+        self.pushover.send_message(msg, title=title, priority=priority)
+        self.alerted[status.serial_number] = tier
+        self.logger.warning("Fired %s hot-water alert: %s", tier.upper(), msg)
 
     async def run_continuous(self, poll_seconds: int) -> None:
         self.logger.info("Starting continuous Rheem monitoring (interval: %ds)", poll_seconds)
@@ -153,6 +177,7 @@ def _build_monitor(cfg: Config, logger: logging.Logger) -> RheemMonitor:
         pushover=pushover,
         logger=logger,
         state_file=state_file,
+        empty_threshold=cfg.rheem.empty_threshold,
         low_threshold=cfg.rheem.low_threshold,
         mid_threshold=cfg.rheem.mid_threshold,
     )

--- a/Rheem/rheem_manager.py
+++ b/Rheem/rheem_manager.py
@@ -12,7 +12,11 @@ Availability levels (from the tank):
     100 = full
 
 State is persisted to {logging_dir}/rheem_monitor_state.json as
-    {"alerted": {"<serial>": true/false}}
+    {"alerted": {"<serial>": "p1"|"p2"}}
+
+Deployment: cron runs `check` every few minutes (run-once per tick —
+fresh auth each run, free crash recovery, matches the repo cron convention).
+`monitor` is a foreground/dev alternative. `test` is a one-shot status dump.
 """
 
 import argparse
@@ -208,6 +212,22 @@ async def _monitor(args: argparse.Namespace, cfg: Config, logger: logging.Logger
     await monitor.run_continuous(args.poll_secs)
 
 
+async def _check(args: argparse.Namespace, cfg: Config, logger: logging.Logger) -> None:
+    """One polling cycle for cron: runs the alert state machine, then exits.
+
+    No Pushover status summary (unlike `test`) — alerts fire from the state
+    machine only when a threshold is crossed. Exit 0 on success so cron stays
+    quiet; non-zero exits surface in the cron log on real failures.
+    """
+    monitor = _build_monitor(cfg, logger)
+    heaters = await monitor.check_once()
+    logger.info(
+        "Rheem check complete: %d heater(s), %d alerted",
+        len(heaters),
+        len(monitor.alerted),
+    )
+
+
 async def _test(args: argparse.Namespace, cfg: Config, logger: logging.Logger) -> None:
     monitor = _build_monitor(cfg, logger)
     heaters = await monitor.check_once()
@@ -229,6 +249,8 @@ async def _test(args: argparse.Namespace, cfg: Config, logger: logging.Logger) -
 async def _run_command(args: argparse.Namespace, cfg: Config, logger: logging.Logger) -> None:
     if args.command == "monitor":
         await _monitor(args, cfg, logger)
+    elif args.command == "check":
+        await _check(args, cfg, logger)
     elif args.command == "test":
         await _test(args, cfg, logger)
 
@@ -243,12 +265,18 @@ def main() -> None:
     )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
-    monitor_parser = subparsers.add_parser("monitor", help="Continuous monitoring")
+    monitor_parser = subparsers.add_parser(
+        "monitor", help="Foreground continuous monitoring (dev; cron uses `check`)"
+    )
     monitor_parser.add_argument(
         "--poll-secs",
         type=int,
         default=None,
         help="Check interval in seconds (default: from config)",
+    )
+
+    _ = subparsers.add_parser(
+        "check", help="One polling cycle (cron): alert state machine, then exit"
     )
 
     _ = subparsers.add_parser("test", help="One-shot status check + Pushover summary")

--- a/Rheem/test_rheem_client.py
+++ b/Rheem/test_rheem_client.py
@@ -5,6 +5,7 @@ No patch() — dependencies (EcoNet api, Pushover) are injected as fakes.
 """
 
 import asyncio
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -306,3 +307,89 @@ def test_multiple_heaters_independent(tmp_path: Path) -> None:
     # One P1 + one P2.
     priorities = sorted(p for _, _, p in pushover.sent)
     assert priorities == [1, 2]
+
+
+# --------------------------------------------------------------------------- #
+# Resilience: transient errors must not kill the monitor loop
+# --------------------------------------------------------------------------- #
+
+
+class ThrowingEcoNetApi:
+    """Fake api whose get_equipment_by_type raises a non-PyeconetError."""
+
+    async def get_equipment_by_type(
+        self, equipment_types: list[EquipmentType]
+    ) -> dict[EquipmentType, list[FakeWaterHeater]]:
+        raise asyncio.TimeoutError("network blip")
+
+
+def _monitor_with_throwing(state_file: str) -> tuple[RheemMonitor, FakePushover]:
+    api = ThrowingEcoNetApi()
+
+    async def factory() -> ThrowingEcoNetApi:
+        return api
+
+    client = RheemClient("u@example.com", "pw", api_factory=factory)
+    pushover = FakePushover()
+    logger = logging.getLogger("test_rheem")
+    monitor = RheemMonitor(
+        client=client,
+        pushover=pushover,
+        logger=logger,
+        state_file=state_file,
+    )
+    return monitor, pushover
+
+
+def test_transient_network_error_does_not_propagate(tmp_path: Path) -> None:
+    """A non-PyeconetError (e.g. asyncio.TimeoutError) is caught, not raised."""
+    state = str(tmp_path / "state.json")
+    monitor, pushover = _monitor_with_throwing(state)
+    # Should return [] without raising.
+    result = asyncio.run(monitor.check_once())
+    assert result == []
+    # No Pushover spam for transient errors (only auth/api get P0).
+    assert pushover.sent == []
+
+
+def test_run_continuous_survives_transient_error(tmp_path: Path) -> None:
+    """run_continuous must not die on a transient error mid-cycle."""
+    state = str(tmp_path / "state.json")
+    monitor, _ = _monitor_with_throwing(state)
+    calls = 0
+
+    async def stop_after(n: int) -> None:
+        nonlocal calls
+        while calls < n:
+            await monitor.check_once()
+            calls += 1
+
+    # If check_once raised, this would propagate and fail the test.
+    asyncio.run(stop_after(3))
+    assert calls == 3
+
+
+def test_save_state_is_atomic_no_tmp_left(tmp_path: Path) -> None:
+    """_save_state writes via tmp+os.replace; no .tmp file remains."""
+    state = str(tmp_path / "state.json")
+    monitor, _ = _monitor_with(
+        [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)], state
+    )
+    asyncio.run(monitor.check_once())
+    # State file is valid JSON.
+    with open(state) as f:
+        data = json.load(f)
+    assert data == {"alerted": {"S1": "p1"}}
+    # No leftover tmp file.
+    assert not Path(state + ".tmp").exists()
+
+
+def test_load_state_recovers_from_corrupt_file(tmp_path: Path) -> None:
+    """A truncated/corrupt state file is ignored (fresh start), not fatal."""
+    state = str(tmp_path / "state.json")
+    Path(state).write_text('{"alerted": {"S1": "p1')  # truncated
+    monitor, _ = _monitor_with(
+        [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)], state
+    )
+    # Loaded fresh (empty), then re-alerts because it's low.
+    assert monitor.alerted == {}

--- a/Rheem/test_rheem_client.py
+++ b/Rheem/test_rheem_client.py
@@ -393,3 +393,28 @@ def test_load_state_recovers_from_corrupt_file(tmp_path: Path) -> None:
     )
     # Loaded fresh (empty), then re-alerts because it's low.
     assert monitor.alerted == {}
+
+
+def test_mid_threshold_gate_blocks_premature_clear(tmp_path: Path) -> None:
+    """Recovery must reach mid_threshold, not merely exceed low_threshold.
+
+    Regression for the dead-`mid_threshold` bug: with mid_threshold=100, a
+    tank at 66 (above low but below mid) must hold the alert, not clear it.
+    """
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)]
+    monitor, pushover = _monitor_with(heaters, state, mid_threshold=100)
+    asyncio.run(monitor.check_once())  # P1 fired
+    assert monitor.alerted["S1"] == "p1"
+    # Recover to 66 — above low_threshold (33) but below mid_threshold (100).
+    heaters[0].availability = 66
+    asyncio.run(monitor.check_once())
+    # No clear fired; alert still active.
+    assert len(pushover.sent) == 1
+    assert "S1" in monitor.alerted
+    # Now reach mid_threshold -> clear.
+    heaters[0].availability = 100
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 2
+    assert pushover.sent[1][2] == -1
+    assert "S1" not in monitor.alerted

--- a/Rheem/test_rheem_client.py
+++ b/Rheem/test_rheem_client.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tests for Rheem EcoNet client and monitor.
+
+No patch() — dependencies (EcoNet api, Pushover) are injected as fakes.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from pyeconet.equipment import EquipmentType
+from pyeconet.errors import GenericHTTPError, InvalidCredentialsError
+
+from Rheem.rheem_client import RheemAPIError, RheemAuthError, RheemClient
+from Rheem.rheem_manager import RheemMonitor
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class FakeWaterHeater:
+    serial_number: str
+    name: str
+    availability: Optional[int]
+    running: bool = False
+    set_point: int = 120
+    connected: bool = True
+
+    @property
+    def device_name(self) -> str:
+        return self.name
+
+    @property
+    def tank_hot_water_availability(self) -> Optional[int]:
+        return self.availability
+
+
+class FakeEcoNetApi:
+    def __init__(self, heaters: list[FakeWaterHeater]) -> None:
+        self._heaters = heaters
+
+    async def get_equipment_by_type(
+        self, equipment_types: list[EquipmentType]
+    ) -> dict[EquipmentType, list[FakeWaterHeater]]:
+        result: dict[EquipmentType, list[FakeWaterHeater]] = {}
+        for et in equipment_types:
+            result[et] = list(self._heaters) if et == EquipmentType.WATER_HEATER else []
+        return result
+
+
+class FakePushover:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, int]] = []
+
+    def send_message(self, message: str, title: str | None = None, priority: int = 0) -> bool:
+        self.sent.append((message, title or "", priority))
+        return True
+
+
+# --------------------------------------------------------------------------- #
+# RheemClient tests
+# --------------------------------------------------------------------------- #
+
+
+def _client_with(heaters: list[FakeWaterHeater]) -> RheemClient:
+    api = FakeEcoNetApi(heaters)
+
+    async def factory() -> FakeEcoNetApi:
+        return api
+
+    return RheemClient("u@example.com", "pw", api_factory=factory)
+
+
+def test_get_water_heaters_maps_availability() -> None:
+    heaters = [
+        FakeWaterHeater(serial_number="S1", name="Garage", availability=66),
+        FakeWaterHeater(serial_number="S2", name="Basement", availability=None),
+    ]
+    client = _client_with(heaters)
+    statuses = asyncio.run(client.get_water_heaters())
+    assert len(statuses) == 2
+    s1, s2 = statuses
+    assert s1.serial_number == "S1"
+    assert s1.name == "Garage"
+    assert s1.availability == 66
+    assert s1.running is False
+    assert s1.set_point == 120
+    assert s1.connected is True
+    assert s2.availability is None
+
+
+def test_get_water_heaters_auth_error() -> None:
+    async def factory() -> FakeEcoNetApi:
+        raise InvalidCredentialsError("bad creds")
+
+    client = RheemClient("u@example.com", "pw", api_factory=factory)
+    with pytest.raises(RheemAuthError):
+        asyncio.run(client.get_water_heaters())
+
+
+def test_get_water_heaters_api_error() -> None:
+    async def factory() -> FakeEcoNetApi:
+        raise GenericHTTPError(500)
+
+    client = RheemClient("u@example.com", "pw", api_factory=factory)
+    with pytest.raises(RheemAPIError):
+        asyncio.run(client.get_water_heaters())
+
+
+# --------------------------------------------------------------------------- #
+# RheemMonitor tests
+# --------------------------------------------------------------------------- #
+
+
+def _monitor_with(
+    heaters: list[FakeWaterHeater],
+    state_file: str,
+    low_threshold: int = 33,
+    mid_threshold: int = 66,
+) -> tuple[RheemMonitor, FakePushover]:
+    client = _client_with(heaters)
+    pushover = FakePushover()
+    logger = logging.getLogger("test_rheem")
+    monitor = RheemMonitor(
+        client=client,
+        pushover=pushover,
+        logger=logger,
+        state_file=state_file,
+        low_threshold=low_threshold,
+        mid_threshold=mid_threshold,
+    )
+    return monitor, pushover
+
+
+def test_low_availability_fires_p1_alert(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    monitor, pushover = _monitor_with(
+        [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)], state
+    )
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    msg, title, priority = pushover.sent[0]
+    assert title == "Rheem Low Hot Water"
+    assert priority == 1
+    assert "Garage" in msg
+    assert monitor.alerted["S1"] is True
+
+
+def test_empty_tank_fires_p1_alert(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    monitor, pushover = _monitor_with(
+        [FakeWaterHeater(serial_number="S1", name="Garage", availability=0)], state
+    )
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    assert pushover.sent[0][2] == 1
+    assert monitor.alerted["S1"] is True
+
+
+def test_already_alerted_no_duplicate(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())
+    # Still low -> no second alert.
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    assert monitor.alerted["S1"] is True
+
+
+def test_recovery_to_mid_clears_alert(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())
+    assert monitor.alerted["S1"] is True
+    # Recover to mid.
+    heaters[0].availability = 66
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 2
+    msg, title, priority = pushover.sent[1]
+    assert title == "Rheem Hot Water Recovered"
+    assert priority == -1
+    assert monitor.alerted["S1"] is False
+
+
+def test_full_tank_no_alert(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    monitor, pushover = _monitor_with(
+        [FakeWaterHeater(serial_number="S1", name="Garage", availability=100)], state
+    )
+    asyncio.run(monitor.check_once())
+    assert pushover.sent == []
+    assert monitor.alerted == {}
+
+
+def test_none_availability_skipped(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    monitor, pushover = _monitor_with(
+        [FakeWaterHeater(serial_number="S1", name="Garage", availability=None)], state
+    )
+    asyncio.run(monitor.check_once())
+    assert pushover.sent == []
+    assert monitor.alerted == {}
+
+
+def test_disconnected_skipped(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    monitor, pushover = _monitor_with(
+        [FakeWaterHeater(serial_number="S1", name="Garage", availability=0, connected=False)],
+        state,
+    )
+    asyncio.run(monitor.check_once())
+    assert pushover.sent == []
+    assert monitor.alerted == {}
+
+
+def test_state_persisted_across_instances(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)]
+    monitor, _ = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())
+    assert monitor.alerted["S1"] is True
+    # New monitor instance loads persisted state.
+    monitor2, pushover2 = _monitor_with(heaters, state)
+    assert monitor2.alerted["S1"] is True
+    # Still low -> no re-alert (state was loaded).
+    asyncio.run(monitor2.check_once())
+    assert len(pushover2.sent) == 0
+
+
+def test_pruned_gone_device(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)]
+    monitor, _ = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())
+    assert "S1" in monitor.alerted
+    # Device disappears.
+    monitor, _ = _monitor_with([], state)
+    asyncio.run(monitor.check_once())
+    assert "S1" not in monitor.alerted
+
+
+def test_multiple_heaters_independent(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    heaters = [
+        FakeWaterHeater(serial_number="S1", name="Garage", availability=33),
+        FakeWaterHeater(serial_number="S2", name="Basement", availability=100),
+    ]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())
+    assert monitor.alerted["S1"] is True
+    assert monitor.alerted.get("S2", False) is False
+    assert len(pushover.sent) == 1

--- a/Rheem/test_rheem_client.py
+++ b/Rheem/test_rheem_client.py
@@ -114,13 +114,14 @@ def test_get_water_heaters_api_error() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# RheemMonitor tests
+# RheemMonitor tests — three-tier (P2 empty / P1 low / clear at mid)
 # --------------------------------------------------------------------------- #
 
 
 def _monitor_with(
     heaters: list[FakeWaterHeater],
     state_file: str,
+    empty_threshold: int = 0,
     low_threshold: int = 33,
     mid_threshold: int = 66,
 ) -> tuple[RheemMonitor, FakePushover]:
@@ -132,6 +133,7 @@ def _monitor_with(
         pushover=pushover,
         logger=logger,
         state_file=state_file,
+        empty_threshold=empty_threshold,
         low_threshold=low_threshold,
         mid_threshold=mid_threshold,
     )
@@ -149,18 +151,20 @@ def test_low_availability_fires_p1_alert(tmp_path: Path) -> None:
     assert title == "Rheem Low Hot Water"
     assert priority == 1
     assert "Garage" in msg
-    assert monitor.alerted["S1"] is True
+    assert monitor.alerted["S1"] == "p1"
 
 
-def test_empty_tank_fires_p1_alert(tmp_path: Path) -> None:
+def test_empty_tank_fires_p2_alert(tmp_path: Path) -> None:
     state = str(tmp_path / "state.json")
     monitor, pushover = _monitor_with(
         [FakeWaterHeater(serial_number="S1", name="Garage", availability=0)], state
     )
     asyncio.run(monitor.check_once())
     assert len(pushover.sent) == 1
-    assert pushover.sent[0][2] == 1
-    assert monitor.alerted["S1"] is True
+    msg, title, priority = pushover.sent[0]
+    assert title == "Rheem Hot Water Empty"
+    assert priority == 2
+    assert monitor.alerted["S1"] == "p2"
 
 
 def test_already_alerted_no_duplicate(tmp_path: Path) -> None:
@@ -171,7 +175,36 @@ def test_already_alerted_no_duplicate(tmp_path: Path) -> None:
     # Still low -> no second alert.
     asyncio.run(monitor.check_once())
     assert len(pushover.sent) == 1
-    assert monitor.alerted["S1"] is True
+    assert monitor.alerted["S1"] == "p1"
+
+
+def test_escalation_low_to_empty_fires_p2(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # P1
+    assert monitor.alerted["S1"] == "p1"
+    # Drops to empty -> escalate to P2.
+    heaters[0].availability = 0
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 2
+    msg, title, priority = pushover.sent[1]
+    assert title == "Rheem Hot Water Empty"
+    assert priority == 2
+    assert monitor.alerted["S1"] == "p2"
+
+
+def test_de_escalation_empty_to_low_no_realert(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=0)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # P2
+    assert monitor.alerted["S1"] == "p2"
+    # Recovers to 1/3rd (still in low zone) -> no re-alert, tier stays p2.
+    heaters[0].availability = 33
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    assert monitor.alerted["S1"] == "p2"
 
 
 def test_recovery_to_mid_clears_alert(tmp_path: Path) -> None:
@@ -179,7 +212,7 @@ def test_recovery_to_mid_clears_alert(tmp_path: Path) -> None:
     heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)]
     monitor, pushover = _monitor_with(heaters, state)
     asyncio.run(monitor.check_once())
-    assert monitor.alerted["S1"] is True
+    assert monitor.alerted["S1"] == "p1"
     # Recover to mid.
     heaters[0].availability = 66
     asyncio.run(monitor.check_once())
@@ -187,7 +220,20 @@ def test_recovery_to_mid_clears_alert(tmp_path: Path) -> None:
     msg, title, priority = pushover.sent[1]
     assert title == "Rheem Hot Water Recovered"
     assert priority == -1
-    assert monitor.alerted["S1"] is False
+    assert "S1" not in monitor.alerted
+
+
+def test_recovery_from_empty_clears_alert(tmp_path: Path) -> None:
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=0)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # P2
+    # Jump straight to full -> clear.
+    heaters[0].availability = 100
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 2
+    assert pushover.sent[1][2] == -1
+    assert "S1" not in monitor.alerted
 
 
 def test_full_tank_no_alert(tmp_path: Path) -> None:
@@ -226,10 +272,10 @@ def test_state_persisted_across_instances(tmp_path: Path) -> None:
     heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33)]
     monitor, _ = _monitor_with(heaters, state)
     asyncio.run(monitor.check_once())
-    assert monitor.alerted["S1"] is True
+    assert monitor.alerted["S1"] == "p1"
     # New monitor instance loads persisted state.
     monitor2, pushover2 = _monitor_with(heaters, state)
-    assert monitor2.alerted["S1"] is True
+    assert monitor2.alerted["S1"] == "p1"
     # Still low -> no re-alert (state was loaded).
     asyncio.run(monitor2.check_once())
     assert len(pushover2.sent) == 0
@@ -251,10 +297,12 @@ def test_multiple_heaters_independent(tmp_path: Path) -> None:
     state = str(tmp_path / "state.json")
     heaters = [
         FakeWaterHeater(serial_number="S1", name="Garage", availability=33),
-        FakeWaterHeater(serial_number="S2", name="Basement", availability=100),
+        FakeWaterHeater(serial_number="S2", name="Basement", availability=0),
     ]
     monitor, pushover = _monitor_with(heaters, state)
     asyncio.run(monitor.check_once())
-    assert monitor.alerted["S1"] is True
-    assert monitor.alerted.get("S2", False) is False
-    assert len(pushover.sent) == 1
+    assert monitor.alerted["S1"] == "p1"
+    assert monitor.alerted["S2"] == "p2"
+    # One P1 + one P2.
+    priorities = sorted(p for _, _, p in pushover.sent)
+    assert priorities == [1, 2]

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -198,8 +198,9 @@ rheem:
   password: ""
   poll_seconds: 300
   # Discrete tank levels reported by EcoNet: 0/33/66/100.
-  low_threshold: 33   # 1/3rd full or empty -> fire P1 alert
-  mid_threshold: 66   # 2/3rd full -> send P-1 clear, reset alert state
+  empty_threshold: 0    # empty -> P2 emergency (retries until acked)
+  low_threshold: 33     # 1/3rd full -> P1 high (bypasses quiet hours)
+  mid_threshold: 66     # 2/3rd full -> P-1 clear, reset alert state
 
 # === Ring Devices ===
 ring:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -32,6 +32,7 @@ pushover:
     RachioFlume: ""
     Ring Security: ""
     SamsungFrame: ""
+    Rheem: ""
     WhatsAppSummary: ""
 
 # === Node Monitoring ===
@@ -190,6 +191,15 @@ august:
   password: ""  
   phone: "+1234567890"
   token_file: config/tokens/august_auth_token.json
+
+# === Rheem EcoNet Water Heater ===
+rheem:
+  email: ""
+  password: ""
+  poll_seconds: 300
+  # Discrete tank levels reported by EcoNet: 0/33/66/100.
+  low_threshold: 33   # 1/3rd full or empty -> fire P1 alert
+  mid_threshold: 66   # 2/3rd full -> send P-1 clear, reset alert state
 
 # === Ring Devices ===
 ring:

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,103 @@
+# lib/ — shared utilities
+
+Shared library used by all homely-vibes modules. Config, logging, notifications, networking, secret I/O, and cross-process locking.
+
+## Modules
+
+### `config.py` — typed configuration
+OmegaConf-based hierarchical YAML config with dataclass-backed type safety.
+
+- `config/default.yaml` — safe defaults, checked into git
+- `config/local.yaml` — secrets + per-host overrides, gitignored (symlinked to `~/bin/Common-configs/Code_config_local.yaml`)
+- Merged hierarchically; `local.yaml` wins.
+
+```python
+from lib.config import get_config, reset_config
+
+cfg = get_config()
+email = cfg.tesla.powerwall_email
+tokens = cfg.pushover.tokens["Powerwall"]
+
+# Long-running processes: hot-reload between cycles
+reset_config()
+cfg = get_config()
+```
+
+**Adding a module's config:** add a dataclass, register it in the root `Config` dataclass, add a `your_module:` block to `config/default.yaml`. Never `cfg_dict.get("key")` — the system exists to give type-checked access.
+
+Public API: `get_config() -> Config`, `reset_config() -> None`, `Config` (root dataclass).
+
+### `logger.py` — dual-handler logging
+```python
+from lib.logger import get_logger
+logger = get_logger(__name__)
+```
+`get_logger` sets up stdout + a per-script log file under `cfg.paths.logging_dir`. The script name is derived from `__main__.__file__` so each entrypoint gets its own log file. `SystemLogger.reset()` / `set_level()` available for testing/runtime control.
+
+Cron entries redirect stdout+stderr to a file (`>> ~/logs/<script>.log 2>&1`) as a safety net for anything that happens before the logger initializes.
+
+### `MyPushover.py` — Pushover notifications
+```python
+from lib.MyPushover import Pushover
+pushover = Pushover(cfg.pushover.user, cfg.pushover.tokens["YourModule"])
+pushover.send_message("msg", title="Title", priority=1)
+```
+Priority convention (`P{N}` = Pushover `priority=N`): **P-1** silent, **P0** normal/recovery, **P1** high (bypasses quiet hours), **P2** emergency (retries until acked). Auth failures land at P0.
+
+### `Mailer.py` — Gmail SMTP
+```python
+from lib.Mailer import sendmail
+sendmail("topic", alert=True, message="<html>...</html>")
+```
+Sends via `smtp.gmail.com:465` (SSL) using `cfg.email.*`. HTML detected by `<html>` prefix; otherwise plain UTF-8. Honors an `always_email` flag and a per-call `alert` boolean (no-op when neither is set).
+
+### `MyTwilio.py` — SMS via Twilio
+```python
+from lib.MyTwilio import sendsms
+sendsms(rcpt="+1...", msg="text")
+```
+Uses `cfg.twilio.*`. Logs the message SID on success.
+
+### `NetHelpers.py` — network/SSH utilities
+- `ping_output(node, count=1, desired_up=True) -> bool` — subprocess ping with timeout.
+- `ssh_connect(ip, user, passwd) -> SSHClient`, `ssh_cmd_v2(client, cmd) -> str` — paramiko.
+- `ssh_cmd(node, user, passwd, winCmd) -> str` — connect + run + close in one call.
+- `http_req(cmd) -> str`, `no_stdout()` context manager, `redirect_to_file(text)`.
+
+### `secure_io.py` — atomic 0o600 secret writes
+**Never** `open(path, "w")` / `write_text()` + `chmod` for a secret — both leave a TOCTOU window at 0o644 under a 0o022 umask.
+
+```python
+from lib.secure_io import write_secret_atomic, ensure_secret_perms
+# We own the write — 0o600 from birth:
+write_secret_atomic(path, {"access_token": "...", "expires_at": 123})
+
+# Third-party library owns the write — tighten perms after it returns:
+ensure_secret_perms(path)
+```
+Accepts `str | bytes | dict` (dict is JSON-encoded). Both are idempotent on existing 0o600 files.
+
+### `file_lock.py` — POSIX advisory flock
+Cross-process critical sections. Used to serialize Ring token refresh across RingSecurity (Python) and RingBeams (Node sidecar) — both read/write `config/tokens/ring_auth_token.json` and Ring OAuth rotates the refresh_token on every use, so overlapping refreshes race the server.
+
+```python
+from lib.file_lock import acquire_lock, LockTimeoutError
+with acquire_lock(token_path, timeout_s=60.0):
+    # exclusive access across processes
+    ...
+```
+Locks a sibling `<path>.lock` file (NOT the resource — the resource is rewritten via tmp+rename, so an fd on the pre-rename inode would dangle). Auto-released on exit/crash. Raises `LockTimeoutError(TimeoutError)` if not acquired in time.
+
+## Submodules
+- `lib/TeslaPy/` — legacy Tesla SDK, git submodule, excluded from linting. (Tesla module now uses Fleet API; submodule retained for history.)
+
+## Conventions
+- **No `patch()` in tests.** Refactor production code to accept the dependency as a parameter (factory or client). Inject fakes that satisfy a `Protocol` or duck-type the surface.
+- **Secrets live in `config/tokens/`** (symlinked to `~/bin/Common-configs/tokens/`, gitignored). Config values in `config/local.yaml` (gitignored).
+- **New module config → dataclass in `config.py` + default.yaml block.** Never ad-hoc `get()`.
+
+## Tests
+```bash
+uv run python -m pytest lib/ -v
+```
+`test_file_lock.py`, `test_secure_io.py` — deterministic, no network.

--- a/lib/config.py
+++ b/lib/config.py
@@ -182,6 +182,18 @@ class AugustConfig:
 
 
 @dataclass
+class RheemConfig:
+    """Rheem EcoNet water heater configuration"""
+
+    email: str
+    password: str
+    poll_seconds: int
+    # Discrete tank levels: 0/33/66/100. Alert at/below low, clear at/above mid.
+    low_threshold: int
+    mid_threshold: int
+
+
+@dataclass
 class RingConfig:
     """Ring devices configuration"""
 
@@ -376,6 +388,7 @@ class Config:
     water_monitor: WaterMonitorConfig
     tesla: TeslaConfig
     august: AugustConfig
+    rheem: RheemConfig
     ring: RingConfig
     ring_beams: RingBeamsConfig
     samsung_frame: SamsungFrameConfig

--- a/lib/config.py
+++ b/lib/config.py
@@ -188,7 +188,9 @@ class RheemConfig:
     email: str
     password: str
     poll_seconds: int
-    # Discrete tank levels: 0/33/66/100. Alert at/below low, clear at/above mid.
+    # Discrete tank levels: 0/33/66/100. Empty (<=empty) -> P2, low
+    # (<=low) -> P1, clear at >= mid.
+    empty_threshold: int
     low_threshold: int
     mid_threshold: int
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "omegaconf>=2.3.0",
     "tesla-fleet-api>=1.4.7",
     "ring-doorbell>=0.9.0",
+    "pyeconet>=0.2.2",
 ]
 
 [project.optional-dependencies]
@@ -75,7 +76,7 @@ dev = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["lib", "Tesla", "BimpopAI", "August", "RingSecurity", "RingBeams"]
+packages = ["lib", "Tesla", "BimpopAI", "August", "RingSecurity", "RingBeams", "Rheem"]
 
 [tool.deptry]
 known_first_party = [
@@ -160,7 +161,7 @@ DEP002 = [
 DEP003 = ["google", "streamlit", "BimpopAI", "PyObjCTools"]  # PyObjCTools comes via rumps → pyobjc
 
 [tool.pytest.ini_options]
-testpaths = ["Tesla", "RachioFlume", "August", "SamsungFrame", "VoiceNotes", "RingSecurity", "RingBeams", "lib"]
+testpaths = ["Tesla", "RachioFlume", "August", "SamsungFrame", "VoiceNotes", "RingSecurity", "RingBeams", "Rheem", "lib"]
 addopts = "-v --tb=short"
 asyncio_mode = "auto"
 
@@ -204,6 +205,7 @@ module = [
     "rumps.*",
     "pynput.*",
     "yalexs.*",
+    "pyeconet.*",
     "twilio.*",
     "webview.*",
     "selenium.*",

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiooui" },
     { name = "bleak" },
-    { name = "dbus-fast", marker = "sys_platform == 'linux'" },
+    { name = "dbus-fast" },
     { name = "uart-devices" },
     { name = "usb-devices" },
 ]
@@ -1037,6 +1037,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pillow-heif" },
     { name = "pydantic" },
+    { name = "pyeconet" },
     { name = "requests" },
     { name = "requests-oauthlib" },
     { name = "ring-doorbell" },
@@ -1120,6 +1121,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pillow-heif", specifier = ">=0.22.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pyeconet", specifier = ">=0.2.2" },
     { name = "pynput", marker = "extra == 'voice'", specifier = ">=1.7.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
@@ -2107,6 +2109,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paho-mqtt"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/15/0a6214e76d4d32e7f663b109cf71fb22561c2be0f701d67f93950cd40542/paho_mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834", size = 148848, upload-time = "2024-04-29T19:52:55.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/cb/00451c3cf31790287768bb12c6bec834f5d292eaf3022afc88e14b8afc94/paho_mqtt-2.1.0-py3-none-any.whl", hash = "sha256:6db9ba9b34ed5bc6b6e3812718c7e06e2fd7444540df2455d2c51bd58808feee", size = 67219, upload-time = "2024-04-29T19:52:48.345Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2501,6 +2512,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240, upload-time = "2024-05-10T15:36:21.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403, upload-time = "2024-05-10T15:36:17.36Z" },
+]
+
+[[package]]
+name = "pyeconet"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "paho-mqtt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/44/52c3b41e312dd4f5cb3e44fbd0e974d0e34fdb54c1e0bc575ffb0f25320d/pyeconet-0.2.2.tar.gz", hash = "sha256:0c07c942a809fc17d638eee3d37c1e8ab4fc2778935f6786861be1a6b88ff84f", size = 14222, upload-time = "2026-03-05T12:04:51.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/3d/ca462f225fd403412912ddb2f903947eb7bc396f68f315276ca8afd5d86d/pyeconet-0.2.2-py3-none-any.whl", hash = "sha256:06e5382fd191bb895826921015c70f8cd82192fb0e57785d795c2ff43c4e4ff0", size = 15326, upload-time = "2026-03-05T12:04:49.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
No visibility into available hot water on the Rheem/EcoNet tank. We want a push alert when hot water is running low, and a silent clear when it recovers — same pattern as August lock / Tesla Powerwall monitoring.

## Impact
New `Rheem/` module monitors EcoNet-connected water heaters via the unofficial `pyeconet` library (ClearBlade cloud, `rheem.clearblade.com`). Fires a **P1** Pushover when available hot water drops to low (empty or 1/3rd full) and a **P-1** silent clear when it recovers to mid (2/3rd full). Per-device hysteresis with persisted state prevents re-alerting every poll and flapping between adjacent levels.

## Changes
- **`Rheem/rheem_client.py`** — wraps `pyeconet` with an injectable `api_factory` (DI over `patch()`); maps `WaterHeater` → `WaterHeaterStatus` dataclass (serial, name, availability, running, set_point, connected). Auth errors → `RheemAuthError`; API errors → `RheemAPIError`.
- **`Rheem/rheem_manager.py`** — CLI (`monitor` / `test`). `RheemMonitor` runs the alert state machine: availability ≤ low_threshold and not already alerted → P1; availability ≥ mid_threshold and alerted → P-1 clear. State persisted to `{logging_dir}/rheem_monitor_state.json` keyed by serial. Skips disconnected tanks and tanks that don't report `@HOTWATER` (None). Auth/comms failures → P0. Depends on a `Notifier` Protocol (send-only surface) so tests inject a fake without mocking `Pushover`.
- **`Rheem/test_rheem_client.py`** — 13 tests, all injected fakes (fake EcoNet api, fake notifier). Covers availability mapping, auth/API errors, alert fire/clear hysteresis, no-duplicate, None-availability skip, disconnected skip, state persistence across instances, gone-device pruning, multi-heater independence.
- **`Rheem/README.md`** — setup, usage, alert priorities, caveats (unofficial API, discrete levels, unsupported tanks).
- **`lib/README.md`** — new: documents the shared `lib/` surface (config, logger, MyPushover, Mailer, MyTwilio, NetHelpers, secure_io, file_lock) and repo conventions (no `patch()`, secrets-on-disk rules, config dataclass pattern).
- **`lib/config.py`** — `RheemConfig` dataclass (email, password, poll_seconds, low_threshold, mid_threshold) + registered in root `Config`.
- **`config/default.yaml`** — `rheem:` block (defaults: poll 300s, low 33, mid 66) + `Rheem` Pushover token slot.
- **`pyproject.toml`** — `pyeconet>=0.2.2` dep; `Rheem` in pytest testpaths, wheel packages, mypy `ignore_missing_imports` override.

## Availability levels (from the tank)
The EcoNet API exposes discrete levels, not a continuous percentage:

| Level | Meaning        | Action                          |
|-------|----------------|---------------------------------|
| 0     | empty          | 🔴 P1 alert                     |
| 33    | "1/3rd full"   | 🔴 P1 alert                     |
| 66    | "2/3rd full"   | 🟢 P-1 clear, reset alert state |
| 100   | full           | no-op (already cleared at 66)   |
| None  | not supported  | skip silently                   |

Thresholds align to these levels (defaults: low=33, mid=66).

## Live verification
Ran `uv run python Rheem/rheem_manager.py test` against the real EcoNet account — auth succeeded, one heater (`"Luke Warm"`) returned `avail=66% (2/3rd full), running=True, set_point=127, connected=True`. P-1 Pushover summary delivered. The tank reports `@HOTWATER`, so alerting is supported on this model. No alert fired (correct — mid is not low).

## Validation
- `ruff check` + `ruff format` ✓
- `mypy` ✓ (16 files, strict)
- `pytest Rheem/` ✓ (13/13)
- `pytest` (full suite) ✓ (294 passed) + NodeCheck (29) + Tesla (13) in isolation
- `deptry .` ✓, `vulture` ✓, `codespell` ✓

## References
- pyeconet (unofficial EcoNet client): https://github.com/w1ll1am23/pyeconet
- EcoNet API backend: `rheem.clearblade.com` (ClearBlade)
- Follows repo patterns: August (`august_client.py` state-persistence alert monitor), Tesla (`tesla_client.py` DI-over-patch SDK wrapper), `lib/secure_io.py`/`lib/file_lock.py` conventions
- #224 — tech-debt: extract the `Notifier` Protocol to `lib/` and adopt across August/Ring/RingBeams/RachioFlume

🤖 Generated with [Pi](https://pi.dev)