### PR TITLE
feat: Rheem setpoint alerts, suppress on raise, stale-zone/Foscam tuning, RingBeams token fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,34 @@ We use **GitHub Issues** for tracking bugs, enhancements, and tech debt. Claude 
 
 **Package Manager**: This project uses `uv` for fast Python dependency management.
 
-**Development Setup**:
+**Worktree venv**: Git worktrees share the main repo's `.venv` (in the primary
+checkout at `~/Documents/deviation-labs/homely_vibes/.venv`). Worktrees don't
+get their own `.venv` (uv won't sync there due to cache permission issues and
+networkless sandboxes). To run tests from a worktree, use the main venv's
+interpreter directly:
+
+```bash
+# From any worktree:
+VIRTUAL_ENV=~/Documents/deviation-labs/homely_vibes/.venv \
+  ~/Documents/deviation-labs/homely_vibes/.venv/bin/python -m pytest [args]
+
+# NodeCheck runs in isolation (matches `make test`):
+VIRTUAL_ENV=~/Documents/deviation-labs/homely_vibes/.venv \
+  ~/Documents/deviation-labs/homely_vibes/.venv/bin/python -m pytest NodeCheck
+```
+
+If tests fail with `PermissionError` on the log directory, create a temporary
+`config/local.yaml` pointing `logging_dir` at a writable path (e.g. `/tmp/hv-logs`)
+and remove it before committing:
+
+```yaml
+# config/local.yaml (temporary, gitignored -- do not commit)
+paths:
+  home: /tmp
+  logging_dir: /tmp/hv-logs
+```
+
+**Development Setup** (primary checkout):
 ```bash
 make setup  # Installs Python 3.13.7, dependencies, Git submodules, and pre-commit hooks
 ```

--- a/NodeCheck/manage_nodes.py
+++ b/NodeCheck/manage_nodes.py
@@ -122,7 +122,7 @@ class NodeChecker:
                 pushover.send_message(
                     f"{self.mode.title()} node reboot completed successfully",
                     title=f"{self.mode.title()} Reboot Complete",
-                    priority=-1,
+                    priority=-2,
                 )
 
         if self.reboot_failures:
@@ -140,7 +140,7 @@ class NodeChecker:
 
         Mailer.sendmail(
             topic=f"[NodeCheck-{self.mode}]",
-            alert=not system_healthy,
+            alert=not is_healthy,
             message="\n".join(self.messages),
             always_email=always_email,
         )

--- a/NodeCheck/purge_old_foscam_files.py
+++ b/NodeCheck/purge_old_foscam_files.py
@@ -103,7 +103,7 @@ def purge_old_foscam_files() -> tuple[bool, str]:
 
     finally:
         # Restore original working directory
-        pushover.send_message(pushover_msg, title="Foscam Cleanup", priority=-1)
+        pushover.send_message(pushover_msg, title="Foscam Cleanup", priority=-2)
         os.chdir(original_cwd)
 
     return success, "\n".join(messages)

--- a/NodeCheck/test_nodes.py
+++ b/NodeCheck/test_nodes.py
@@ -493,3 +493,40 @@ class TestArpNode:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestGenerateReport:
+    """Test NodeChecker.generate_report Pushover priority routing.
+
+    Uses __new__ to bypass __init__ (which loads full config) and patches the
+    module-level pushover object.
+    """
+
+    def _checker(self) -> NodeChecker:
+        c = NodeChecker.__new__(NodeChecker)
+        c.mode = "foscam"
+        c.nodes = []
+        c.messages = []
+        c.reboot_failures = []
+        c.recovery_failures = []
+        return c
+
+    @patch("NodeCheck.manage_nodes.pushover")
+    @patch("NodeCheck.manage_nodes.Mailer")
+    def test_reboot_complete_is_p2(self, mock_mailer: Any, mock_pushover: Any) -> None:
+        """Successful reboot notification is priority -2 (lowest)."""
+        checker = self._checker()
+        checker.generate_report(is_healthy=True, was_rebooted=True)
+        calls = mock_pushover.send_message.call_args_list
+        reboot_call = [c for c in calls if "reboot completed" in c[0][0]]
+        assert len(reboot_call) == 1
+        assert reboot_call[0][1]["priority"] == -2
+
+    @patch("NodeCheck.manage_nodes.pushover")
+    @patch("NodeCheck.manage_nodes.Mailer")
+    def test_healthy_no_reboot_no_message(self, mock_mailer: Any, mock_pushover: Any) -> None:
+        """Healthy with no reboot -> no success Pushover at all."""
+        checker = self._checker()
+        checker.generate_report(is_healthy=True, was_rebooted=False)
+        calls = mock_pushover.send_message.call_args_list
+        assert len(calls) == 0

