### PR TITLE
feat(NodeCheck): add ARP-based heartbeat probe for WiFi power-save devices

### DIFF
--- a/BrowserAlert/README.md
+++ b/BrowserAlert/README.md
@@ -9,7 +9,7 @@ This system monitors web browsing activity by analyzing Chrome browser history a
 ## Prerequisites
 
 ### Network Setup
-- **Static IP**: 192.168.1.24
+- **Static IP**: 192.168.x.x
 - **Network**: Ensure device is on main network (Aerosol), not guest network
   - Check from Deco Device page
   - If on Guest network, disable Guest on Deco to force device to roam back
@@ -122,7 +122,7 @@ Also tried: `chrome://net-internals/#dns`
 Attempted redirect configuration:
 ```apache
 # /etc/apache2/sites-enabled/000-default.conf
-ErrorDocument 404 http://192.168.1.1:30000/shn_blocking.html?cat_id=100&domain=EDEN_Inc_Not_Allowed/
+ErrorDocument 404 http://192.168.x.x:30000/shn_blocking.html?cat_id=100&domain=EDEN_Inc_Not_Allowed/
 
 # Test and restart
 sudo apache2ctl configtest

--- a/NodeCheck/README.md
+++ b/NodeCheck/README.md
@@ -30,8 +30,8 @@ uv run NodeCheck/manage_nodes.py --type foscam --always_email
 ### Hardware Specs
 
 ```bash
-uv run NodeCheck/check_hw_specs.py --ip 192.168.1.200
-uv run NodeCheck/check_hw_specs.py --ip 192.168.1.200 --user <ssh-user> --port 22
+uv run NodeCheck/check_hw_specs.py --ip 192.168.x.x
+uv run NodeCheck/check_hw_specs.py --ip 192.168.x.x --user <ssh-user> --port 22
 ```
 
 SSHes into the host and prints model, SoC, CPU, memory, storage, network
@@ -79,17 +79,17 @@ node_check:
     password: your_password
   node_configs:
     "Camera1":
-      ip: "192.168.1.51"
+      ip: "192.168.x.x"
       node_type: foscam
       username: your_username
       password: your_password
     "WinBox1":
-      ip: "192.168.1.100"
+      ip: "192.168.x.x"
       node_type: windows
       username: your_username
       password: your_password
     "Server1":
-      ip: "192.168.1.101"
+      ip: "192.168.x.x"
       node_type: generic
     "PhoneOnWifi":
       ip: "192.168.1.xxx"

--- a/NodeCheck/README.md
+++ b/NodeCheck/README.md
@@ -63,6 +63,7 @@ temperature. Prompts for a sudo password only if the remote requires one
 - **`FoscamNode`**: Camera operations (image capture, HTTP reboot)
 - **`WindowsNode`**: SSH commands, uptime checks
 - **`GenericNode`**: Ping-only monitoring
+- **`ArpNode`**: Presence via ARP cache — for WiFi devices that drop ICMP under power-save (e.g. iPhones)
 
 ## Configuration
 
@@ -90,6 +91,9 @@ node_check:
     "Server1":
       ip: "192.168.1.101"
       node_type: generic
+    "PhoneOnWifi":
+      ip: "192.168.1.xxx"
+      node_type: arp
 ```
 
 ## Command Reference

--- a/NodeCheck/check_hw_specs.py
+++ b/NodeCheck/check_hw_specs.py
@@ -9,8 +9,8 @@ Prompts for a sudo password only if the remote sudo requires one
 (tries passwordless first, falls back to password).
 
 Usage:
