### PR TITLE
refactor(lib): promote Notifier Protocol to lib/notifications

### DIFF
--- a/August/august_client.py
+++ b/August/august_client.py
@@ -18,6 +18,7 @@ from yalexs.lock import Lock, LockStatus, LockDoorStatus
 from lib.config import get_config
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
+from lib.notifications import Notifier
 from lib.secure_io import ensure_secret_perms
 
 # August revoked the API key yalexs ships for Brand.AUGUST (d9984f29...): the
@@ -89,7 +90,7 @@ class AugustClient:
         password: str,
         phone: Optional[str] = None,
         *,
-        pushover: Optional[Pushover] = None,
+        pushover: Optional[Notifier] = None,
     ):
         self.email = email
         self.password = password
@@ -319,7 +320,7 @@ class AugustMonitor:
         door_alert_cooldown_minutes: int = 2,
         *,
         client: Optional[AugustClient] = None,
-        pushover: Optional[Pushover] = None,
+        pushover: Optional[Notifier] = None,
         state_file: Optional[str] = None,
     ):
         # Injectable client + pushover + state_file path so tests never touch

--- a/RachioFlume/alert_engine.py
+++ b/RachioFlume/alert_engine.py
@@ -20,7 +20,7 @@ from enum import Enum
 from typing import Optional
 
 from lib.logger import get_logger
-from lib.MyPushover import Pushover
+from lib.notifications import Notifier
 from RachioFlume.alert_rules import AlertRule, ZoneThreshold, send_zone_outcome_pushover
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import FlumeClient, WaterReading
@@ -129,7 +129,7 @@ class AlertEngine:
         self,
         flume_client: FlumeClient,
         rachio_client: RachioClient,
-        pushover: Pushover,
+        pushover: Notifier,
         db: WaterTrackingDB,
         rules: list[AlertRule],
         zone_thresholds: Optional[dict[int, ZoneThreshold]] = None,

--- a/RachioFlume/alert_rules.py
+++ b/RachioFlume/alert_rules.py
@@ -16,7 +16,7 @@ import logging
 from pydantic import BaseModel, Field
 
 from lib.config import get_config
-from lib.MyPushover import Pushover
+from lib.notifications import Notifier
 
 
 class AlertRule(BaseModel):