--- a/NodeCheck/test_nodes.py
+++ b/NodeCheck/test_nodes.py
@@ -513,7 +513,7 @@ class TestGenerateReport:
 
     @patch("NodeCheck.manage_nodes.pushover")
     @patch("NodeCheck.manage_nodes.Mailer")
-    def test_reboot_complete_is_p2(self, mock_mailer: Any, mock_pushover: Any) -> None:
+    def test_reboot_complete_is_p2(self, _mock_mailer: Any, mock_pushover: Any) -> None:
         """Successful reboot notification is priority -2 (lowest)."""
         checker = self._checker()
         checker.generate_report(is_healthy=True, was_rebooted=True)
@@ -524,7 +524,7 @@ class TestGenerateReport:
 
     @patch("NodeCheck.manage_nodes.pushover")
     @patch("NodeCheck.manage_nodes.Mailer")
-    def test_healthy_no_reboot_no_message(self, mock_mailer: Any, mock_pushover: Any) -> None:
+    def test_healthy_no_reboot_no_message(self, _mock_mailer: Any, mock_pushover: Any) -> None:
         """Healthy with no reboot -> no success Pushover at all."""
         checker = self._checker()
         checker.generate_report(is_healthy=True, was_rebooted=False)

--- a/Rheem/rheem_manager.py
+++ b/Rheem/rheem_manager.py
@@ -40,6 +40,11 @@ def _label(avail: int) -> str:
     return _AVAILABILITY_LABEL.get(avail, f"{avail}%")
 
 
+def _setpoint(status: WaterHeaterStatus) -> str:
+    """Format the setpoint for inclusion in alert messages, or 'unknown'."""
+    return f"{status.set_point}°F" if status.set_point is not None else "unknown"
+
+
 class RheemMonitor:
     """Polls water heaters and fires/clears low-hot-water alerts."""
 
@@ -63,6 +68,9 @@ class RheemMonitor:
         # Per-device current alert tier: "p1" (low) or "p2" (empty).
         # Absent key = not alerted. Cleared only on recovery to >= mid_threshold.
         self.alerted: dict[str, str] = {}
+        # Per-device last observed setpoint, used to detect a raise that would
+        # explain a sudden drop in availability (tank reheating to new target).
+        self.setpoints: dict[str, int] = {}
         self._load_state()
 
     def _load_state(self) -> None:
@@ -70,6 +78,7 @@ class RheemMonitor:
             with open(self.state_file, "r") as f:
                 state = json.load(f)
                 self.alerted = state.get("alerted", {})
+                self.setpoints = state.get("setpoints", {})
             self.logger.debug("Loaded Rheem monitor state from %s", self.state_file)
         except (FileNotFoundError, json.JSONDecodeError):
             self.logger.debug("No existing Rheem state file; starting fresh")
@@ -81,7 +90,7 @@ class RheemMonitor:
         tmp_path = self.state_file + ".tmp"
         try:
             with open(tmp_path, "w") as f:
-                json.dump({"alerted": self.alerted}, f)
+                json.dump({"alerted": self.alerted, "setpoints": self.setpoints}, f)
             os.replace(tmp_path, self.state_file)
             self.logger.debug("Saved Rheem monitor state to %s", self.state_file)
         except OSError as e:
@@ -122,6 +131,7 @@ class RheemMonitor:
 
         # Prune devices that no longer appear.
         self.alerted = {s: v for s, v in self.alerted.items() if s in current_serials}
+        self.setpoints = {s: v for s, v in self.setpoints.items() if s in current_serials}
         self._save_state()
         return heaters
 
@@ -134,13 +144,24 @@ class RheemMonitor:
             self.logger.debug("%s does not report availability; skipping", status.name)
             return
 
+        # Record the current setpoint for next cycle's comparison before any
+        # early return so we always have a baseline to detect a raise.
+        previous_setpoint = self.setpoints.get(status.serial_number)
+        if status.set_point is not None:
+            self.setpoints[status.serial_number] = status.set_point
+        setpoint_raised = (
+            status.set_point is not None
+            and previous_setpoint is not None
+            and status.set_point > previous_setpoint
+        )
+
         active_tier = self.alerted.get(status.serial_number)
 
         # Clear only on explicit recovery to >= mid_threshold (not merely
         # "above low" — that would let a level between low and mid prematurely
         # clear an active alert). mid_threshold is the configured recovery gate.
         if active_tier is not None and avail >= self.mid_threshold:
