### PR TITLE
feat(NoShorts): V2 rewrite (shelved on-device — see V2_PRD.md §8)

### DIFF
--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -2,20 +2,34 @@
 //  ContentView.swift
 //  NoShorts
 //
+//  V2 architecture: WKWebView, LocalProxy scoped to *.youtube.com via
+//  ProxyConfiguration.matchDomains. All other traffic (googlevideo, ytimg,
+//  doubleclick, googleapis, etc.) goes direct from the WebContent process
+//  via system DNS. See V2_PRD.md §5 for the full rationale.
+//
 
 import SwiftUI
 import WebKit
 import Observation
 import Network
 
-// Runs at document start: fingerprint removal + CSS + autoplay block + SPA navigation guard
+// MARK: - Injected user scripts
+
+/// Runs at document start in every frame. Does three things:
+/// 1. Hides `window.webkit` on accounts.google.com so Google's sign-in doesn't
+///    fingerprint us as a WKWebView.
+/// 2. Injects CSS that hides Shorts affordances before first paint.
+/// 3. Wraps `HTMLVideoElement.prototype.play()` so it only resolves within
+///    1.5s of a real user gesture. Load-bearing beyond autoplay: without this
+///    wrapper YouTube's player refuses to serve modern content (confirmed
+///    during the 2026-07 debugging session).
+/// 4. Intercepts SPA `pushState`/`replaceState` for `/shorts`.
 private let earlyScript = """
 (function() {
     if (window.location.hostname.includes('accounts.google')) {
         try { Object.defineProperty(window, 'webkit', { get: () => undefined, configurable: true }); } catch(e) {}
     }
 
-    // CSS: hide Shorts before paint
     const s = document.createElement('style');
     s.id = 'no-shorts';
     s.textContent = `
@@ -29,47 +43,43 @@ private let earlyScript = """
     `;
     (document.head || document.documentElement).appendChild(s);
 
-    // Block autoplay: intercept video.play() — only allow within 1.5s of a user touch/click
     let lastInteraction = 0;
-    document.addEventListener('touchstart', () => { lastInteraction = Date.now(); }, { capture: true, passive: true });
-    document.addEventListener('click', () => { lastInteraction = Date.now(); }, { capture: true, passive: true });
+    document.addEventListener('touchstart', () => { lastInteraction = Date.now(); },
+        { capture: true, passive: true });
+    document.addEventListener('click', () => { lastInteraction = Date.now(); },
+        { capture: true, passive: true });
     const _play = HTMLVideoElement.prototype.play;
     HTMLVideoElement.prototype.play = function() {
         if (Date.now() - lastInteraction < 1500) return _play.call(this);
         return Promise.reject(new DOMException('Autoplay blocked', 'NotAllowedError'));
     };
 
-    // Block SPA navigation to /shorts. Home (/) is handled in Swift via KVO on
-    // webView.url so we catch it regardless of who triggered the URL change.
     const _push = history.pushState.bind(history);
     const _replace = history.replaceState.bind(history);
     const isShorts = (u) => u && String(u).startsWith('/shorts');
-    history.pushState = (s,t,u) => { if (!isShorts(u)) _push(s,t,u); };
-    history.replaceState = (s,t,u) => { if (!isShorts(u)) _replace(s,t,u); };
+    history.pushState    = (state, title, url) => { if (!isShorts(url)) _push(state, title, url); };
+    history.replaceState = (state, title, url) => { if (!isShorts(url)) _replace(state, title, url); };
 })();
 """
 
-// Listens for HTML5 video play/pause/ended events anywhere in the page and
-// posts a message to native. Works for inline playback AND fullscreen — both
-// fire `play`/`pause` events on the same <video> element.
+/// Report HTML5 video lifecycle back to Swift so we can lock orientation.
+/// Deliberately NOT listening for `error`/`stalled` — those fire on every
+/// buffer hiccup and previously caused portrait↔landscape flapping.
 private let videoEventScript = """
 (function() {
     const post = (kind) => {
         try { window.webkit.messageHandlers.video.postMessage(kind); } catch(e) {}
     };
-    const onPlay = (e) => { if (e.target instanceof HTMLVideoElement) post('play'); };
-    const onPause = (e) => { if (e.target instanceof HTMLVideoElement) post('pause'); };
-    const onEnded = (e) => { if (e.target instanceof HTMLVideoElement) post('ended'); };
-    document.addEventListener('play', onPlay, true);
-    document.addEventListener('pause', onPause, true);
-    document.addEventListener('ended', onEnded, true);
-    // Navigating away from a watch page tears down the <video> element
-    // without firing pause. pagehide covers the SPA-back case too.
+    document.addEventListener('play',  (e) => { if (e.target instanceof HTMLVideoElement) post('play');  }, true);
+    document.addEventListener('pause', (e) => { if (e.target instanceof HTMLVideoElement) post('pause'); }, true);
+    document.addEventListener('ended', (e) => { if (e.target instanceof HTMLVideoElement) post('ended'); }, true);
+    // pagehide covers SPA-back navigating away from /watch without a pause event.
     window.addEventListener('pagehide', () => post('pause'));
 })();
 """
 
-// Runs at document end: DOM removal + debounced MutationObserver
+/// Runs at document end + as a MutationObserver: yank any Shorts DOM nodes
+/// that survived the CSS in earlyScript.
 private let shortsBlockScript = """
 (function() {
     function removeShorts() {
@@ -88,7 +98,6 @@ private let shortsBlockScript = """
             if (item.querySelector('a[href*="/shorts/"]')) item.remove();
         });
     }
-
     removeShorts();
     let debounce;
     new MutationObserver(() => {
@@ -100,6 +109,8 @@ private let shortsBlockScript = """
 
 private let sessionDuration: TimeInterval = 30 * 60
 
+// MARK: - Model
+
 @Observable
 final class WebViewModel {
     @ObservationIgnored let webView: WKWebView
@@ -107,10 +118,15 @@ final class WebViewModel {
     var isLoading = false
     var canGoBack = false
     var canGoForward = false
+    var proxyReady = false
 
     init() {
         let config = WKWebViewConfiguration()
         config.mediaTypesRequiringUserActionForPlayback = .video
+        // YouTube's adaptive-streaming pipeline expects inline <video>. Without
+        // this, playback on iOS 26 hits a limited fullscreen-only codepath.
+        config.allowsInlineMediaPlayback = true
+
         config.userContentController.addUserScript(
             WKUserScript(source: earlyScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         )
@@ -121,17 +137,23 @@ final class WebViewModel {
             WKUserScript(source: videoEventScript, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
         )
 
-        // Route WKWebView traffic through a local DoH-backed proxy so requests
-        // bypass system DNS (and any NextDNS-style filtering on youtube.com).
+        // Route ONLY *.youtube.com through the local DoH-backed proxy. Every
+        // other host (googlevideo, ytimg, doubleclick, googleapis, ...) goes
+        // direct via WKWebView's own networking + system DNS. This is the
+        // critical scoping that V1 got wrong on iOS 26.5.2 — see V2_PRD.md §5.
         if let port = try? proxy.start() {
-            let endpoint = NWEndpoint.hostPort(host: "127.0.0.1", port: NWEndpoint.Port(rawValue: port)!)
-            let proxyConfig = ProxyConfiguration(httpCONNECTProxy: endpoint, tlsOptions: nil)
+            let endpoint = NWEndpoint.hostPort(host: "127.0.0.1",
+                                               port: NWEndpoint.Port(rawValue: port)!)
+            var proxyConfig = ProxyConfiguration(httpCONNECTProxy: endpoint, tlsOptions: nil)
+            proxyConfig.matchDomains = ["youtube.com"]
             let dataStore = WKWebsiteDataStore.default()
             dataStore.proxyConfigurations = [proxyConfig]
             config.websiteDataStore = dataStore
-            NSLog("LocalProxy listening on 127.0.0.1:\(port)")
+            self.proxyReady = true
+            NSLog("LocalProxy started on 127.0.0.1:\(port), scoped to *.youtube.com")
         } else {
-            NSLog("LocalProxy failed to start; WKWebView will use system DNS")
+            NSLog("LocalProxy failed to start; NoShorts cannot reach youtube.com")
+            self.proxyReady = false
         }
 
         let wv = WKWebView(frame: .zero, configuration: config)
@@ -139,15 +161,17 @@ final class WebViewModel {
         self.webView = wv
     }
 
+    // MARK: - Navigation helpers
+
     func load(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         webView.load(URLRequest(url: url))
     }
 
-    func goHome() { load("https://www.youtube.com/feed/channels") }
     func goPlaylists() { load("https://www.youtube.com/feed/playlists") }
-    func goLiked() { load("https://www.youtube.com/playlist?list=LL") }
-    func goAccount() { load("https://www.youtube.com/account") }
+    func goLiked()     { load("https://www.youtube.com/playlist?list=LL") }
+    func goHome()      { load("https://www.youtube.com/feed/channels") }
+    func goAccount()   { load("https://www.youtube.com/account") }
 
     func search(_ query: String) {
         let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
@@ -155,16 +179,17 @@ final class WebViewModel {
     }
 }
 
+// MARK: - WKWebView bridge & delegate
+
 struct YouTubeWebView: UIViewRepresentable {
     let model: WebViewModel
 
     func makeCoordinator() -> Coordinator { Coordinator(model: model) }
 
     func makeUIView(context: Context) -> WKWebView {
-        let wv = model.webView
-        wv.navigationDelegate = context.coordinator
+        model.webView.navigationDelegate = context.coordinator
         model.goPlaylists()
-        return wv
+        return model.webView
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {}
@@ -172,24 +197,41 @@ struct YouTubeWebView: UIViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         let model: WebViewModel
-        private var urlObservation: NSKeyValueObservation?
+        private var urlObs: NSKeyValueObservation?
+        private var canBackObs: NSKeyValueObservation?
+        private var canFwdObs: NSKeyValueObservation?
+        private var orientationTask: Task<Void, Never>?
+        private var currentOrientation: UIInterfaceOrientationMask = .portrait
 
         init(model: WebViewModel) {
             self.model = model
             super.init()
             model.webView.configuration.userContentController.add(self, name: "video")
+
             // Catch SPA URL changes (history.pushState / replaceState). decidePolicyFor
-            // does NOT fire for these, so YouTube's in-app Home tab tap can sneak past.
-            urlObservation = model.webView.observe(\.url, options: [.new]) { [weak self] _, change in
+            // does NOT fire for these, so a YouTube-in-page Home tap can sneak past
+            // without KVO on the url property.
+            urlObs = model.webView.observe(\.url, options: [.new]) { [weak self] _, change in
                 guard let self, let url = change.newValue ?? nil else { return }
                 if Self.isYouTubeHome(url) {
                     Task { @MainActor in self.model.goPlaylists() }
                 }
             }
+            // Mirror the history-stack flags live. Reading them only in didFinish
+            // leaves the toolbar chevrons stale whenever a nav is cancelled — which
+            // our /shorts and home intercepts do frequently.
+            canBackObs = model.webView.observe(\.canGoBack, options: [.new, .initial]) { [weak self] wv, _ in
+                Task { @MainActor in self?.model.canGoBack = wv.canGoBack }
+            }
+            canFwdObs = model.webView.observe(\.canGoForward, options: [.new, .initial]) { [weak self] wv, _ in
+                Task { @MainActor in self?.model.canGoForward = wv.canGoForward }
+            }
         }
 
         deinit {
-            urlObservation?.invalidate()
+            urlObs?.invalidate()
+            canBackObs?.invalidate()
+            canFwdObs?.invalidate()
             model.webView.configuration.userContentController.removeScriptMessageHandler(forName: "video")
         }
 
@@ -197,17 +239,34 @@ struct YouTubeWebView: UIViewRepresentable {
             (url.host?.hasSuffix("youtube.com") == true) && (url.path.isEmpty || url.path == "/")
         }
 
-        nonisolated func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
+        // MARK: WKScriptMessageHandler — video events → orientation
+
+        nonisolated func userContentController(_ controller: WKUserContentController,
+                                               didReceive message: WKScriptMessage) {
             guard let kind = message.body as? String else { return }
             Task { @MainActor in
+                let target: UIInterfaceOrientationMask
                 switch kind {
-                case "play":
-                    Self.setOrientation(.landscapeRight)
-                case "pause", "ended":
-                    Self.setOrientation(.portrait)
-                default:
-                    break
+                case "play":           target = .landscapeRight
+                case "pause", "ended": target = .portrait
+                default: return
                 }
+                self.scheduleOrientation(target)
+            }
+        }
+
+        /// 400 ms coalesce. YouTube's player fires transient pause→play during
+        /// buffering; without coalescing, the screen orientation flaps.
+        private func scheduleOrientation(_ target: UIInterfaceOrientationMask) {
+            if target == currentOrientation && orientationTask == nil { return }
+            orientationTask?.cancel()
+            orientationTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 400_000_000)
+                guard let self, !Task.isCancelled else { return }
+                self.orientationTask = nil
+                guard target != self.currentOrientation else { return }
+                self.currentOrientation = target
+                Self.setOrientation(target)
             }
         }
 
@@ -224,25 +283,40 @@ struct YouTubeWebView: UIViewRepresentable {
             }
         }
 
+        // MARK: WKNavigationDelegate
+
         func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction) async -> WKNavigationActionPolicy {
             guard let url = action.request.url else { return .allow }
-            if url.path.hasPrefix("/shorts") { model.goPlaylists(); return .cancel }
-            if Self.isYouTubeHome(url) { model.goPlaylists(); return .cancel }
+            // /shorts: cancel silently. No follow-up load() — pushing playlists
+            // onto history destroys any forward stack.
+            if url.path.hasPrefix("/shorts") { return .cancel }
+            // youtube.com/ (algorithmic home): redirect to Playlists, but only
+            // on forward navs. Backward/Forward navs must be preserved or the
+            // toolbar chevrons appear broken.
+            if Self.isYouTubeHome(url) {
+                if action.navigationType != .backForward { model.goPlaylists() }
+                return .cancel
+            }
             return .allow
         }
 
-        func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) { model.isLoading = true }
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+            model.isLoading = true
+        }
 
         func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
             webView.evaluateJavaScript(shortsBlockScript)
             model.isLoading = false
-            model.canGoBack = webView.canGoBack
-            model.canGoForward = webView.canGoForward
+            // canGoBack / canGoForward are mirrored via KVO in init.
         }
 
-        func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) { model.isLoading = false }
+        func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+            model.isLoading = false
+        }
     }
 }
+
+// MARK: - Root view
 
 struct ContentView: View {
     @State private var model = WebViewModel()
@@ -272,16 +346,24 @@ struct ContentView: View {
                 .padding(.top, 60)
                 .padding(.trailing, 12)
                 .frame(maxWidth: .infinity, alignment: .trailing)
+
+            if !model.proxyReady {
+                proxyErrorBanner
+                    .padding(.top, 60)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
         }
         .onAppear { startTimer() }
         .onDisappear { timer?.invalidate() }
     }
 
+    // MARK: Toolbars
+
     private var topToolbar: some View {
         HStack(spacing: 0) {
-            toolbarButton("play.square.stack.fill", enabled: true) { model.goPlaylists() }
-            toolbarButton("hand.thumbsup.fill", enabled: true) { model.goLiked() }
-            toolbarButton("square.grid.3x3.fill", enabled: true) { model.goHome() }
+            toolbarButton("play.square.stack.fill",  enabled: true) { model.goPlaylists() }
+            toolbarButton("hand.thumbsup.fill",      enabled: true) { model.goLiked() }
+            toolbarButton("square.grid.3x3.fill",    enabled: true) { model.goHome() }
             toolbarButton("person.crop.circle.fill", enabled: true) { model.goAccount() }
         }
         .frame(height: 52)
@@ -292,41 +374,15 @@ struct ContentView: View {
     private var bottomToolbar: some View {
         HStack(spacing: 0) {
             if isSearching {
-                HStack(spacing: 8) {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundStyle(.secondary)
-                        .padding(.leading, 12)
-                    TextField("Search YouTube", text: $searchText)
-                        .focused($searchFocused)
-                        .submitLabel(.search)
-                        .onSubmit {
-                            if !searchText.isEmpty { model.search(searchText) }
-                            isSearching = false
-                            searchText = ""
-                        }
-                    Button {
-                        isSearching = false
-                        searchText = ""
-                        searchFocused = false
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.secondary)
-                            .padding(.trailing, 12)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .frame(height: 36)
-                .background(Color(.secondarySystemBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .padding(.horizontal, 12)
+                searchField
             } else {
-                toolbarButton("chevron.left", enabled: model.canGoBack) { model.webView.goBack() }
+                toolbarButton("chevron.left",  enabled: model.canGoBack)    { model.webView.goBack() }
                 toolbarButton("chevron.right", enabled: model.canGoForward) { model.webView.goForward() }
                 toolbarButton("magnifyingglass", enabled: true) {
                     isSearching = true
                     searchFocused = true
                 }
-                toolbarButton("house.fill", enabled: true) { model.goHome() }
+                toolbarButton("house.fill",      enabled: true) { model.goHome() }
                 toolbarButton("arrow.clockwise", enabled: true) { model.webView.reload() }
             }
         }
@@ -335,6 +391,38 @@ struct ContentView: View {
         .overlay(alignment: .top) { Divider() }
         .animation(.easeInOut(duration: 0.2), value: isSearching)
     }
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .padding(.leading, 12)
+            TextField("Search YouTube", text: $searchText)
+                .focused($searchFocused)
+                .submitLabel(.search)
+                .onSubmit {
+                    if !searchText.isEmpty { model.search(searchText) }
+                    isSearching = false
+                    searchText = ""
+                }
+            Button {
+                isSearching = false
+                searchText = ""
+                searchFocused = false
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+                    .padding(.trailing, 12)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 36)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 12)
+    }
+
+    // MARK: Session countdown
 
     private var countdownBadge: some View {
         let minutes = Int(remaining) / 60
@@ -349,6 +437,16 @@ struct ContentView: View {
             .background(isVeryLow ? Color.red : Color(.systemBackground).opacity(0.85))
             .clipShape(Capsule())
             .shadow(radius: 2)
+    }
+
+    private var proxyErrorBanner: some View {
+        Text("DoH proxy unavailable — restart NoShorts")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(Color.red)
+            .clipShape(Capsule())
     }
 
     private func startTimer() {

--- a/NoShorts/NoShorts/DoHResolver.swift
+++ b/NoShorts/NoShorts/DoHResolver.swift
@@ -2,8 +2,17 @@
 //  DoHResolver.swift
 //  NoShorts
 //
-//  DNS-over-HTTPS resolver. Bypasses system DNS (and any NextDNS-style filtering)
-//  by querying https://dns.google/dns-query directly via URLSession.
+//  Minimal DNS-over-HTTPS resolver used by LocalProxy to look up hostnames
+//  that NextDNS refuses to resolve on this device (only `*.youtube.com`).
+//
+//  Scope on purpose:
+//  - Single upstream: `dns.google`. No Cloudflare fallback, no multi-endpoint
+//    merge — see V2_PRD.md §7 (fail-fast) for why extra failover was cut.
+//  - IPv4 (A) records only. AAAA caused ENETDOWN on carrier paths with broken
+//    v6 during the 2026-07 debugging session.
+//  - Returns the first A record from the cache/response, not the full set.
+//    LocalProxy scope is limited to `*.youtube.com`, which resolves to Google-
+//    owned IPs and doesn't need per-request failover.
 //
 
 import Foundation
@@ -13,7 +22,7 @@ actor DoHResolver {
 
     private let endpoint = URL(string: "https://dns.google/dns-query")!
     private let session: URLSession
-    private var cache: [String: (ips: [String], expiresAt: Date)] = [:]
+    private var cache: [String: (ip: String, expiresAt: Date)] = [:]
 
     init() {
         let cfg = URLSessionConfiguration.ephemeral
@@ -24,26 +33,23 @@ actor DoHResolver {
     }
 
     func resolve(_ host: String) async throws -> String {
-        if let entry = cache[host], entry.expiresAt > Date(), let ip = entry.ips.first {
-            return ip
+        if let entry = cache[host], entry.expiresAt > Date() {
+            return entry.ip
         }
 
-        let query = try buildQuery(for: host)
         var req = URLRequest(url: endpoint)
         req.httpMethod = "POST"
         req.setValue("application/dns-message", forHTTPHeaderField: "Content-Type")
         req.setValue("application/dns-message", forHTTPHeaderField: "Accept")
-        req.httpBody = query
+        req.httpBody = try buildQuery(for: host)
 
         let (data, response) = try await session.data(for: req)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             throw DoHError.badResponse
         }
 
-        let (ips, ttl) = try parseAnswers(data)
-        guard let ip = ips.first else { throw DoHError.noAnswer }
-
-        cache[host] = (ips, Date().addingTimeInterval(min(TimeInterval(ttl), 300)))
+        let (ip, ttl) = try firstAnswer(data)
+        cache[host] = (ip, Date().addingTimeInterval(min(TimeInterval(ttl), 300)))
         return ip
     }
 
@@ -51,20 +57,20 @@ actor DoHResolver {
         var pkt = Data()
         // Header: id=0 (DoH ignores), flags=0x0100 (standard query, RD), 1 question
         pkt.append(contentsOf: [0x00, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
-
         for label in host.split(separator: ".") {
             let bytes = Array(label.utf8)
             guard bytes.count <= 63 else { throw DoHError.invalidHost }
             pkt.append(UInt8(bytes.count))
             pkt.append(contentsOf: bytes)
         }
-        pkt.append(0x00) // root
-        pkt.append(contentsOf: [0x00, 0x01]) // QTYPE A
-        pkt.append(contentsOf: [0x00, 0x01]) // QCLASS IN
+        pkt.append(0x00)                          // root
+        pkt.append(contentsOf: [0x00, 0x01])      // QTYPE A
+        pkt.append(contentsOf: [0x00, 0x01])      // QCLASS IN
         return pkt
     }
 
-    private func parseAnswers(_ data: Data) throws -> (ips: [String], ttl: UInt32) {
+    /// Walk the DNS response, return (first A record IP string, its TTL).
+    private func firstAnswer(_ data: Data) throws -> (String, UInt32) {
         guard data.count >= 12 else { throw DoHError.shortPacket }
         let qd = (UInt16(data[4]) << 8) | UInt16(data[5])
         let an = (UInt16(data[6]) << 8) | UInt16(data[7])
@@ -73,11 +79,8 @@ actor DoHResolver {
         var idx = 12
         for _ in 0..<qd {
             idx = try skipName(data, at: idx)
-            idx += 4 // QTYPE + QCLASS
+            idx += 4  // QTYPE + QCLASS
         }
-
-        var ips: [String] = []
-        var minTTL: UInt32 = .max
         for _ in 0..<an {
             idx = try skipName(data, at: idx)
             guard idx + 10 <= data.count else { throw DoHError.shortPacket }
@@ -88,12 +91,12 @@ actor DoHResolver {
             idx += 10
             guard idx + rdLen <= data.count else { throw DoHError.shortPacket }
             if type == 1 && rdLen == 4 {
-                ips.append("\(data[idx]).\(data[idx + 1]).\(data[idx + 2]).\(data[idx + 3])")
-                minTTL = min(minTTL, ttl)
+                let ip = "\(data[idx]).\(data[idx + 1]).\(data[idx + 2]).\(data[idx + 3])"
+                return (ip, ttl)
             }
             idx += rdLen
         }
-        return (ips, minTTL == .max ? 60 : minTTL)
+        throw DoHError.noAnswer
     }
 
     private func skipName(_ data: Data, at start: Int) throws -> Int {
@@ -101,7 +104,7 @@ actor DoHResolver {
         while i < data.count {
             let b = data[i]
             if b == 0 { return i + 1 }
-            if b & 0xC0 == 0xC0 { return i + 2 } // pointer
+            if b & 0xC0 == 0xC0 { return i + 2 }   // pointer, 2 bytes
             i += 1 + Int(b)
         }
         throw DoHError.shortPacket

--- a/NoShorts/NoShorts/LocalProxy.swift
+++ b/NoShorts/NoShorts/LocalProxy.swift
@@ -2,9 +2,15 @@
 //  LocalProxy.swift
 //  NoShorts
 //
-//  HTTP CONNECT proxy on 127.0.0.1. Resolves hostnames via DoHResolver (bypassing
-//  system DNS / NextDNS), then tunnels TLS bytes verbatim. Pointed at by
-//  WKWebsiteDataStore.proxyConfigurations so all WKWebView traffic flows through it.
+//  HTTP CONNECT proxy on 127.0.0.1 that only ever sees `*.youtube.com` traffic
+//  from WKWebView (because `ProxyConfiguration.matchDomains = ["youtube.com"]`
+//  is set on the data store, see ContentView.swift). For each CONNECT request:
+//    1. Resolve the host via DoH (bypasses NextDNS's `*.youtube.com` deny).
+//    2. Open a plain TCP connection to that IP:port.
+//    3. Reply "HTTP/1.1 200 Connection Established" and pipe bytes.
+//
+//  Deliberately minimal: no per-connection retry, no multi-IP failover, no
+//  hostname-based bypass, no v6 support. See V2_PRD.md §5 for the rationale.
 //
 
 import Foundation
@@ -15,8 +21,11 @@ final class LocalProxy: @unchecked Sendable {
     private var listener: NWListener?
     private(set) var port: UInt16 = 0
 
+    /// Start listening on the loopback interface, return the ephemeral port.
     func start() throws -> UInt16 {
         let params = NWParameters.tcp
+        // Loopback-only so the proxy is unreachable from LAN.
+        params.requiredInterfaceType = .loopback
         let l = try NWListener(using: params, on: .any)
         l.newConnectionHandler = { [weak self] conn in self?.handle(conn) }
 
@@ -35,16 +44,15 @@ final class LocalProxy: @unchecked Sendable {
         guard sem.wait(timeout: .now() + 3) == .success,
               let p = l.port, p.rawValue > 0 else {
             l.cancel()
-            throw NSError(domain: "LocalProxy", code: -1, userInfo: [NSLocalizedDescriptionKey: "listener not ready or port invalid"])
+            throw NSError(domain: "LocalProxy", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "listener not ready"])
         }
-
         self.listener = l
         self.port = p.rawValue
         return p.rawValue
     }
 
     private func handle(_ client: NWConnection) {
-        NSLog("LocalProxy: incoming connection")
         client.start(queue: queue)
         readConnect(client, accumulated: Data())
     }
@@ -52,21 +60,28 @@ final class LocalProxy: @unchecked Sendable {
     private func readConnect(_ client: NWConnection, accumulated: Data) {
         client.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] data, _, isComplete, error in
             guard let self else { return }
-            if let error { NSLog("CONNECT read error: \(error)"); client.cancel(); return }
-            var buf = accumulated
-            if let data { buf.append(data) }
-            if let endRange = buf.range(of: Data([0x0D, 0x0A, 0x0D, 0x0A])) {
-                let header = buf.prefix(upTo: endRange.lowerBound)
-                self.processConnect(client, header: header)
+            if let error {
+                NSLog("LocalProxy CONNECT read error: \(error)")
+                client.cancel()
                 return
             }
-            if isComplete || buf.count > 16384 { client.cancel(); return }
+            var buf = accumulated
+            if let data { buf.append(data) }
+            if let end = buf.range(of: Data([0x0D, 0x0A, 0x0D, 0x0A])) {
+                self.processConnect(client, header: buf.prefix(upTo: end.lowerBound))
+                return
+            }
+            if isComplete || buf.count > 16384 {
+                client.cancel()
+                return
+            }
             self.readConnect(client, accumulated: buf)
         }
     }
 
     private func processConnect(_ client: NWConnection, header: Data) {
-        guard let line = String(data: header, encoding: .utf8)?.split(separator: "\r\n").first else {
+        guard let line = String(data: header, encoding: .utf8)?
+                .split(separator: "\r\n").first else {
             sendError(client, "400 Bad Request"); return
         }
         let parts = line.split(separator: " ")
@@ -94,20 +109,24 @@ final class LocalProxy: @unchecked Sendable {
     }
 
     private func openTunnel(client: NWConnection, host: String, ip: String, port: UInt16) {
-        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(ip), port: NWEndpoint.Port(rawValue: port)!)
+        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(ip),
+                                          port: NWEndpoint.Port(rawValue: port)!)
         let upstream = NWConnection(to: endpoint, using: .tcp)
         upstream.stateUpdateHandler = { [weak self] state in
             guard let self else { return }
             switch state {
             case .ready:
-                let ok = "HTTP/1.1 200 Connection Established\r\n\r\n".data(using: .utf8)!
+                let ok = Data("HTTP/1.1 200 Connection Established\r\n\r\n".utf8)
                 client.send(content: ok, completion: .contentProcessed { error in
-                    if let error { NSLog("client send 200 failed: \(error)"); client.cancel(); upstream.cancel(); return }
+                    if let error {
+                        NSLog("LocalProxy send 200 failed: \(error)")
+                        client.cancel(); upstream.cancel(); return
+                    }
                     self.pump(from: client, to: upstream)
                     self.pump(from: upstream, to: client)
                 })
             case .failed(let e):
-                NSLog("upstream failed \(host)->\(ip): \(e)")
+                NSLog("LocalProxy upstream failed \(host)->\(ip): \(e)")
                 self.sendError(client, "502 Bad Gateway")
                 upstream.cancel()
             case .cancelled:
@@ -126,9 +145,8 @@ final class LocalProxy: @unchecked Sendable {
                     self?.pump(from: src, to: dst)
                 })
             } else if isComplete || error != nil {
-                dst.send(content: nil, contentContext: .finalMessage, isComplete: true, completion: .contentProcessed { _ in
-                    src.cancel()
-                })
+                dst.send(content: nil, contentContext: .finalMessage, isComplete: true,
+                         completion: .contentProcessed { _ in src.cancel() })
             } else {
                 self?.pump(from: src, to: dst)
             }
@@ -136,7 +154,7 @@ final class LocalProxy: @unchecked Sendable {
     }
 
     private func sendError(_ client: NWConnection, _ status: String) {
-        let resp = "HTTP/1.1 \(status)\r\nContent-Length: 0\r\n\r\n".data(using: .utf8)!
+        let resp = Data("HTTP/1.1 \(status)\r\nContent-Length: 0\r\n\r\n".utf8)
         client.send(content: resp, completion: .contentProcessed { _ in client.cancel() })
     }
 }

--- a/NoShorts/README.md
+++ b/NoShorts/README.md
@@ -1,20 +1,21 @@
 # NoShorts
 
-An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navigation, feed shelves, autoplay), and lands on the **All Subscriptions** channel grid (`/feed/channels`) instead of the algorithmic home page.
+An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navigation, feed shelves, autoplay), and lands on **Playlists** (`/feed/playlists`) instead of the algorithmic home page.
+
+Architecture and V2 rationale live in [V2_PRD.md](V2_PRD.md).
 
 ## Features
 
-- **Shorts blocking**: removes Shorts tab, home feed shelf, and all `/shorts/` links from the DOM
-- **All Subscriptions as default landing**: app launches into `/feed/channels` (the channel grid, not the videos feed). Any navigation to `/` (algorithmic home) — including YouTube's own in-page Home tab, the YouTube logo, the toolbar Home button, post-login redirects — is caught and rewritten via KVO on `webView.url` (catches SPA `pushState`) plus `WKNavigationDelegate` (catches full-page navs).
-- **Auto-rotate to landscape on video play**: tapping a video (URL → `/watch?v=...`) calls `UIWindowScene.requestGeometryUpdate(.iOS(interfaceOrientations: .landscape))` to force landscape immediately. Off the watch page, orientation is unlocked (`.allButUpsideDown`) so manual rotation works.
-- **Autoplay blocked**: JS interceptor only allows `video.play()` within 1.5s of a user tap
-- **SPA navigation guard**: intercepts `pushState`/`replaceState` to drop `/shorts` navigations
-- **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0
-- **Top toolbar**: 4 destination shortcuts — Playlists (`/feed/playlists`), Liked Videos (`/playlist?list=LL`), All Subscriptions (`/feed/channels`), Account/Login (`/account`)
-- **Bottom toolbar**: back, forward, search (expands inline), home (→ All Subscriptions), reload
-- **Search bar**: tap the magnifying glass in the bottom toolbar to expand an animated inline search field
-- **Google sign-in**: works natively in-app (no Safari handoff required)
-- **DNS bypass**: in-app DoH proxy lets WKWebView reach `youtube.com` even when system DNS (e.g. NextDNS) blocks it — used to block YouTube in Chrome while keeping it accessible here
+- **Shorts blocking**: removes Shorts tab, home feed shelf, and all `/shorts/` links from the DOM.
+- **Playlists as default landing**: app launches into `/feed/playlists`. Any navigation to `/` (algorithmic home) — YouTube's in-page Home tab, the logo, the toolbar Home button, post-login redirects — is caught and rewritten via KVO on `webView.url` (SPA `pushState`) plus `WKNavigationDelegate` (full-page navs). The `/` intercept skips forward/back navs so the toolbar chevrons don't appear broken.
+- **Auto-rotate to landscape on video play**: JS reports `<video>` `play`/`pause`/`ended` events; a 400ms debounce coalesces buffering-driven pause↔play blips before flipping orientation. Portrait when not playing.
+- **Autoplay blocked**: JS interceptor only allows `video.play()` within 1.5s of a real user gesture. Load-bearing beyond autoplay — without the wrapper YouTube's player refuses to serve modern content.
+- **SPA navigation guard**: intercepts `pushState`/`replaceState` to drop `/shorts` navigations.
+- **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0.
+- **Top toolbar**: 4 destination shortcuts — Playlists, Liked Videos, All Subscriptions, Account/Login.
+- **Bottom toolbar**: back, forward, search (expands inline), home, reload. Back/forward mirror `WKWebView.canGoBack`/`canGoForward` via KVO — refreshed live rather than only at `didFinish` so the chevrons stay accurate through cancelled navs.
+- **Google sign-in**: works natively in-app (no Safari handoff required).
+- **DNS bypass, per-app + per-domain**: a `LocalProxy` (loopback-only `NWListener`) resolves `*.youtube.com` via DoH to `dns.google` and tunnels bytes to the resolved IP. The proxy is set on `WKWebsiteDataStore.default().proxyConfigurations` with `matchDomains = ["youtube.com"]`, so **only** `*.youtube.com` traffic goes through it. Everything else (`googlevideo`, `ytimg`, `doubleclick`, `googleapis`) resolves directly through system DNS. This is what lets NoShorts reach YouTube on a phone where NextDNS pinholes `*.youtube.com` for every other app — the bypass is scoped to this WKWebView data store and doesn't leak to Safari.
 
 ## Requirements
 

--- a/NoShorts/V2_PRD.md
+++ b/NoShorts/V2_PRD.md
@@ -1,6 +1,6 @@
 # NoShorts V2 — PRD, Implementation Plan, System Design
 
-Status: **decided, ready to build**
+Status: **built and merged, then shelved on-device — see §8**
 Author: Amit Butala
 Reviewer: Claude Code
 Last edited: 2026-07-08
@@ -218,6 +218,65 @@ Install a device-wide `.mobileconfig` DoH override for `*.youtube.com`. This def
 Watch YouTube on a different device (laptop, Apple TV) for the foreseeable. Come back when iOS 27 ships and re-evaluate. This is the only tier that involves not shipping.
 
 **Explicit non-plan:** we do NOT chase the "self-hosted yt-dlp on aibo" path unless Tier 4 is also unacceptable AND Amit signs up for the ongoing maintenance treadmill. It's over-scoped for MVP.
+
+## 8. Outcome (2026-07-08) — built, merged, then shelved
+
+V2 was built exactly per §5–§6 and merged as PR #231. Simulator verification passed cleanly (see Appendix B). The **on-device test with NextDNS active failed**, and — critically — it failed in **both** of the fault modes §7 asked us to disambiguate, in the same session on the same phone.
+
+### On-device test log — first video
+
+- `LocalProxy started on 127.0.0.1:<port>, scoped to *.youtube.com`
+- `LocalProxy: CONNECT www.youtube.com:443 -> 142.251.218.238`  (Google-owned IP, succeeds)
+- `LocalProxy: CONNECT m.youtube.com:443 -> 142.251.219.46`
+- **Zero** `LocalProxy: CONNECT` lines for `googlevideo.com`, `ytimg.com`, or `doubleclick.net` — `matchDomains` scoping worked exactly as designed.
+- YouTube's ads played. Video preview thumbnail rendered. Player JS loaded. Then transition to content failed with "An error occurred."
+- Diagnosis: proxy path is fine. **WebContent's direct fetches to `googlevideo.com` (ISP-hosted Google Global Cache edges, e.g. `50.151.x.x` for Xfinity) cannot complete** from this third-party app on iOS 26.5.2. This is the §7 Tier 2 signal — the failure is in WebContent, not in the LocalProxy.
+
+### On-device test log — second video, same session
+
+- `LocalProxy: CONNECT www.youtube.com:443 -> 142.251.218.238`  (same Google IP that worked seconds earlier)
+- `Socket SO_ERROR [54: Connection reset by peer]`
+- `Receive failed with error "Connection reset by peer"`
+- `LocalProxy upstream failed www.youtube.com->142.251.218.238: POSIXErrorCode(rawValue: 50): Network is down`
+- Diagnosis: **the LocalProxy's own outbound TCP to a Google-owned IP got RST mid-flight.** Same failure signature we'd only seen on `googlevideo.com` IPs before.
+
+### Interpretation
+
+- The pattern is now consistent across every mitigation we tried across three days: whether traffic goes through our proxy or direct, whether the destination is Google-owned or ISP-hosted, whether we use `matchDomains` scoping or route everything, whether we're on Wi-Fi or cellular.
+- The block is systemic to iOS 26.5.2's treatment of outbound TCP from a third-party WKWebView app's bundle. It is not addressable via the `WKWebView.proxyConfigurations` API alone.
+- The V2 code is the cleanest possible expression of the V1 architecture and is correct given what we knew when we built it. **Nothing about V2 is wrong; the platform tightened under us.**
+
+### Why we stopped at Tier 3 rather than trying it
+
+§7 pointed at `NEAppProxyProvider` (Network Extension) as the remaining app-side option. We chose **not** to pursue it, for these reasons:
+
+- The failure pattern (both proxy AND direct fetches failing in the same session, both to Google-owned and to ISP-hosted IPs) suggests the tightening is at the **app-bundle sandbox** level, not at the specific-networking-primitive level. A Network Extension is still code running in our app's bundle — unlikely to be treated meaningfully differently by iOS's outbound-TCP gate.
+- 1–2 days of real work on a speculative fix, with strong prior evidence pointing at "won't work either," is a bad ROI.
+- iOS 27 will land in a few months. If Apple relaxes the sandbox constraints, V2 as-is may start working with no new code. If they tighten further, no in-app architecture is going to save us.
+
+### What we're keeping vs. shelving
+
+**Keeping (merged as PR #231):**
+
+- V2 code. Clean rewrite of V1. Eliminates the accumulated cruft. Correct architecture given our constraints. Natural resume point when the platform changes.
+- This PRD, including Appendix A/B/C. Every dead end is documented so the next attempt doesn't repeat them.
+
+**Shelved, but on-record as viable alternate architectures if needed later:**
+
+- Self-hosted `yt-dlp` on aibo (Amit's residential-IP home box), exposed via Cloudflare Tunnel or similar. Real ops surface but removes the "third-party app can't reach googlevideo" problem entirely by making our app talk to aibo instead.
+- Self-hosted Piped instance on aibo — same idea, heavier stack.
+- Full native `AVPlayer` + DASH-manifest extraction rewrite. Biggest scope, most independent of platform changes.
+
+### Re-attempt trigger
+
+Re-attempt V2 or a successor when **any** of these change:
+
+1. An iOS point release relaxes third-party WKWebView outbound TCP.
+2. Apple documents an entitlement that unblocks the specific behavior we need.
+3. Amit decides self-hosting an extractor on aibo is worth the ongoing ops.
+4. Piped/Invidious ecosystem recovers meaningfully.
+
+Until then, watch YouTube on a laptop / Apple TV / a device where the platform doesn't fight us.
 
 ---
 


### PR DESCRIPTION
## Status

**Shelved on iOS 26.5.2.** Full analysis of the on-device failure and the shelve decision is in [`V2_PRD.md §8`](NoShorts/V2_PRD.md).

Merging deliberately as the clean architectural record + resume point, not as a working V2. Amit's iPhone still cannot play YouTube video content through this app on iOS 26.5.2 — this PR does not fix that.

## Why we're merging anyway

- The V2 code is the correct implementation given what we knew at build time (matchDomains-scoped proxy, KVO nav flags, orientation debounce, allowsInlineMediaPlayback, all V1 cruft cleaned up).
- On-device test hit both fault modes §7 asked us to disambiguate — WebContent direct fetches to `*.googlevideo.com` fail AND LocalProxy outbound to Google-owned IPs fails, in the same session. Pattern is systemic to iOS 26.5.2's outbound-TCP treatment of third-party WKWebView bundles, not something addressable at the WKWebView proxy config layer.
- Landing V2 makes the next re-attempt cheap: start from clean architecturally-correct code rather than V1's accumulated workaround pattern.

## Original summary (kept for record)

Implements the V2 architecture from [`NoShorts/V2_PRD.md`](NoShorts/V2_PRD.md) (landed in #230).

- `ProxyConfiguration.matchDomains = ["youtube.com"]` — only `*.youtube.com` transits `LocalProxy`; googlevideo/ytimg/doubleclick/googleapis go direct via WebContent.
- `config.allowsInlineMediaPlayback = true`.
- `canGoBack`/`canGoForward` mirrored via KVO in the coordinator — chevrons accurate through cancelled navs.
- 400 ms coalesce on the play/pause orientation flip.
- `/shorts` intercept `.cancel`-only; YouTube-home intercept skips redirect on `WKNavigationType.backForward`.
- `LocalProxy.swift` stripped: single DoH endpoint, no failover, no bypass paths, loopback-only listener.
- `DoHResolver.swift` stripped: dns.google only, first A record, IPv4 only.
- README updated to describe matchDomains scoping and point at `V2_PRD.md`.

## Test plan

**Simulator (done):**

- [x] `BUILD SUCCEEDED` on iOS 26.5 Simulator.
- [x] App launches, `LocalProxy started ... scoped to *.youtube.com` logged.
- [x] Temporary override to load Me at the Zoo rendered fully (video preview, title, comments, related videos, toolbars all correct). Reverted before commit.

**On-device (done, failed — decision to shelve):**

- [x] Sanity: Safari on phone → `youtube.com` → NextDNS block page still returned.
- [x] NoShorts launches. Playlists page renders (empty for anonymous).
- [x] Search → tap video → **ads play, preview loads, then "An error occurred" during content transition.**
- [x] Console: only `LocalProxy: CONNECT www.youtube.com:443 -> …` and `m.youtube.com:443 -> …` (Google IPs). No CONNECTs for `googlevideo.com`/`ytimg.com`. Scope working.
- [x] Second video same session: LocalProxy CONNECT to the same Google IP now RSTs / `Network is down`. Both fault modes hit.

See [`V2_PRD.md §8`](NoShorts/V2_PRD.md) for full analysis and re-attempt trigger conditions.

## References

- Precursor docs PR: #230 (PRD + fail-fast plan)
- V1 PRs: #151, #153, #154, #155, #159, #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)