### PR TITLE
feat(NodeCheck): flap-suppress transient node-down probes (Option C)

### DIFF
--- a/NodeCheck/heartbeat_nodes.py
+++ b/NodeCheck/heartbeat_nodes.py
@@ -2,7 +2,7 @@
 import argparse
 import sys
 import time
-from typing import List, Set
+from typing import Dict, List, Set
 from lib.config import NodeType, get_config
 from lib.logger import SystemLogger
 from lib.MyPushover import Pushover
@@ -15,6 +15,12 @@ _NODE_CLASS_BY_TYPE: dict[NodeType, type[GenericNode]] = {
     NodeType.GENERIC: GenericNode,
     NodeType.ARP: ArpNode,
 }
+
+# Flap suppression: require this many consecutive down probes before alerting.
+# Absorbs one-off blips (WiFi power-save, transient packet loss, cold ARP cache)
+# without waiting a full cooloff period. Costs one extra poll cycle of latency
+# before a real outage triggers a page.
+_MIN_CONSECUTIVE_DOWN_FOR_ALERT = 2
 
 logger = SystemLogger.get_logger(__name__)
 
@@ -29,6 +35,7 @@ class HeartbeatMonitor:
 
         self.last_down_nodes: Set[str] = set()
         self.last_notification_time: float | None = None
+        self.consecutive_down: Dict[str, int] = {}
 
     def _create_nodes_list(self) -> List[GenericNode]:
         """Create nodes for all node types and filter based on specific_nodes parameter"""
@@ -62,22 +69,37 @@ class HeartbeatMonitor:
         return nodes
 
     def check_monitored_nodes(self) -> Set[str]:
-        """Check all monitored nodes and return set of down node names"""
-        down_nodes = set()
+        """Probe every node and return only the flap-suppressed down set.
+
+        A node must fail `_MIN_CONSECUTIVE_DOWN_FOR_ALERT` consecutive probes
+        before appearing in the returned set. A single successful probe resets
+        the streak. This applies uniformly to every NodeType.
+        """
+        confirmed_down: Set[str] = set()
 
         for node in self.monitored_nodes:
+            logger.debug(f"Checking {node.name} ({node.config.ip})...")
             try:
-                logger.debug(f"Checking {node.name} ({node.config.ip})...")
-                if not node.heartbeat():
-                    down_nodes.add(node.name)
-                    logger.warning(f"Node {node.name} is down")
-                else:
-                    logger.debug(f"Node {node.name} is healthy")
+                healthy = node.heartbeat()
             except Exception as e:
                 logger.error(f"Error checking node {node.name}: {e}")
-                down_nodes.add(node.name)
+                healthy = False
 
-        return down_nodes
+            if healthy:
+                if self.consecutive_down.get(node.name, 0) > 0:
+                    logger.debug(f"Node {node.name} recovered (streak reset)")
+                self.consecutive_down[node.name] = 0
+                continue
+
+            streak = self.consecutive_down.get(node.name, 0) + 1
+            self.consecutive_down[node.name] = streak
+            if streak >= _MIN_CONSECUTIVE_DOWN_FOR_ALERT:
+                confirmed_down.add(node.name)
+                logger.warning(f"Node {node.name} is down (streak={streak})")
+            else:
+                logger.info(f"Node {node.name} failed probe (streak={streak}, suppressing alert)")
+
+        return confirmed_down
 
     def send_notification(self, down_nodes: Set[str]) -> None:
         """Send pushover notification for down nodes"""

--- a/NodeCheck/nodes.py
+++ b/NodeCheck/nodes.py
@@ -212,6 +212,8 @@ class ArpNode(GenericNode):
     def heartbeat(self) -> bool:
         # Fire one ping to trigger ARP resolution if the entry is stale.
         # Result is intentionally discarded — we only care about the ARP cache.