-    uv run NodeCheck/check_hw_specs.py --ip 192.168.1.200
-    uv run NodeCheck/check_hw_specs.py --ip 192.168.1.200 --user <ssh-user>
+    uv run NodeCheck/check_hw_specs.py --ip 192.168.x.x
+    uv run NodeCheck/check_hw_specs.py --ip 192.168.x.x --user <ssh-user>
 """
 
 import argparse

--- a/NodeCheck/heartbeat_nodes.py
+++ b/NodeCheck/heartbeat_nodes.py
@@ -6,13 +6,14 @@ from typing import List, Set
 from lib.config import NodeType, get_config
 from lib.logger import SystemLogger
 from lib.MyPushover import Pushover
-from NodeCheck.nodes import FoscamNode, GenericNode, SomfyMyLinkNode, WindowsNode
+from NodeCheck.nodes import ArpNode, FoscamNode, GenericNode, SomfyMyLinkNode, WindowsNode
 
 _NODE_CLASS_BY_TYPE: dict[NodeType, type[GenericNode]] = {
     NodeType.FOSCAM: FoscamNode,
     NodeType.WINDOWS: WindowsNode,
     NodeType.MYLINK: SomfyMyLinkNode,
     NodeType.GENERIC: GenericNode,
+    NodeType.ARP: ArpNode,
 }
 
 logger = SystemLogger.get_logger(__name__)

--- a/NodeCheck/nodes.py
+++ b/NodeCheck/nodes.py
@@ -225,6 +225,11 @@ class ArpNode(GenericNode):
             logger.debug(f"ARP check for {self.name}: timeout")
             self.is_online = False
             return False
+        except FileNotFoundError:
+            # `arp` binary missing (minimal Linux images may ship only iproute2).
+            logger.warning(f"ARP check for {self.name}: `arp` binary not found on PATH")
+            self.is_online = False
+            return False
 
         stdout = result.stdout or ""
         has_mac = bool(_MAC_RE.search(stdout))

--- a/NodeCheck/nodes.py
+++ b/NodeCheck/nodes.py
@@ -2,6 +2,7 @@
 import json
 import re
 import socket
+import subprocess
 import time
 from lib import NetHelpers
 from lib.config import NodeConfig
@@ -199,3 +200,35 @@ class WindowsNode(GenericNode):
                 logger.info(f"{self.name} is up since {foundStr}")
                 return True
         return False
+
+
+# WiFi devices in power-save (notably iPhones) drop ICMP replies but stay
+# associated with the AP, so the router's ARP cache still has a valid MAC.
+# ArpNode probes presence via the ARP cache instead of ICMP.
+_MAC_RE = re.compile(r"([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}")
+
+
+class ArpNode(GenericNode):
+    def heartbeat(self) -> bool:
+        # Fire one ping to trigger ARP resolution if the entry is stale.
+        # Result is intentionally discarded — we only care about the ARP cache.
+        NetHelpers.ping_output(node=self.config.ip, count=1, desired_up=True)
+        try:
+            result = subprocess.run(
+                ["arp", "-n", self.config.ip],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            logger.debug(f"ARP check for {self.name}: timeout")
+            self.is_online = False
+            return False
+
+        stdout = result.stdout or ""
+        has_mac = bool(_MAC_RE.search(stdout))
+        is_incomplete = "incomplete" in stdout.lower()
+        self.is_online = has_mac and not is_incomplete
+        logger.debug(f"ARP check for {self.name}: {self.is_online} ({stdout!r})")
+        return self.is_online

--- a/NodeCheck/test_nodes.py
+++ b/NodeCheck/test_nodes.py
@@ -2,13 +2,14 @@
 """Tests for NodeCheck nodes module."""
 
 import pytest
+import subprocess
 from unittest.mock import patch
 from typing import Any
 import json
 import socket
 from unittest.mock import MagicMock
 from NodeCheck.manage_nodes import NodeChecker
-from NodeCheck.nodes import FoscamNode, GenericNode, SomfyMyLinkNode, WindowsNode
+from NodeCheck.nodes import ArpNode, FoscamNode, GenericNode, SomfyMyLinkNode, WindowsNode
 from lib.config import NodeConfig, NodeType
 
 
@@ -414,6 +415,68 @@ class TestWaitForHeartbeat:
 
         assert self._checker()._wait_for_heartbeat(node, attempts=4, delay=0) is False
         assert node.heartbeat.call_count == 4
+
+
+class TestArpNode:
+    """Test ArpNode functionality"""
+
+    @pytest.fixture
+    def arp_config(self) -> NodeConfig:
+        return NodeConfig("192.0.2.79", NodeType.ARP)
+
+    @pytest.fixture
+    def arp_node(self, arp_config: NodeConfig) -> ArpNode:
+        return ArpNode("TestPhone", arp_config)
+
+    @patch("NodeCheck.nodes.subprocess.run")
+    @patch("NodeCheck.nodes.NetHelpers.ping_output")
+    def test_arp_node_online(self, mock_ping: Any, mock_run: Any, arp_node: ArpNode) -> None:
+        """MAC in ARP cache -> online, regardless of ping result."""
+        mock_ping.return_value = False
+        mock_run.return_value = MagicMock(
+            stdout="? (192.0.2.79) at aa:bb:cc:dd:ee:ff [ether] on en0\n",
+            returncode=0,
+        )
+
+        assert arp_node.heartbeat() is True
+        assert arp_node.is_online is True
+
+    @patch("NodeCheck.nodes.subprocess.run")
+    @patch("NodeCheck.nodes.NetHelpers.ping_output")
+    def test_arp_node_offline_incomplete(
+        self, mock_ping: Any, mock_run: Any, arp_node: ArpNode
+    ) -> None:
+        """ARP cache entry marked (incomplete) -> offline."""
+        mock_ping.return_value = False
+        mock_run.return_value = MagicMock(
+            stdout="? (192.0.2.79) at (incomplete) on en0\n",
+            returncode=0,
+        )
+
+        assert arp_node.heartbeat() is False
+        assert arp_node.is_online is False
+
+    @patch("NodeCheck.nodes.subprocess.run")
+    @patch("NodeCheck.nodes.NetHelpers.ping_output")
+    def test_arp_node_offline_no_entry(
+        self, mock_ping: Any, mock_run: Any, arp_node: ArpNode
+    ) -> None:
+        """Empty ARP output -> offline."""
+        mock_ping.return_value = False
+        mock_run.return_value = MagicMock(stdout="", returncode=1)
+
+        assert arp_node.heartbeat() is False
+        assert arp_node.is_online is False
+
+    @patch("NodeCheck.nodes.subprocess.run")
+    @patch("NodeCheck.nodes.NetHelpers.ping_output")
+    def test_arp_node_timeout(self, mock_ping: Any, mock_run: Any, arp_node: ArpNode) -> None:
+        """subprocess timeout -> offline, no crash."""
+        mock_ping.return_value = False
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="arp", timeout=2)
+
+        assert arp_node.heartbeat() is False
+        assert arp_node.is_online is False
 
 
 if __name__ == "__main__":

--- a/NodeCheck/test_nodes.py
+++ b/NodeCheck/test_nodes.py
@@ -478,6 +478,18 @@ class TestArpNode:
         assert arp_node.heartbeat() is False
         assert arp_node.is_online is False
 
+    @patch("NodeCheck.nodes.subprocess.run")
+    @patch("NodeCheck.nodes.NetHelpers.ping_output")
+    def test_arp_node_binary_missing(
+        self, mock_ping: Any, mock_run: Any, arp_node: ArpNode
+    ) -> None:
+        """`arp` binary not on PATH -> offline, no crash."""
+        mock_ping.return_value = False
+        mock_run.side_effect = FileNotFoundError(2, "No such file or directory", "arp")
+
+        assert arp_node.heartbeat() is False
+        assert arp_node.is_online is False
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/SamsungFrame/README.md
+++ b/SamsungFrame/README.md
@@ -133,7 +133,7 @@ uv run python SamsungFrame/manage_samsung.py status
 
 Example output:
 ```
-Connecting to Samsung Frame TV at 192.168.1.4...
+Connecting to Samsung Frame TV at 192.168.x.x...
 ==================================================
 TV STATUS
 ==================================================
@@ -318,7 +318,7 @@ Run `uv run python SamsungFrame/manage_samsung.py list-mattes` to see your TV's 
 
 ### Cannot Connect to TV
 
-**Symptoms**: `Failed to connect to TV at 192.168.1.4`
+**Symptoms**: `Failed to connect to TV at 192.168.x.x`
 
 **Solutions**:
 - Verify TV is powered on (not fully off)

--- a/lib/config.py
+++ b/lib/config.py
@@ -29,6 +29,7 @@ class NodeType(StrEnum):
     WINDOWS = "windows"
     GENERIC = "generic"
     MYLINK = "mylink"
+    ARP = "arp"
 
 
 class OpMode(StrEnum):


### PR DESCRIPTION
## Summary

- Adds an opt-in `NodeType.ARP` for NodeCheck. Instead of ICMP, `ArpNode` checks the local ARP cache for a valid MAC to determine presence.
- Useful for WiFi devices (notably iPhones) that stop replying to ping under aggressive power-save but remain associated with the AP.
- Also masks previously checked-in private LAN IPs (`192.168.x.x`) in READMEs and CLI docstrings.

## Design

- New `ArpNode(GenericNode)` fires a single priming ping to trigger ARP resolution if the cache is cold, then parses `arp -n <ip>` for a colon-formatted MAC. Treats `(incomplete)` and empty output as offline. Handles subprocess timeout gracefully.
- BSD (macOS) and Linux `arp` produce compatible line formats — regex `([0-9a-f]{2}:){5}[0-9a-f]{2}` matches both.
- Registered in the existing `_NODE_CLASS_BY_TYPE` dispatch table in `heartbeat_nodes.py` — no refactor to existing types.

## Files

| File | Change |
|---|---|
| `lib/config.py` | `NodeType.ARP` enum value |
| `NodeCheck/nodes.py` | new `ArpNode` class |
| `NodeCheck/heartbeat_nodes.py` | dispatch registration |
| `NodeCheck/test_nodes.py` | 4 unit tests (online / incomplete / no-entry / timeout) |
| `NodeCheck/README.md` | doc + example |
| `BrowserAlert/README.md`, `SamsungFrame/README.md`, `NodeCheck/check_hw_specs.py` | mask private IPs |

## Test plan

- [x] `uv run pytest NodeCheck` — 33 passed (4 new)
- [x] `uv run ruff format && uv run ruff check` — clean
- [x] Pre-commit hooks — Format / Run Tests / Secrets Scan all passed
- [ ] Prod host: after merge, `git pull && uv sync` on prod, observe next NodeCheck cron cycle log for the ARP-typed device.

## References

- Local plan: `/Users/abutala/.claude/plans/modify-node-check-to-iridescent-snowglobe.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)