@@ -123,7 +123,7 @@ def load_zone_thresholds_from_config() -> dict[str, dict[str, ZoneThreshold]]:
 
 def send_zone_outcome_pushover(
     *,
-    pushover: Pushover,
+    pushover: Notifier,
     logger: logging.Logger,
     log_label: str,
     header: str,

--- a/RachioFlume/hose_timer_processor.py
+++ b/RachioFlume/hose_timer_processor.py
@@ -19,7 +19,7 @@ from RachioFlume.alert_rules import (
 from RachioFlume.data_storage import WaterTrackingDB
 from RachioFlume.flume_client import FlumeClient
 from RachioFlume.rachio_hose_client import HoseValve, RachioHoseClient
-from lib.MyPushover import Pushover
+from lib.notifications import Notifier
 from lib.logger import get_logger
 
 
@@ -44,7 +44,7 @@ class HoseTimerProcessor:
     def __init__(
         self,
         client: RachioHoseClient,
-        pushover: Pushover,
+        pushover: Notifier,
         db: WaterTrackingDB,
         thresholds: Optional[dict[str, ZoneThreshold]] = None,
         flume_client: Optional[FlumeClient] = None,

--- a/RachioFlume/simulate_alerts.py
+++ b/RachioFlume/simulate_alerts.py
@@ -122,7 +122,7 @@ async def run_simulation(
     engine = AlertEngine(
         flume_client=fake_flume,  # type: ignore[arg-type]
         rachio_client=fake_rachio,  # type: ignore[arg-type]
-        pushover=fake_pushover,  # type: ignore[arg-type]
+        pushover=fake_pushover,
         db=db,
         rules=rules,
         zone_thresholds=controller_thresholds,

--- a/RachioFlume/stale_zone_checker.py
+++ b/RachioFlume/stale_zone_checker.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from RachioFlume.data_storage import WaterTrackingDB
-from lib.MyPushover import Pushover
+from lib.notifications import Notifier
 from lib.logger import get_logger
 
 _LAST_RUN_KEY = "stale_zone::last_run"
@@ -27,7 +27,7 @@ class StaleZoneChecker:
     def __init__(
         self,
         db: WaterTrackingDB,
-        pushover: Pushover,
+        pushover: Notifier,
         stale_zone_days: int = 7,
     ) -> None:
         self.db = db

--- a/Rheem/rheem_manager.py
+++ b/Rheem/rheem_manager.py
@@ -26,21 +26,14 @@ import json
 import logging
 import os
 import sys
-from typing import Protocol
-
 from Rheem.rheem_client import RheemAPIError, RheemAuthError, RheemClient, WaterHeaterStatus
 from lib.config import Config, get_config
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
+from lib.notifications import Notifier
 
 
 _AVAILABILITY_LABEL = {0: "empty", 33: "1/3rd full", 66: "2/3rd full", 100: "full"}
-
-
-class Notifier(Protocol):
-    """Send-only notification surface (satisfied by Pushover or test fakes)."""
-
-    def send_message(self, message: str, title: str | None = None, priority: int = 0) -> bool: ...
 
 
 def _label(avail: int) -> str:

--- a/RingBeams/beams_manager.py
+++ b/RingBeams/beams_manager.py
@@ -31,6 +31,7 @@ from lib.config import RingBeamsConfig, get_config
 from lib.file_lock import LockTimeoutError, acquire_lock
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
+from lib.notifications import Notifier
 
 PUSHOVER_KEY = "Ring Security"
 WIRED_BATTERY_STATUSES = {"none", "charging", "charged"}
@@ -166,7 +167,7 @@ def classify(devices: list[DeviceRecord], threshold_pct: int) -> tuple[list[str]
 
 
 def notify(
-    pushover: Pushover,
+    pushover: Notifier,
     low: list[str],
     tamper: list[str],
     errors: list[str],

--- a/RingSecurity/ring_manager.py
+++ b/RingSecurity/ring_manager.py
@@ -24,6 +24,7 @@ from lib.config import RingConfig, get_config
 from lib.file_lock import LockTimeoutError, acquire_lock
 from lib.logger import get_logger
 from lib.MyPushover import Pushover
+from lib.notifications import Notifier
 from lib.secure_io import write_secret_atomic
 
 USER_AGENT = "android:com.ringapp"
@@ -122,7 +123,7 @@ async def check_devices(
     return low, offline
 
 
-def notify(pushover: Pushover, low: list[str], offline: list[str], logger: logging.Logger) -> None:
+def notify(pushover: Notifier, low: list[str], offline: list[str], logger: logging.Logger) -> None:
     if low:
         body = "\n".join(low)
         logger.info(f"Low battery alert: {body}")

--- a/lib/notifications.py
+++ b/lib/notifications.py
@@ -1,0 +1,16 @@
+"""Shared notification abstractions.
+
+`Notifier` is a send-only Protocol satisfied by `lib.MyPushover.Pushover` and by
+test fakes. Modules should depend on this Protocol at their DI boundary rather
+than importing the concrete `Pushover` class — this keeps tests free of
+`patch()` and lets us swap notification backends per-module without touching
+monitor code.
+"""
+
+from typing import Protocol
+
+
+class Notifier(Protocol):
+    """Send-only notification surface (satisfied by Pushover or test fakes)."""
+
+    def send_message(self, message: str, title: str | None = None, priority: int = 0) -> bool: ...


### PR DESCRIPTION
## Summary

- Extract the send-only `Notifier` Protocol (previously local to `Rheem/rheem_manager.py`) into `lib/notifications.py`.
- Adopt `Notifier` at DI boundaries across **August**, **Ring**, **RingBeams**, **RachioFlume**, and **Rheem**. Monitor / helper constructors and functions now type their pusher param as `Notifier` instead of the concrete `lib.MyPushover.Pushover`.
- Drop a now-unused `# type: ignore[arg-type]` in `RachioFlume/simulate_alerts.py` — the test fake `_CapturingPushover` structurally satisfies `Notifier`, so mypy accepts it without a workaround.

Closes #224.

## Why

Every module (August, Ring, RingBeams, RachioFlume) was importing concrete `Pushover` at the DI boundary. The Rheem module introduced a `Notifier` Protocol locally; this PR promotes it to `lib/` and adopts it repo-wide.

Benefits (from the issue):

- Consistent DI boundary for testability — no `patch()`, no `FakePushover` subclassing real `Pushover`.
- Decouples monitors from the concrete Pushover HTTP client.
- Enables swapping notification backends (Pushover → Twilio/Mailer) per module without touching monitor code.

## Test plan

- [x] `make ruff` — all checks passed
- [x] `make mypy` — success, no issues found in 100 source files
- [x] `make test` — full suite green (Tesla, August, RachioFlume, SamsungFrame, NodeCheck)
- [ ] Deploy to `aibo` after merge (`git pull && uv sync`) — cron jobs auto-pick-up on next tick

## References

- Issue: #224 (tech-debt: extract shared Notifier Protocol to lib/)
- Precedent: `Rheem/rheem_manager.py` (PR #225) introduced the local Protocol
- CLAUDE.md convention: "Never `patch()` production code" — this refactor is the structural enabler