-            msg = f"Hot water recovered: {status.name} at {_label(avail)} ({avail}%)"
+            msg = f"Hot water recovered: {status.name} at {_label(avail)} ({avail}%), setpoint {_setpoint(status)}"
             self.pushover.send_message(msg, title="Rheem Hot Water Recovered", priority=-1)
             del self.alerted[status.serial_number]
             self.logger.info("Cleared hot-water alert: %s", msg)
@@ -153,11 +174,32 @@ class RheemMonitor:
             return
 
         # In a low zone (empty or 1/3rd). Decide whether to fire/escalate.
+        # Suppress when the setpoint was raised since the last check: the drop
+        # in availability is expected while the tank reheats to the new target.
         if active_tier is None:
-            self._fire(status, avail, current_tier)
+            if setpoint_raised:
+                self.logger.info(
+                    "Suppressing %s alert for %s: setpoint raised %s->%s, "
+                    "low availability likely due to reheating",
+                    current_tier,
+                    status.name,
+                    previous_setpoint,
+                    status.set_point,
+                )
+            else:
+                self._fire(status, avail, current_tier)
         elif current_tier == "p2" and active_tier == "p1":
-            # Escalate low -> empty.
-            self._fire(status, avail, current_tier)
+            # Escalate low -> empty (unless setpoint was raised).
+            if setpoint_raised:
+                self.logger.info(
+                    "Suppressing p2 escalation for %s: setpoint raised %s->%s, "
+                    "low availability likely due to reheating",
+                    status.name,
+                    previous_setpoint,
+                    status.set_point,
+                )
+            else:
+                self._fire(status, avail, current_tier)
         # Same tier, or recovering empty->low: no re-alert (clear at mid resets).
 
     def _tier_for(self, availability: int) -> str | None:
@@ -171,7 +213,7 @@ class RheemMonitor:
     def _fire(self, status: WaterHeaterStatus, avail: int, tier: str) -> None:
         priority = 2 if tier == "p2" else 1
         label = "empty" if tier == "p2" else "low"
-        msg = f"Hot water {label}: {status.name} at {_label(avail)} ({avail}%)"
+        msg = f"Hot water {label}: {status.name} at {_label(avail)} ({avail}%), setpoint {_setpoint(status)}"
         title = "Rheem Hot Water Empty" if tier == "p2" else "Rheem Low Hot Water"
         self.pushover.send_message(msg, title=title, priority=priority)
         self.alerted[status.serial_number] = tier

--- a/Rheem/test_rheem_client.py
+++ b/Rheem/test_rheem_client.py
@@ -30,7 +30,7 @@ class FakeWaterHeater:
     name: str
     availability: Optional[int]
     running: bool = False
-    set_point: int = 120
+    set_point: Optional[int] = 120
     connected: bool = True
 
     @property

--- a/Rheem/test_rheem_client.py
+++ b/Rheem/test_rheem_client.py
@@ -152,6 +152,7 @@ def test_low_availability_fires_p1_alert(tmp_path: Path) -> None:
     assert title == "Rheem Low Hot Water"
     assert priority == 1
     assert "Garage" in msg
+    assert "setpoint 120°F" in msg
     assert monitor.alerted["S1"] == "p1"
 
 
@@ -165,6 +166,7 @@ def test_empty_tank_fires_p2_alert(tmp_path: Path) -> None:
     msg, title, priority = pushover.sent[0]
     assert title == "Rheem Hot Water Empty"
     assert priority == 2
+    assert "setpoint 120°F" in msg
     assert monitor.alerted["S1"] == "p2"
 
 
@@ -221,6 +223,7 @@ def test_recovery_to_mid_clears_alert(tmp_path: Path) -> None:
     msg, title, priority = pushover.sent[1]
     assert title == "Rheem Hot Water Recovered"
     assert priority == -1
+    assert "setpoint 120°F" in msg
     assert "S1" not in monitor.alerted
 
 
@@ -292,6 +295,138 @@ def test_pruned_gone_device(tmp_path: Path) -> None:
     monitor, _ = _monitor_with([], state)
     asyncio.run(monitor.check_once())
     assert "S1" not in monitor.alerted