+        # A single cold-cache false-negative is absorbed by HeartbeatMonitor's
+        # consecutive-failure flap suppression.
         NetHelpers.ping_output(node=self.config.ip, count=1, desired_up=True)
         try:
             result = subprocess.run(

--- a/NodeCheck/test_heartbeat_nodes.py
+++ b/NodeCheck/test_heartbeat_nodes.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Tests for HeartbeatMonitor flap-suppression logic."""
 
-from typing import List
+from typing import List, cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from NodeCheck.heartbeat_nodes import HeartbeatMonitor
+from NodeCheck.nodes import GenericNode
 
 
 def _fake_node(name: str, healthy_sequence: List[bool]) -> MagicMock:
@@ -23,7 +24,7 @@ def _monitor(nodes: List[MagicMock]) -> HeartbeatMonitor:
     monitor = HeartbeatMonitor.__new__(HeartbeatMonitor)
     monitor.specific_nodes = None
     monitor.pushover = MagicMock()
-    monitor.monitored_nodes = nodes
+    monitor.monitored_nodes = cast(List[GenericNode], nodes)
     monitor.last_down_nodes = set()
     monitor.last_notification_time = None
     monitor.consecutive_down = {}

--- a/NodeCheck/test_heartbeat_nodes.py
+++ b/NodeCheck/test_heartbeat_nodes.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Tests for HeartbeatMonitor flap-suppression logic."""
+
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+from NodeCheck.heartbeat_nodes import HeartbeatMonitor
+
+
+def _fake_node(name: str, healthy_sequence: List[bool]) -> MagicMock:
+    """Build a mock node whose heartbeat() returns the given sequence in order."""
+    node = MagicMock()
+    node.name = name
+    node.config.ip = f"192.0.2.{abs(hash(name)) % 200 + 1}"
+    node.heartbeat.side_effect = healthy_sequence
+    return node
+
+
+def _monitor(nodes: List[MagicMock]) -> HeartbeatMonitor:
+    """Construct a HeartbeatMonitor bypassing __init__ (no config, no pushover)."""
+    monitor = HeartbeatMonitor.__new__(HeartbeatMonitor)
+    monitor.specific_nodes = None
+    monitor.pushover = MagicMock()
+    monitor.monitored_nodes = nodes
+    monitor.last_down_nodes = set()
+    monitor.last_notification_time = None
+    monitor.consecutive_down = {}
+    return monitor
+
+
+class TestFlapSuppression:
+    def test_single_down_probe_is_suppressed(self) -> None:
+        """One failing probe should NOT surface as down (streak=1 < 2)."""
+        node = _fake_node("Phone", [False])
+        monitor = _monitor([node])
+
+        assert monitor.check_monitored_nodes() == set()
+        assert monitor.consecutive_down["Phone"] == 1
+
+    def test_two_consecutive_down_probes_alert(self) -> None:
+        """Two consecutive failures surface the node as down."""
+        node = _fake_node("Phone", [False, False])
+        monitor = _monitor([node])
+
+        assert monitor.check_monitored_nodes() == set()
+        assert monitor.check_monitored_nodes() == {"Phone"}
+        assert monitor.consecutive_down["Phone"] == 2
+
+    def test_recovery_resets_streak(self) -> None:
+        """A successful probe between failures resets the streak."""
+        node = _fake_node("Phone", [False, True, False])
+        monitor = _monitor([node])
+
+        assert monitor.check_monitored_nodes() == set()  # streak=1, suppressed
+        assert monitor.check_monitored_nodes() == set()  # healthy, reset
+        assert monitor.consecutive_down["Phone"] == 0
+        assert monitor.check_monitored_nodes() == set()  # streak=1 again, suppressed
+
+    def test_exception_counts_as_down(self) -> None:
+        """Uncaught heartbeat exception is treated as a failing probe."""
+        node = _fake_node("Broken", [False])
+        node.heartbeat.side_effect = RuntimeError("boom")
+        monitor = _monitor([node])
+
+        assert monitor.check_monitored_nodes() == set()
+        assert monitor.consecutive_down["Broken"] == 1
+
+    def test_mixed_nodes_independent_streaks(self) -> None:
+        """Streaks are tracked independently per node."""
+        healthy = _fake_node("Server", [True, True])
+        flaky = _fake_node("Phone", [False, False])
+        monitor = _monitor([healthy, flaky])
+
+        assert monitor.check_monitored_nodes() == set()
+        assert monitor.check_monitored_nodes() == {"Phone"}
+        assert monitor.consecutive_down["Server"] == 0
+        assert monitor.consecutive_down["Phone"] == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds consecutive-failure tracking in `HeartbeatMonitor`: a node must fail **two consecutive probes** before it appears in the down set that drives Pushover alerts. A single successful probe resets the streak. Applies uniformly to every `NodeType`.

## Motivation

After #226 landed and deployed to aibo, running the ARP-typed node produced this on first invocation:

```
19:00:48  WARNING  Node Gardener iPhone X is down     ← cold ARP cache
19:00:49  INFO     Sent notification: Node ... is down ← P2 Pushover fired
19:00:59  INFO     ... recovery detected              ← next probe clean
19:00:59  INFO     Sent recovery notification
```

The priming ping triggers ARP resolution asynchronously, so `arp -n` reads an `(incomplete)` entry before the reply lands. A P2 alert fired on every restart. Same failure class hits ping-only nodes under transient packet loss.

## Design

- Renamed `check_monitored_nodes()` semantics: it now returns *confirmed-down* nodes (streak >= 2), not raw failed probes.
- Streak state lives in `HeartbeatMonitor.consecutive_down: Dict[str, int]` — one central data structure, no per-Node subclass code.
- Considered but rejected: intra-probe retry inside `ArpNode` (was implemented then reverted — duplicated the same idea and only applied to one node type).

**Cost**: one extra poll cycle before a real outage alerts. At the default 3600s poll that's ~2h added latency — matches the noise tolerance the alerting is already calibrated for.

## Files

| File | Change |
|---|---|
| `NodeCheck/heartbeat_nodes.py` | `consecutive_down` dict + streak logic in `check_monitored_nodes` |
| `NodeCheck/nodes.py` | Comment noting flap suppression handles cold-cache case |
| `NodeCheck/test_heartbeat_nodes.py` | **new** — 5 flap-suppression tests |

## Test plan

- [x] `uv run pytest NodeCheck` — 39 passed (5 new)
- [x] `uv run ruff format && uv run ruff check` — clean
- [x] Pre-commit hooks — pass
- [ ] Deploy to aibo, restart the NodeCheck cron, confirm no P2 fires on first cycle.

## References

- Follow-up to #226 (initial ARP support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)