+
+
+def test_none_setpoint_shows_unknown(tmp_path: Path) -> None:
+    """A heater that doesn't report a setpoint shows 'unknown' in the alert."""
+    state = str(tmp_path / "state.json")
+    monitor, pushover = _monitor_with(
+        [FakeWaterHeater(serial_number="S1", name="Garage", availability=33, set_point=None)], state
+    )
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    msg, _, _ = pushover.sent[0]
+    assert "setpoint unknown" in msg
+
+
+def test_setpoint_raised_suppresses_new_alert(tmp_path: Path) -> None:
+    """Setpoint raised since last check suppresses a new low alert.
+
+    The tank reports less hot water because it's reheating to the new higher
+    target, not because of an actual shortage — don't alert.
+    """
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=100, set_point=120)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # baseline: full, no alert
+    assert pushover.sent == []
+    # Setpoint raised and availability drops to low.
+    heaters[0].set_point = 140
+    heaters[0].availability = 33
+    asyncio.run(monitor.check_once())
+    assert pushover.sent == []  # suppressed
+    assert "S1" not in monitor.alerted
+
+
+def test_setpoint_raised_suppresses_escalation(tmp_path: Path) -> None:
+    """Setpoint raised while already in P1 suppresses P2 escalation."""
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=33, set_point=120)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # P1 fired
+    assert monitor.alerted["S1"] == "p1"
+    assert len(pushover.sent) == 1
+    # Setpoint raised and availability drops to empty.
+    heaters[0].set_point = 140
+    heaters[0].availability = 0
+    asyncio.run(monitor.check_once())
+    # Escalation suppressed; still only the original P1.
+    assert len(pushover.sent) == 1
+    assert monitor.alerted["S1"] == "p1"
+
+
+def test_setpoint_unchanged_still_alerts(tmp_path: Path) -> None:
+    """No setpoint raise -> alert fires normally (regression guard)."""
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=100, set_point=120)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # baseline
+    # Same setpoint, availability drops to low.
+    heaters[0].availability = 33
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    assert monitor.alerted["S1"] == "p1"
+
+
+def test_setpoint_lowered_still_alerts(tmp_path: Path) -> None:
+    """Setpoint lowered does not suppress (drop is not caused by reheating)."""
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=100, set_point=140)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # baseline
+    heaters[0].set_point = 120
+    heaters[0].availability = 33
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    assert monitor.alerted["S1"] == "p1"
+
+
+def test_setpoint_raised_then_unchanged_fires_alert(tmp_path: Path) -> None:
+    """Suppression is one-cycle only; if still low next check, alert fires."""
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=100, set_point=120)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # baseline
+    # Setpoint raised, availability drops.
+    heaters[0].set_point = 140
+    heaters[0].availability = 33
+    asyncio.run(monitor.check_once())  # suppressed
+    assert pushover.sent == []
+    # Next cycle: setpoint unchanged, still low -> alert fires.
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    assert monitor.alerted["S1"] == "p1"
+
+
+def test_none_setpoint_never_suppresses(tmp_path: Path) -> None:
+    """A tank that doesn't report setpoint can never trigger suppression."""
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=100, set_point=None)]
+    monitor, pushover = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())  # baseline
+    heaters[0].availability = 33
+    asyncio.run(monitor.check_once())
+    assert len(pushover.sent) == 1
+    assert monitor.alerted["S1"] == "p1"
+
+
+def test_setpoint_persisted_across_instances(tmp_path: Path) -> None:
+    """Setpoint tracking survives restart (persisted in state file)."""
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=100, set_point=120)]
+    monitor, _ = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())
+    assert monitor.setpoints["S1"] == 120
+    # New instance loads persisted setpoint.
+    monitor2, pushover2 = _monitor_with(heaters, state)
+    assert monitor2.setpoints["S1"] == 120
+    # Raise setpoint + drop availability -> suppressed (previous setpoint known).
+    heaters[0].set_point = 140
+    heaters[0].availability = 33
+    asyncio.run(monitor2.check_once())
+    assert pushover2.sent == []
+
+
+def test_setpoints_pruned_with_gone_device(tmp_path: Path) -> None:
+    """Setpoint entry is pruned when a device disappears."""
+    state = str(tmp_path / "state.json")
+    heaters = [FakeWaterHeater(serial_number="S1", name="Garage", availability=100, set_point=120)]
+    monitor, _ = _monitor_with(heaters, state)
+    asyncio.run(monitor.check_once())
+    assert "S1" in monitor.setpoints
+    monitor, _ = _monitor_with([], state)
+    asyncio.run(monitor.check_once())
+    assert "S1" not in monitor.setpoints
 
 
 def test_multiple_heaters_independent(tmp_path: Path) -> None:
@@ -379,7 +514,7 @@ def test_save_state_is_atomic_no_tmp_left(tmp_path: Path) -> None:
     # State file is valid JSON.
     with open(state) as f:
         data = json.load(f)
-    assert data == {"alerted": {"S1": "p1"}}
+    assert data == {"alerted": {"S1": "p1"}, "setpoints": {"S1": 120}}
     # No leftover tmp file.
     assert not Path(state + ".tmp").exists()
 

--- a/RingBeams/fetch_status.js
+++ b/RingBeams/fetch_status.js
@@ -40,14 +40,31 @@ function readRefreshToken(path) {
     return raw;
 }
 
+function decodeRefreshToken(token) {
+    // ring-client-api wraps the real refresh token as base64(JSON({rt, hid}))
+    // on rotation (see rest-client.js toBase64). Python ring-doorbell expects
+    // the raw refresh_token string in the JSON envelope, not the base64 blob.
+    // Decode it back so the shared token file stays compatible with both sides.
+    try {
+        const config = JSON.parse(Buffer.from(token, 'base64').toString('ascii'));
+        if (config && config.rt) return config.rt;
+    } catch (_) {
+        // Not base64-encoded — already a raw token string, return as-is.
+    }
+    return token;
+}
+
 function writeRefreshToken(path, token) {
+    // Decode base64-wrapped token from ring-client-api back to the raw
+    // refresh_token string that Python ring-doorbell expects.
+    const rawToken = decodeRefreshToken(token);
     // Preserve Python-style JSON envelope if the file currently holds a dict.
-    let payload = token;
+    let payload = rawToken;
     try {
         const raw = fs.readFileSync(path, 'utf-8').trim();
         if (raw.startsWith('{')) {
             const parsed = JSON.parse(raw);
-            parsed.refresh_token = token;
+            parsed.refresh_token = rawToken;
             payload = JSON.stringify(parsed);
         }
     } catch (_) {

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -289,7 +289,7 @@ rachio_flume:
     # === Stale-zone monitoring ===
     # Fire a P-1 heads-up if any enabled controller zone or connected
     # hose-timer valve hasn't run within this many days.
-    stale_zone_days: 7
+    stale_zone_days: 15
 
 # === PersonalCalSync (Google Apps Script) ===
 personal_cal_sync:


### PR DESCRIPTION
## Changes

### Rheem water heater alerts (commit 1)
- **Setpoint in notifications**: All Pushover messages (fire, escalate, recover) now include setpoint (or unknown when not reported)
- **Suppress on setpoint raise**: If the setpoint was raised since the last check and the tank reports lower availability, the alert is suppressed for one cycle — the drop is expected while reheating to the new target, not an actual shortage. Tracked per-device in persisted state.
- **Bugfix**: generate_report in NodeCheck/manage_nodes.py referenced system_healthy (a module-scope variable from __main__) instead of the is_healthy parameter — fixed.

### Stale-zone monitoring (commit 1)
- Threshold moved from 7 to 15 days in config/default.yaml

### Foscam notification priorities (commit 1)
- Reboot-complete and cleanup-successful notifications lowered from priority -1 to -2 (lowest urgency)

### RingBeams token format fix (commit 2)
- **Root cause of RingSecurity auth failures on aibo**: ring-client-api (Node) wraps the rotated refresh token as base64(JSON({rt, hid})) via toBase64(). fetch_status.js wrote this base64 blob into the shared token file. Python ring-doorbell expects the raw refresh_token string which causes invalid_grant and auth failure. RingBeams kept working because ring-client-api does fromBase64() internally.
- **Fix**: Added decodeRefreshToken() to fetch_status.js — base64-decodes and extracts .rt before writing to the shared file. Falls through unchanged if not base64. Both sides now read/write the same raw token format.

### CLAUDE.md docs (commit 2)
- Documents how to run pytest from git worktrees using the shared main venv

## Testing
- All 343 tests passing (302 main suite + 41 NodeCheck isolation)

## Post-merge action
Re-authenticate Ring on aibo once: uv run python RingSecurity/ring_manager.py auth (current token file may already be base64-poisoned)