### PR TITLE
fix(NoShorts): restore iOS 26.5.2 playback — honest UA, strip BotGuard-visible JS tampering

### DIFF
--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -16,11 +16,11 @@ import Network
 // MARK: - Injected user scripts
 
 /// Runs at document start in every frame: CSS that hides Shorts affordances
-/// before first paint. Track-A diagnostic build (see noshorts-v2-plan.md):
-/// the window.webkit hide, HTMLVideoElement.play() wrapper, and pushState
-/// wrappers are stripped — all three are BotGuard-visible tampering and the
-/// prime suspects for failed stream attestation (no pot= param, streams
-/// killed mid-body). /shorts SPA navs are NOT blocked in this build.
+/// before first paint. CSS-only BY DESIGN — the former window.webkit hide,
+/// HTMLVideoElement.play() wrapper, and pushState wrappers were BotGuard-visible
+/// tampering that tripped YouTube's stream attestation and killed playback
+/// (V2_REMEDIATION_PLAN.md §3a). Do not reintroduce page-JS tampering here.
+/// /shorts SPA navs are currently unguarded — Swift-side replacement: issue #232.
 private let earlyScript = """
 (function() {
     const s = document.createElement('style');

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -15,21 +15,14 @@ import Network
 
 // MARK: - Injected user scripts
 
-/// Runs at document start in every frame. Does three things:
-/// 1. Hides `window.webkit` on accounts.google.com so Google's sign-in doesn't
-///    fingerprint us as a WKWebView.
-/// 2. Injects CSS that hides Shorts affordances before first paint.
-/// 3. Wraps `HTMLVideoElement.prototype.play()` so it only resolves within
-///    1.5s of a real user gesture. Load-bearing beyond autoplay: without this
-///    wrapper YouTube's player refuses to serve modern content (confirmed
-///    during the 2026-07 debugging session).
-/// 4. Intercepts SPA `pushState`/`replaceState` for `/shorts`.
+/// Runs at document start in every frame: CSS that hides Shorts affordances
+/// before first paint. Track-A diagnostic build (see noshorts-v2-plan.md):
+/// the window.webkit hide, HTMLVideoElement.play() wrapper, and pushState
+/// wrappers are stripped — all three are BotGuard-visible tampering and the
+/// prime suspects for failed stream attestation (no pot= param, streams
+/// killed mid-body). /shorts SPA navs are NOT blocked in this build.
 private let earlyScript = """
 (function() {
-    if (window.location.hostname.includes('accounts.google')) {
-        try { Object.defineProperty(window, 'webkit', { get: () => undefined, configurable: true }); } catch(e) {}
-    }
-
     const s = document.createElement('style');
     s.id = 'no-shorts';
     s.textContent = `
@@ -42,23 +35,6 @@ private let earlyScript = """
         ytm-pivot-bar-renderer { display:none!important; }
     `;
     (document.head || document.documentElement).appendChild(s);
-
-    let lastInteraction = 0;
-    document.addEventListener('touchstart', () => { lastInteraction = Date.now(); },
-        { capture: true, passive: true });
-    document.addEventListener('click', () => { lastInteraction = Date.now(); },
-        { capture: true, passive: true });
-    const _play = HTMLVideoElement.prototype.play;
-    HTMLVideoElement.prototype.play = function() {
-        if (Date.now() - lastInteraction < 1500) return _play.call(this);
-        return Promise.reject(new DOMException('Autoplay blocked', 'NotAllowedError'));
-    };
-
-    const _push = history.pushState.bind(history);
-    const _replace = history.replaceState.bind(history);
-    const isShorts = (u) => u && String(u).startsWith('/shorts');
-    history.pushState    = (state, title, url) => { if (!isShorts(url)) _push(state, title, url); };
-    history.replaceState = (state, title, url) => { if (!isShorts(url)) _replace(state, title, url); };
 })();
 """
 
@@ -126,6 +102,10 @@ final class WebViewModel {
         // YouTube's adaptive-streaming pipeline expects inline <video>. Without
         // this, playback on iOS 26 hits a limited fullscreen-only codepath.
         config.allowsInlineMediaPlayback = true
+        // Honest UA: WebKit generates the true OS/WebKit prefix and appends
+        // this Safari-shaped suffix. Replaces the pinned iOS-17 customUserAgent
+        // lie, which contradicted the real WebKit fingerprint (Track A).
+        config.applicationNameForUserAgent = "Version/26.5 Mobile/15E148 Safari/604.1"
 
         config.userContentController.addUserScript(
             WKUserScript(source: earlyScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
@@ -162,7 +142,6 @@ final class WebViewModel {
         // to observe googlevideo request statuses. Never ships in Release.
         wv.isInspectable = true
         #endif
-        wv.customUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
         self.webView = wv
     }
 

--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -157,6 +157,11 @@ final class WebViewModel {
         }
 
         let wv = WKWebView(frame: .zero, configuration: config)
+        #if DEBUG
+        // Phase-0 diagnostics: attach Mac Safari Web Inspector (Develop menu)
+        // to observe googlevideo request statuses. Never ships in Release.
+        wv.isInspectable = true
+        #endif
         wv.customUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
         self.webView = wv
     }

--- a/NoShorts/README.md
+++ b/NoShorts/README.md
@@ -2,15 +2,17 @@
 
 An iOS app that wraps YouTube in a `WKWebView`, blocks all Shorts content (navigation, feed shelves, autoplay), and lands on **Playlists** (`/feed/playlists`) instead of the algorithmic home page.
 
-Architecture and V2 rationale live in [V2_PRD.md](V2_PRD.md).
+Architecture and V2 rationale live in [V2_PRD.md](V2_PRD.md). The iOS 26.5.2 playback outage,
+its diagnosis (Google stream attestation, not an OS network block), and the fix are in
+[V2_REMEDIATION_PLAN.md](V2_REMEDIATION_PLAN.md).
 
 ## Features
 
 - **Shorts blocking**: removes Shorts tab, home feed shelf, and all `/shorts/` links from the DOM.
 - **Playlists as default landing**: app launches into `/feed/playlists`. Any navigation to `/` (algorithmic home) — YouTube's in-page Home tab, the logo, the toolbar Home button, post-login redirects — is caught and rewritten via KVO on `webView.url` (SPA `pushState`) plus `WKNavigationDelegate` (full-page navs). The `/` intercept skips forward/back navs so the toolbar chevrons don't appear broken.
 - **Auto-rotate to landscape on video play**: JS reports `<video>` `play`/`pause`/`ended` events; a 400ms debounce coalesces buffering-driven pause↔play blips before flipping orientation. Portrait when not playing.
-- **Autoplay blocked**: JS interceptor only allows `video.play()` within 1.5s of a real user gesture. Load-bearing beyond autoplay — without the wrapper YouTube's player refuses to serve modern content.
-- **SPA navigation guard**: intercepts `pushState`/`replaceState` to drop `/shorts` navigations.
+- **Autoplay gated natively**: `mediaTypesRequiringUserActionForPlayback = .video`. The former JS `video.play()` wrapper was removed 2026-07-09 — prototype tampering tripped YouTube's stream attestation and killed playback (see [V2_REMEDIATION_PLAN.md](V2_REMEDIATION_PLAN.md) §3a).
+- **Shorts navigation guard**: full-page navigations to `/shorts` are cancelled in `WKNavigationDelegate`. SPA (`pushState`) navigations are currently unguarded — the JS `pushState` wrapper was removed with the attestation fix; a Swift-side replacement is tracked in [#232](https://github.com/DeviationLabs/homely-vibes/issues/232).
 - **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0.
 - **Top toolbar**: 4 destination shortcuts — Playlists, Liked Videos, All Subscriptions, Account/Login.
 - **Bottom toolbar**: back, forward, search (expands inline), home, reload. Back/forward mirror `WKWebView.canGoBack`/`canGoForward` via KVO — refreshed live rather than only at `didFinish` so the chevrons stay accurate through cancelled navs.
@@ -80,9 +82,11 @@ Two `WKUserScript` injections run on every page:
 
 **`atDocumentStart` (`earlyScript`)**:
 - Injects CSS to hide Shorts elements before first paint (`.pivot-shorts`, `ytm-shorts-lockup-view-model`, etc.)
-- Intercepts `HTMLVideoElement.prototype.play()` — blocked unless called within 1.5s of a user touch/click
-- Intercepts `history.pushState`/`replaceState` to drop any navigation to `/shorts`
-- Removes `window.webkit` for `accounts.google.com` only, so Google's sign-in flow doesn't detect WKWebView
+- **CSS-only by design.** It previously also wrapped `HTMLVideoElement.prototype.play()`,
+  `history.pushState`/`replaceState`, and hid `window.webkit` on `accounts.google.com`. All three were
+  removed 2026-07-09: page-visible JS tampering is detectable by YouTube's BotGuard attestation, which
+  responded by killing googlevideo media streams mid-body (`200 OK` + zero bytes, no `pot=` parameter,
+  `playerfallback/1`). Removing them (plus the honest UA) restored playback on iOS 26.5.2.
 
 **`atDocumentEnd` (`shortsBlockScript`)**:
 - DOM removal of all Shorts-related elements
@@ -95,7 +99,7 @@ A `KVO` observer on `webView.url` catches SPA URL changes (`history.pushState`/`
 ## Architecture Notes / Gotchas
 
 ### Why mobile user agent?
-YouTube's mobile site (`m.youtube.com`-style layout via user agent) renders more predictably in WKWebView than the desktop site. The app uses a standard iPhone Safari UA.
+YouTube's mobile site (`m.youtube.com`-style layout via user agent) renders more predictably in WKWebView than the desktop site. The app uses `applicationNameForUserAgent = "Version/26.5 Mobile/15E148 Safari/604.1"`, so WebKit generates a truthful UA (real OS + WebKit version) with a Safari-shaped suffix. **Do not pin a fake `customUserAgent`**: the old iOS-17 pin contradicted the real WebKit fingerprint and contributed to YouTube's attestation failures (V2_REMEDIATION_PLAN.md §3a).
 
 ### Why `@Observable` instead of `ObservableObject`?
 Swift 6 strict concurrency prevents `@MainActor` classes from conforming to `ObservableObject`. Using `@Observable` macro with `@ObservationIgnored` on the `WKWebView` property sidesteps the issue cleanly.
@@ -107,7 +111,7 @@ Injecting CSS before paint prevents the Shorts shelf from flickering in before t
 `setInterval` at 800ms caused page freezes on YouTube's heavy SPA. A debounced (300ms) `MutationObserver` fires only when the DOM actually changes and doesn't block the main thread.
 
 ### Google sign-in in WKWebView
-Google detects WKWebView via `window.webkit` and blocks sign-in with a "browser not supported" error. Removing `window.webkit` (scoped to `accounts.google.com` only) makes it appear as Safari. Cookies stay in the WKWebView jar — no `SFSafariViewController` needed.
+Google detects WKWebView via `window.webkit` and can block sign-in with a "browser not supported" error. The old workaround (removing `window.webkit` on `accounts.google.com`) was stripped with the 2026-07-09 attestation fix. Existing sessions persist in the default data store's cookie jar, so this only matters for *fresh* sign-ins — if one hits the block, revisit under [#232](https://github.com/DeviationLabs/homely-vibes/issues/232) (the hide was scoped to accounts.google.com and may be safe to restore alone; verify playback with Web Inspector after).
 
 ### Discovering actual mobile YouTube element names
 YouTube's mobile DOM uses custom elements not documented anywhere (`ytm-shorts-lockup-view-model`, `ytm-pivot-bar-renderer`, etc.). To discover them, inject `document.querySelectorAll('*')` filtered to custom elements via `evaluateJavaScript` with a Swift completion handler — `console.log` output is not accessible from Swift.
@@ -127,7 +131,7 @@ YouTube's mobile DOM uses custom elements not documented anywhere (`ytm-shorts-l
 - **App installs but crashes immediately with `dyld_shared_cache_extract_dylibs` error** — different problem from the above; happens when the device's iOS is newer than Xcode's symbol cache. Edit Scheme → Run → Info → uncheck **Debug executable**.
 
 ### Autoplay interception
-`mediaTypesRequiringUserActionForPlayback = .video` alone is insufficient — YouTube's player works around it. The JS-level `HTMLVideoElement.prototype.play()` override is the reliable fix. The 1.5s window after a touch/click allows legitimate user-initiated plays (including tap-to-play on feed thumbnails).
+Native-only: `mediaTypesRequiringUserActionForPlayback = .video`. The earlier claim that a JS-level `HTMLVideoElement.prototype.play()` override was "the reliable fix" dated from the broken-proxy era and is disproven — the wrapper itself was tripping stream attestation. If autoplay leaks through the native gate, solve it Swift-side ([#232](https://github.com/DeviationLabs/homely-vibes/issues/232)), never by re-tampering with the prototype.
 
 ## Block-YouTube-in-Chrome Setup (DNS bypass)
 

--- a/NoShorts/V2_PRD.md
+++ b/NoShorts/V2_PRD.md
@@ -221,6 +221,17 @@ Watch YouTube on a different device (laptop, Apple TV) for the foreseeable. Come
 
 ## 8. Outcome (2026-07-08) — built, merged, then shelved
 
+> **Update 2026-07-09 — unshelved and FIXED.** This section's root-cause interpretation ("systemic to
+> iOS 26.5.2's treatment of outbound TCP from a third-party WKWebView app's bundle") is **disproven**.
+> Web Inspector diagnostics showed direct WebContent→googlevideo fetches succeeding continuously
+> (manifests, first media segments) while the server killed media streams mid-body (`200 OK` + zero
+> bytes, `Server: gvs 1.0`, no `pot=` parameter, `playerfallback/1`) — i.e., **YouTube stream
+> attestation (PoToken/BotGuard) enforcement**, not an OS network gate. The observed RSTs were remote,
+> from Google edges. Fix: honest UA via `applicationNameForUserAgent` + removal of BotGuard-visible JS
+> tampering (`play()` wrapper, `pushState` wrappers, `window.webkit` hide). Playback verified restored
+> on-device with NextDNS active. Full diagnosis and evidence: [V2_REMEDIATION_PLAN.md](V2_REMEDIATION_PLAN.md).
+> The section below is preserved unedited as the historical record of what we believed on 2026-07-08.
+
 V2 was built exactly per §5–§6 and merged as PR #231. Simulator verification passed cleanly (see Appendix B). The **on-device test with NextDNS active failed**, and — critically — it failed in **both** of the fault modes §7 asked us to disambiguate, in the same session on the same phone.
 
 ### On-device test log — first video

--- a/NoShorts/V2_REMEDIATION_PLAN.md
+++ b/NoShorts/V2_REMEDIATION_PLAN.md
@@ -1,0 +1,186 @@
+# NoShorts — Playback Remediation Plan (iOS 26.5.2)
+
+Date: 2026-07-09 · Author: Claude Code · Owner: Amit · **Status: RESOLVED — see §3a (playback restored on iOS 26.5.2)**
+Moved into the repo 2026-07-09 (formerly `~/.claude/plans/noshorts-v2-plan.md`) so history rides with the code.
+Predecessor scoping draft: [`V2_SCOPING_ARCHIVE.md`](V2_SCOPING_ARCHIVE.md). Companion: [`V2_PRD.md`](V2_PRD.md).
+
+## TL;DR — the thesis has changed
+
+`V2_PRD.md §8` concluded "iOS 26.5.2 blocks outbound TCP from third-party WKWebView app bundles"
+and shelved V2. **Re-reading the session evidence (console screenshots) contradicts that conclusion.**
+The dominant failure signal is `Connection reset by peer` — a **remote** RST arriving *after* the TCP
+tunnel was established and data flowed. An OS sandbox gate would refuse connections locally
+(no SYN / EPERM-style errors); it would not serve you a few seconds of video and then RST from the peer.
+
+The most likely root cause is **Google server-side enforcement** (SABR-only streaming + per-video
+PoToken attestation, actively rolling out to web clients in 2025–2026 — see References), which is
+known to kill media streams after initial bytes for clients that fail attestation. NoShorts trips it because:
+
+- it pins a **fake Safari iOS 17.0 UA** (2023-era) on a real iOS 26.5 WebKit — a contradiction bot-scoring sees;
+- it **tampers with `HTMLVideoElement.prototype.play`** and hides `window.webkit` — prototype tampering is BotGuard-visible;
+- "ads play, content doesn't" is the classic PoToken-enforcement signature (ad serving has separate attestation);
+- the break "**feels like it recently started**" while the app was unchanged — server-side rollouts do that; OS updates don't retroactively break an untouched app *sometimes*.
+
+The plan: **do not write remediation code yet.** Run Phase 0 (half a day of decisive diagnostics),
+which cleanly separates the three competing theories, then execute the matching track.
+
+## 1. Evidence inventory
+
+| # | Observation | Source |
+|---|-------------|--------|
+| E-a | V1 (proxy-everything): CONNECT tunnels to `manifest.googlevideo.com` on **Google-owned IPs (142.251.x) succeed** | screenshot 2026-07-06T18:42 |
+| E-b | V1: tunnels to `rr*---sn-*.googlevideo.com` **ISP GGC edges (68.105.28.x) get `recvmsg failed [54: Connection reset by peer]` mid-tunnel** — established, data flowed, then remote RST | same |
+| E-c | V1 UX: video plays **a few seconds, subtitles render**, then dies. Subtitles come from `youtube.com/api/timedtext` (proxied, works); media dies mid-stream | Amit, 2026-07-09 |
+| E-d | V2 (matchDomains-scoped): **ads play, preview loads**, player spins, "An error occurred". Zero googlevideo CONNECTs (scoping worked) | PR #231 test plan; screenshot 2026-07-08T22:07 |
+| E-e | V2 second video, same session: `Socket SO_ERROR [54: Connection reset by peer]` on the **youtube.com** tunnel to 142.251.218.238 — same IP that worked minutes earlier. "Network is down" is the teardown error *after* the RST | screenshot 2026-07-08T22:09 |
+| E-f | Same failure on Comcast Wi-Fi and cellular (different edges) | PRD App. A |
+| E-g | Simulator, no proxy, Mac DNS: watch page renders fully | PRD App. B |
+| E-h | Both V1 and V2 pin `customUserAgent` = Safari **iOS 17.0** (identical string). PRD notes bumping it to iOS 26 made failure *immediate* instead of after ~2 s | ContentView.swift (pre-596a9fa), PRD App. A |
+| E-i | Worked on iOS 26.0; broken on 26.5.2. But also "feels like it recently started" with app unchanged | Amit |
+| E-j | No public reports of an iOS 26.5 WKWebView `proxyConfigurations` lockdown (searched 2026-07-09). A platform gate on WebView outbound TCP would break Chrome/Firefox iOS (both WKWebView) — no such reports either | web search |
+| E-k | YouTube web client is now SABR-only (adaptive-format URLs removed from player response) with per-video PoToken experiments — yt-dlp/YouTube.js communities hit this through 2025–2026 | yt-dlp #12482, #13968; YouTube.js #724 |
+
+## 2. Theories, ranked
+
+**T1 — Google server-side enforcement (SABR/PoToken/bot-score). LIKELY.**
+Explains E-b/E-c (stream killed after initial bytes), E-d (ads attested separately), E-e (IP/session
+reputation escalates within a session), E-f (IP-independent), E-i ("recently started"), E-k (documented
+rollout). The E-h UA experiment reads as: UA selects which player stack YouTube serves — iOS 26 UA →
+SABR-only → fails at start; iOS 17 UA → legacy URLs → served, then enforcement kills the stream.
+*Kill criterion: signed-in + honest-UA + untampered build still RSTs AND Web Inspector shows no 403s.*
+
+**T2 — iOS 26.5.2 `proxyConfigurations` regression poisons the whole WebContent networking path. POSSIBLE.**
+Would explain why the app broke "at" the OS update. Weakened by E-d (ads stream fine direct from
+googlevideo in the same WebContent process) and E-j. Cannot explain E-c's few-seconds-then-RST shape.
+*Kill criterion: control build with zero proxy config still fails identically.*
+
+**T3 — iOS app-bundle outbound-TCP sandbox gate (the PRD §8 conclusion). MOSTLY DEAD.**
+Contradicted by E-a (some googlevideo tunnels succeed), E-b/E-e (remote RSTs, not local refusals),
+E-d (ads stream), E-j (would be world-breaking news). Keep only as the fallback explanation if
+Phase 0 shows connections failing with **no SYN on the wire**.
+
+## 3. Phase 0 — decisive diagnostics (half a day, mostly no code)
+
+Run in order; each step's outcome prunes the tree.
+
+**D0. Make the WebView inspectable (1 line, biggest payoff).**
+`webView.isInspectable = true` in `ContentView.swift` (debug builds). Enable Web Inspector on the
+phone (Settings → Safari → Advanced). Mac Safari → Develop → iPhone → NoShorts. Reproduce the failure
+and read the **HTTP status codes of the failing googlevideo requests** and the player's JS console.
+- `403` (or `429`) on media segments → **T1 confirmed.** Go to Track A.
+- Requests die with generic network errors, no HTTP response → T2/T3 still alive → D1.
+
+**D1. Packet capture via rvictl (no app change).**
+`rvictl -s <device-udid>` on the Mac, `sudo tcpdump -i rvi0 -w noshorts.pcap`, reproduce, open in Wireshark.
+For the failing googlevideo flows check: Is there a SYN? Does TLS complete? How many bytes before RST,
+and **who sends the RST** (direction)?
+- SYN → TLS → data → RST *from server* → **T1.**
+- No SYN ever leaves the phone → local block → **T3** (PRD was right after all; go to Track C).
+- SYN leaves, no SYN-ACK / RST injected at low TTL → middlebox/ISP weirdness (unlikely; note and continue).
+
+**D2. Signed-in retry (5 min, no code).**
+Sign into the Google account inside NoShorts, replay the same video. Enforcement is materially laxer
+for signed-in sessions. Any improvement is a T1 fingerprint.
+
+**D3. Control build — pristine WebView (30 min).**
+Temporarily remove from NextDNS the `youtube.com` deny (my.nextdns.io, remember to restore).
+Build variant with: **no proxy config, no customUserAgent, no injected scripts.** Just a WKWebView
+loading a watch page.
+- Plays → the app environment is the trigger → bisect one axis at a time: (1) add back UA-pin,
+  (2) add back `earlyScript`, (3) add back proxy w/ matchDomains. The first re-added piece that
+  breaks playback is the offender. T1 vs T2 resolved precisely.
+- Doesn't play even pristine → T2 eliminated too; re-test in Chrome iOS (D4).
+
+**D4. Third-party browser control (5 min, while NextDNS allow is still on).**
+Chrome or Firefox iOS on the same phone (both are WKWebView shells) → youtube.com → play.
+- Plays → T3 is dead permanently, on the record.
+- Fails the same way → something device-wide (NextDNS profile interaction, Screen Time, network) — re-examine assumptions.
+
+**Exit artifact:** update `V2_PRD.md §8` with the Phase-0 verdict.
+
+## 3a. PHASE-0 VERDICT (2026-07-09) — T1 confirmed, T3 disproven
+
+Ran D0 (Web Inspector via `isInspectable`, branch `abutala/noshorts-diag-inspectable`):
+
+- `manifest.googlevideo.com` m3u8 fetches: h2, direct from WebContent, succeed continuously → no OS TCP block. **T3 dead.**
+- `rr12---sn-*` seg.ts fetches: http/1.1, first few succeed (up to 162 KB), then all fail in 1–42 ms.
+  One inspected failure: **HTTP 200 + full headers (`Server: gvs 1.0`), zero body** — server killed the stream mid-response.
+- Segment URLs carry **no `pot=`** and **`playerfallback/1`**, on a **signed-in** session (D2 moot — V1 cookies persisted; login does not fix it).
+- Protocol column shows no h3 anywhere → QUIC theory dead.
+
+→ Google-side stream enforcement. Track A executed: commit `596a9fa` (honest UA via
+`applicationNameForUserAgent`, earlyScript stripped to CSS-only).
+
+**RESULT (2026-07-09, on-device, NextDNS active): PLAYBACK RESTORED. ✅**
+A1 alone fixed it — no player-surface change (A2), no off-device proxy (A3), no extractor (A4) needed.
+Root cause confirmed: YouTube stream attestation reacting to the fake iOS-17 UA + BotGuard-visible JS
+tampering, not any iOS networking change. `V2_PRD.md §8` amended accordingly.
+Follow-up: [#232](https://github.com/DeviationLabs/homely-vibes/issues/232) — restore /shorts SPA guard
++ autoplay gesture-gate Swift-side (attestation-safe), and the sign-in `window.webkit` hide if a fresh
+login ever needs it.
+
+## 4. Remediation tracks
+
+### Track A — T1 confirmed (Google enforcement). Goal: pass attestation like a normal browser.
+Ordered by effort; stop at the first one that works.
+
+1. **A1 — Stop masquerading.** Drop the iOS-17 UA pin (use the real WebKit UA, optionally via
+   `applicationNameForUserAgent` to keep the Safari token with the *true* OS version). Remove the
+   `window.webkit`-hiding hack and the `HTMLVideoElement.prototype.play` wrapper (autoplay control is
+   already provided natively by `mediaTypesRequiringUserActionForPlayback = .video` — test whether the
+   wrapper is actually needed on iOS 26; its "load-bearing" claim dates from the broken-proxy era).
+   Keep CSS/DOM shorts-hiding (cosmetic, low bot-score risk). Test signed-in.
+2. **A2 — Switch player surface.** If A1 insufficient: try `m.youtube.com` as mweb, and the
+   `/embed/<id>` player (different client IDs, different enforcement tiers).
+3. **A3 — Off-device CONNECT proxy on the home Linux box.** Point `proxyConfigurations` at a proxy on
+   the prod host (LAN + Tailscale for cellular) instead of loopback; the host resolves DNS itself
+   (NextDNS bypass intact, G2 intact — only NoShorts is configured; egress stays residential so no
+   IP-reputation hit). Also fully de-risks any loopback-proxy interplay (helps T2 as a bonus).
+   ~50 lines of config (tinyproxy/squid), zero new Swift beyond the endpoint.
+4. **A4 — Self-hosted extractor (last resort).** `yt-dlp` + PoToken provider (bgutil) behind a small
+   HTTP API on the home box; app plays via AVPlayer or a minimal page. Note the SABR client
+   implementations now exist in the open (YouTube.js `SabrStream`), so this path is viable but is the
+   ops treadmill the PRD explicitly deprioritized. Requires Amit to sign up for maintenance.
+
+### Track B — T2 confirmed (proxyConfigurations poison).
+1. **B1 = A3** (off-device proxy) — removes the loopback proxy while keeping per-app scoping. First choice.
+2. **B2 — Device-wide DoH `.mobileconfig`** scoped override (PRD Tier 4). Defeats G2 — Safari gets
+   YouTube back too. Honest fallback; Amit's call. (Verify a DNSSettings payload can actually scope
+   per-domain before promising this — flagged unverified.)
+3. **B3 — `NEDNSProxyProvider`** with `sourceAppSigningIdentifier`-based per-app answers. Verify first
+   whether DNS-proxy extensions activate on unsupervised personal devices — historically MDM-only,
+   which would kill this. Don't start code before that check.
+
+### Track C — T3 confirmed (real OS gate; PRD §8 stands).
+Shelve per PRD §8 re-attempt triggers. A3/A4 remain the only workarounds (traffic terminating at a
+home host looks like plain HTTPS and dodges whatever gate exists). Re-check at each iOS point release.
+
+## 5. Recommended sequence
+
+1. D0 + D2 in one build/session → likely verdict same afternoon. ✅ done — see §3a.
+2. If 403s: A1 bisect (1–2 h) → A2 (1 h) → A3 (an evening incl. proxy setup). ◄ **A1 in flight (596a9fa)**
+3. If not 403s: D1 capture → D3/D4 controls → pick track by the matrix above.
+4. Timebox: if A1–A3 all fail, decide **A4 vs shelve** — that decision belongs to Amit (§6).
+5. Whatever the outcome: update `V2_PRD.md §8` + file a `gh issue` for the chosen follow-up work.
+
+## 6. Decisions Amit owns (answer before Track A/B code continues)
+
+1. ~~Sign in to Google inside NoShorts?~~ Moot — already signed in (V1 cookies persisted); doesn't fix it.
+2. **NextDNS console access mid-test** — OK to temporarily lift the youtube.com deny for D3/D4? (Restore after.)
+3. **Home box as network dependency** (A3/B1): acceptable ops surface? (Proxy is dumb + stateless; but
+   cellular playback then rides home upload bandwidth.)
+4. **If it comes to it: A4 treadmill vs shelve?**
+
+## References
+
+- [`V2_PRD.md`](V2_PRD.md) (esp. §7 fail-fast ladder, §8 outcome — to be amended per §3a)
+- [`V2_SCOPING_ARCHIVE.md`](V2_SCOPING_ARCHIVE.md) (pre-PRD scoping draft, preserved for history)
+- PR [#230](https://github.com/DeviationLabs/homely-vibes/pull/230) (PRD), PR [#231](https://github.com/DeviationLabs/homely-vibes/pull/231) (V2 rewrite + on-device test log)
+- Debug session transcript: local Claude Code session `8d0e15c8` (2026-07-06 → 07-09), incl. 16 device
+  console screenshots; key frames: 2026-07-06T18:42 (V1 RST-mid-tunnel), 2026-07-08T22:07/22:09 (V2 failures)
+- Web Inspector evidence (2026-07-09): seg.ts 200-then-killed with `Server: gvs 1.0`, no `pot=`, `playerfallback/1`; protocol matrix h2/http1.1, no h3
+- [yt-dlp #12482 — web client only has SABR formats](https://github.com/yt-dlp/yt-dlp/issues/12482)
+- [yt-dlp #13968 — YouTube forcing SABR despite cookies](https://github.com/yt-dlp/yt-dlp/issues/13968)
+- [YouTube.js #724 — streaming URLs failing due to PoToken experiment](https://github.com/LuanRT/YouTube.js/issues/724)
+- [YouTube.js SabrStream API](https://ytjs.dev/googlevideo/api/exports/sabr-stream/classes/SabrStream) (open SABR client impl — keeps A4 viable)
+- [Apple forums: "Network is down" in WebView networking](https://developer.apple.com/forums/thread/714908) (precedent that NW "network is down" ≠ literal sandbox verdict)

--- a/NoShorts/V2_SCOPING_ARCHIVE.md
+++ b/NoShorts/V2_SCOPING_ARCHIVE.md
@@ -1,0 +1,249 @@
+# NoShorts V2 — pre-PRD scoping draft (ARCHIVE)
+
+Preserved for history 2026-07-09 (formerly `~/.claude/plans/noshorts-v2-plan.md`, the working draft
+that evolved into [V2_PRD.md](V2_PRD.md)). Superseded; see [V2_REMEDIATION_PLAN.md](V2_REMEDIATION_PLAN.md) for the current state.
+
+
+Session mode: **iterate the plan until every open question is answered. No code until the plan is settled.**
+
+## 0. Diagnostic finding that reshapes everything (2026-07-07)
+
+Ran a simulator experiment: took V1's `ContentView.swift`, stripped out the `LocalProxy` setup entirely, loaded `https://www.youtube.com/watch?v=jNQXAC9IVRw` directly in the WKWebView. On iOS 26.5.2 Simulator (iPhone 17 Pro), the watch page loaded fully — video preview, title, uploader, view count, comments, related videos, all rendered normally. V1 could never get to this state on-device.
+
+**Reinterpretation of the whole V1 saga:** V1's on-device failure was not FairPlay DRM, not Apple-only entitlements, not third-party WKWebView being fundamentally locked out of YouTube. **It was the LocalProxy configuration interacting badly with iOS 26.5.2's outbound-TCP handling.** Remove the LocalProxy, WKWebView plays YouTube like it always did.
+
+The `Playback ID` error I saw when I forced autoplay in that same experiment is expected — YouTube's player refuses to autoplay content that wasn't triggered by a user gesture, in every browser. Not evidence of anything blocking us.
+
+**Which means V2 is not a rewrite. V2 is V1 minus the LocalProxy.**
+
+The Piped / yt-dlp / AVPlayer detour I was exploring earlier is no longer needed. The V1 UI was fine. The V1 WKWebView-plays-YouTube pattern was fine. The only architectural mistake was routing traffic through a local `NWConnection`-based proxy for DNS purposes when iOS 26.5.2 doesn't tolerate that.
+
+## 0a. Revised V2 architecture
+
+- V1's SwiftUI shell stays: playlist-first home, session timer, orientation lock, hide-shorts JS, chevrons, search bar, everything.
+- **Delete `LocalProxy.swift` and `DoHResolver.swift` in their entirety.** WKWebView gets a plain default `WKWebsiteDataStore` — no proxy configuration.
+- **Move the DNS bypass responsibility to the phone level**, off the app. The app assumes DNS resolves cleanly for `*.youtube.com` and everything else. How that resolution happens is a phone-level configuration concern, not an in-app one.
+- Add `config.allowsInlineMediaPlayback = true` (confirmed useful for consistent inline playback).
+- Keep the existing user scripts (early script's autoplay wrapper, shorts hiding, video event script, pushState guard).
+
+## 0b. New primary open question
+
+**Q11: how do we bypass NextDNS's `*.youtube.com` deny at the phone level, off the app?** Options, ranked by simplicity:
+
+1. **`.mobileconfig` configuration profile installed via iOS Settings.** Standard Apple mechanism. Says: "for `*.youtube.com`, use dns.google DoH; for everything else, use whatever the phone's set to." Zero code. Cross-app: Safari benefits too, which is a nice side-effect. Install once via mail attachment or served over HTTPS. My default: this.
+2. **A tiny companion iOS app that installs a `NEDNSSettingsManager` DoH profile.** Same effect but managed by an app on the phone. Needs the `com.apple.developer.networking.custom-dns` entitlement, which Apple sometimes gates for personal apps.
+3. **Adjust NextDNS itself** to exempt the phone from the `*.youtube.com` block. Simplest of all, but only works if we're OK letting all traffic on that phone see YouTube.
+4. **A DNS proxy `NEPacketTunnelProvider`** app. Heavier than #2, more control.
+
+I strongly recommend #1 (`.mobileconfig`) — it's the least code, most standard, and Apple-supported. If it works on-device with your NextDNS setup, V2 is done: install the profile, run V1 with the LocalProxy code deleted.
+
+## 0c. Remaining unknowns / risks
+
+- **On-device confirmation.** Simulator uses the Mac's DNS, so we haven't proven the `.mobileconfig` approach works with NextDNS active on the phone. This is testable in one session with a physical device.
+- **NextDNS on Amit's phone may itself be a DNS profile.** If so, iOS DNS profile priority rules apply — the most-recently-installed profile might win, or system might allow multiple domain-scoped profiles to compose. We won't know without trying.
+- **We haven't confirmed video actually plays end-to-end in simulator.** Only that the watch page renders and the video preview appears. Simulator's HTML5 video / HLS support has known quirks. Real proof requires on-device testing. But if V1 played briefly-then-errored on-device (which it did), the mechanism is basically there.
+
+## 0d. If Q11 solution works — reduced V2 scope
+
+MVP becomes trivially small:
+
+1. Delete `NoShorts/NoShorts/LocalProxy.swift`.
+2. Delete `NoShorts/NoShorts/DoHResolver.swift`.
+3. Edit `NoShorts/NoShorts/ContentView.swift` to remove the `proxy` property and its start-plus-config block. Add `config.allowsInlineMediaPlayback = true`.
+4. Craft a `noshorts.mobileconfig` that scopes `dns.google` DoH to `*.youtube.com` only.
+5. Install profile on Amit's phone.
+6. Install V2 on Amit's phone (fresh bundle ID `com.deviationlabs.NoShortsV2` to coexist with V1 for A/B comparison, then swap once confirmed).
+7. Verify.
+
+That's an afternoon, not a project. Everything in §5 (must-have MVP: playlists-home, hide shorts, session timer, orientation lock) is already there in V1 code — we're just stripping the broken proxy layer.
+
+---
+
+**Everything below this line is the previous plan draft, kept for reference. All the Piped / yt-dlp / self-host discussion is moot now that we know the actual problem was the LocalProxy configuration.**
+
+## 1. Why V2 exists
+
+V1 is architected as WKWebView-hosts-YouTube-mobile-web + local DoH proxy to bypass NextDNS deny of `*.youtube.com`. This pattern:
+
+- Depends on WKWebView successfully playing YouTube's HLS+FairPlay-protected content, which requires entitlements only Safari holds.
+- Broke on iOS 26.5.2 in a way that also blocks non-Google outbound TCP from the app entirely.
+- Cannot be fixed at the app layer — Apple has been squeezing this pattern shut across iOS releases.
+
+V2 abandons the "wrap YouTube web" pattern. It talks to YouTube's actual media pipeline itself and plays with `AVPlayer`. The playback path becomes: our code → YouTube extractor → DASH/HLS URL → AVPlayer. No WKWebView in the media path.
+
+## 2. Constraints and hard truths I'm assuming (please confirm/correct)
+
+- **Users**: right now, one — Amit. Not a public product. Not App Store. Dev-signed / TestFlight scope only.
+- **Devices**: iPhone (13 Pro was in this session). iOS 26.5.2+. No need for iPad-optimized layout, tvOS, or macOS Catalyst — unless corrected.
+- **DRM**: V2 will *not* support DRM'd content. YouTube premium requires Widevine or FairPlay handshake we cannot provide as a third-party app. Public/unencrypted content only. This is an accepted limitation.
+- **Ads**: because we're going direct to media segments, we skip the ad pipeline entirely. Not accidentally — deliberately, and this is a feature.
+- **Google sign-in**: needed for personalized data (subscriptions, Watch Later, Likes). But signing in through a third-party client is itself detectable by Google and gets accounts flagged/blocked. This is a hard tradeoff.
+- **Legal / TOS**: this pattern (extractor-based YouTube client) violates YouTube TOS. All open-source alternatives operate in this same gray zone. Not distributed to App Store. Amit accepts this.
+
+## 3. Big architectural fork — must be decided first
+
+**Option A — Direct extraction (SmartTubeIOS-style):**
+
+App itself talks to YouTube's servers, parses player configs, extracts DASH manifest URLs, feeds AVPlayer.
+
+- Pro: fully self-contained. No dependency on anyone else's server. Works everywhere with just an internet connection.
+- Con: YouTube changes their extractor-facing surface every few weeks. Someone (Amit) has to patch. This is the well-known "extractor treadmill."
+- Con: age-gated content, live streams, signed URLs, throttling, PoT (Proof-of-Origin Token) checks — each is its own workstream.
+
+**Option B — Backend proxy (Yattee-style, Piped/Invidious):**
+
+App calls out to a Piped or Invidious server (hosted by community or self-hosted) which does the extraction and returns clean URLs / manifests. App plays the result with AVPlayer.
+
+- Pro: extractor maintenance is someone else's problem.
+- Pro: consistent API surface. Client code stays small and clean.
+- Con: dependence on external service — public instances get rate-limited, go down, or ban traffic.
+- Con: adds ~10–20ms latency to every request.
+- Con: if we self-host, that's a whole ops surface (backend infra, SSL, uptime).
+
+**Option C — Hybrid:**
+
+Try direct extraction first; fall back to a configured Piped/Invidious backend on extractor failure. Best of both, most complex.
+
+**Decision needed from Amit:** A, B, or C? My default recommendation is **B (Yattee-style, Piped backend)**. Reasons:
+
+- Amit already has a track record of maintaining IoT projects (homely_vibes). Adding "keep YouTube extractor working" to that list is real burden.
+- The whole session today shows Amit values *working* over *perfectly-architected-but-fragile*.
+- Piped is stable enough that Yattee ships on the App Store using it.
+- If Piped instances start being untrustworthy, we can self-host one — it's a well-documented Docker deploy.
+
+If Amit prefers self-hosting the extraction: pick B and plan to run a personal Piped instance.
+
+## 4. Fork existing app vs. start from scratch
+
+**Option 1 — Fork SmartTubeIOS:**
+
+Clone [milika/SmartTubeIOS](https://github.com/milika/SmartTubeIOS). Rebrand. Delete features we don't want. Add NoShorts's opinionated behavior (shorts hiding, playlist-first home, 30-min session timer).
+
+- Pro: shortest path to working. Days, not weeks.
+- Pro: SmartTubeIOS already handles extraction, AVPlayer wiring, SponsorBlock, quality picker, subtitles, PIP, background audio, etc.
+- Con: inherits their architectural decisions; some may not match what we'd want.
+- Con: harder to keep in sync with upstream if we want to pull fixes later. Fork drift.
+
+**Option 2 — Fork Yattee:**
+
+Clone [Yattee](https://github.com/yattee/yattee). Different starting point — assumes Piped/Invidious backend.
+
+- Pro: matches Option B architecture from §3 if that's what we pick.
+- Pro: on the App Store, so proven distribution model.
+- Con: more feature-heavy than we want; feels heavier.
+
+**Option 3 — Build from scratch:**
+
+New Xcode project. Pull in libraries as needed (extractor, player).
+
+- Pro: exact fit to NoShorts's product spec.
+- Pro: no accidental inherited complexity.
+- Con: weeks. Every capability (subtitles, PIP, background, quality picker) has to be built.
+
+**Decision needed:** 1, 2, or 3? My recommendation is **Option 1 (fork SmartTubeIOS)** if we pick §3-A (direct extraction), or **Option 2 (fork Yattee)** if we pick §3-B. Not Option 3 — the incremental cost per feature is too high.
+
+## 5. Product spec — what NoShorts V2 IS
+
+Carrying forward from V1's intent, but reduced to what's non-negotiable:
+
+**Must-have MVP:**
+
+- Sign in with Google, browse your subscribed channels.
+- Play videos in `AVPlayer` (no WKWebView involved in playback).
+- Home screen defaults to Playlists (not Trending).
+- Shorts are hidden across the app.
+- 30-minute session timer — app becomes unusable after that until next launch.
+- Landscape lock rotates on play, portrait on pause/end.
+
+**Nice-to-have V2.1:**
+
+- Watch Later playlist support.
+- Search.
+- Subtitles.
+- Playback speed control.
+- Background audio (locked screen, other apps).
+
+**Explicitly deferred / cut:**
+
+- iPad-optimized layout.
+- Apple TV.
+- Live streams.
+- Comments.
+- Ad support (deliberately none).
+- DRM content playback.
+- Downloading videos for offline.
+
+Amit confirm the MVP list matches your intent.
+
+## 6. Open technical questions I need answered before scaffolding
+
+**Extraction / networking:**
+
+1. If §3-A: which extractor library will we use? Options: (a) invoke SmartTubeIOS's built-in extractor, (b) port NewPipeExtractor from Java, (c) embed [yt-dlp](https://github.com/yt-dlp/yt-dlp) via a shell / Python — probably not viable on iOS.
+2. If §3-B: use a public Piped instance, self-host one, or a fallback list?
+3. Handle "YouTube rate-limits our IP" gracefully — what's the UX?
+4. Handle "video is age-gated / region-locked" — surface error or silently skip?
+
+**Auth:**
+
+5. Google sign-in via OAuth requires a WebView-based flow at some step (Google's own sign-in page). Are we OK with a one-shot WKWebView JUST for sign-in? Or do we go anonymous-only and skip subscriptions?
+6. If signing in: how do we persist credentials? iOS Keychain, standard OAuth refresh flow.
+
+**Player:**
+
+7. AVPlayer + HLS: which quality tiers matter? 720p enough, or need 1080p/4K?
+8. Do we need FFmpeg wrapping (KSPlayer style) for exotic codecs, or is AVPlayer alone enough for public YouTube content?
+9. Background audio + PIP entitlement — need `UIBackgroundModes` = `audio`.
+
+**UI / design:**
+
+10. SwiftUI (V2 code style) or UIKit (SmartTubeIOS may be UIKit-heavy)?
+11. Reuse V1's SwiftUI patterns? (session timer, orientation lock, red-accent design) — these are small and worth pulling forward.
+
+**Distribution / build:**
+
+12. TestFlight / Ad-Hoc / dev-signed only? (Assuming dev-signed until proven otherwise.)
+13. Bundle ID — reuse `com.deviationlabs.NoShorts` or new one for V2?
+14. Repo layout — new repo, or under homely_vibes as `NoShortsV2/`?
+
+**V1 fate:**
+
+15. What do we do with V1's uncommitted changes on `abutala/noshorts-playback-and-nav-fixes`? Options: (a) commit the two real wins (`allowsInlineMediaPlayback`, `matchDomains`) and ship a small PR that at least de-clunks V1, (b) discard everything, (c) leave the branch dangling forever.
+16. Is V1 archived / kept installed as a fallback, or actively deleted from Amit's phone?
+
+## 7. Milestones once questions are answered
+
+- **M0 — Repo scaffold:** decide fork target (SmartTubeIOS or Yattee), clone, get it building locally, run once on device to prove baseline.
+- **M1 — Rebrand:** bundle ID, name, launch screen, app icon. Prove the fork installs alongside V1 without conflict.
+- **M2 — MVP feature strip:** remove features not in §5's MVP. Add NoShorts's shorts-hiding, playlist-home, session timer, orientation lock.
+- **M3 — Ship internally:** installed on Amit's phone via Xcode, used daily for a week.
+- **M4 — Iterate on V2.1 features:** subtitles, search, background audio, etc.
+
+Rough calendar (assuming Option 1 fork of SmartTubeIOS + Option B backend):
+
+- M0–M1: 1 weekend.
+- M2: 1–2 weekends.
+- M3: continuous starting after M2.
+- M4: as need arises.
+
+## 8. Risks / kill-switches
+
+- **Extractor treadmill (if we pick A):** if patching becomes >1 hour every two weeks, switch to B.
+- **Piped instance untrustworthy (if we pick B):** switch to self-hosted Piped on personal infra.
+- **Google account gets flagged for third-party client use (if we sign in):** decide whether to accept anonymous-only mode.
+- **iOS 27 tightens further and blocks even native `AVPlayer` from reaching non-Google IPs from third-party apps:** at that point, the app is unsalvageable regardless of architecture. But nothing in the current signals suggests this — the block affects the WKWebView + WebContent pipeline, not raw NWConnection or AVPlayer.
+
+## 9. Questions to Amit — resolve these before I write code
+
+Numbered for easy reply:
+
+1. Direct extraction (A) or Piped-style backend (B) or hybrid (C)? (My default: B.)
+2. Fork SmartTubeIOS (1), fork Yattee (2), or from scratch (3)? (My default: 1 if A, 2 if B.)
+3. Google sign-in in MVP, or anonymous-first? (My default: anonymous-first for MVP, sign-in for V2.1.)
+4. Any features on §5's "must have MVP" list you'd cut or add?
+5. What to do with V1's uncommitted changes — commit the two wins as a small PR, or discard?
+6. Repo location — under `homely_vibes/NoShortsV2/`, or a new top-level repo?
+7. Bundle ID — reuse `com.deviationlabs.NoShorts` (installs on top of V1, replaces it) or new (`com.deviationlabs.NoShortsV2`, coexists)?
+8. Anything I've mis-assumed in §2? (One user, iPhone-only, no DRM, no App Store, TOS violation accepted.)
+
+I'll iterate this plan file with each answer. No code until every question here has an answer AND the plan reads self-consistently.


### PR DESCRIPTION
## Summary

**Playback works again on iOS 26.5.2 with NextDNS active** — verified on-device by Amit.

Root cause was **not** an iOS networking lockdown. `V2_PRD.md §8`'s conclusion ("iOS 26.5.2 blocks outbound TCP from third-party WKWebView bundles") is disproven by Web Inspector evidence and amended in this PR. The actual cause: **YouTube stream attestation (PoToken/BotGuard) enforcement** killing googlevideo media streams for a client that looked tampered:

- googlevideo `seg.ts` requests returned **HTTP 200 + full headers (`Server: gvs 1.0`) then zero body** — server killed the stream mid-response
- segment URLs carried **no `pot=` parameter** and **`playerfallback/1`**, even signed-in
- `manifest.googlevideo.com` fetches (h2, direct from WebContent) succeeded continuously throughout — no OS TCP block
- no h3/QUIC in play (protocol column: h2 + http/1.1 only)

## Fix (commit-by-commit)

1. `fcc856e` — DEBUG-only `webView.isInspectable = true` (the diagnostic instrument; kept for future debugging)
2. `596a9fa` — the fix:
   - honest UA via `applicationNameForUserAgent` (true iOS 26.5 WebKit identity) replacing the pinned fake iOS-17 `customUserAgent`
   - `earlyScript` reduced to CSS-only: removed `HTMLVideoElement.prototype.play()` wrapper, `history.pushState/replaceState` wrappers, `window.webkit` hide — all BotGuard-visible tampering
3. `4d1fd8c` — docs: `V2_REMEDIATION_PLAN.md` moved into repo (RESOLVED), PRD §8 correction note, README stale-claims fixes, pre-PRD scoping draft archived as `V2_SCOPING_ARCHIVE.md`

## Known trade-offs (tracked in #232)

- `/shorts` SPA (pushState) navigations no longer blocked (full-page navs still cancelled in `decidePolicyFor`)
- autoplay gated only by native `mediaTypesRequiringUserActionForPlayback = .video`
- fresh Google sign-ins may hit the webview block (existing session cookies persist and work)

Follow-up direction: Swift-side (KVO) shorts guard — no page-JS tampering, ever.

## Test plan

- [x] Simulator compile checks after each code commit (`BUILD SUCCEEDED`, only pre-existing Swift-6 warnings)
- [x] On-device (iPhone 13 Pro, iOS 26.5.2, NextDNS `*.youtube.com` deny active): video playback end-to-end restored (Amit, 2026-07-09)
- [x] Web Inspector diagnostics captured before/after (see `V2_REMEDIATION_PLAN.md` §3a evidence)

## References

- `NoShorts/V2_REMEDIATION_PLAN.md` (added here) — full evidence inventory, theory ranking, Phase-0 diagnostics, verdict
- `NoShorts/V2_PRD.md` §8 (amended here) — original shelve decision + correction note
- `NoShorts/V2_SCOPING_ARCHIVE.md` (added here) — pre-PRD scoping draft, preserved for history
- Predecessor PRs: #230 (PRD), #231 (V2 rewrite, shelved)
- Follow-up issue: #232 (restore /shorts SPA guard + autoplay gate, attestation-safe)
- [yt-dlp #12482 — web client only has SABR formats](https://github.com/yt-dlp/yt-dlp/issues/12482)
- [yt-dlp #13968 — YouTube forcing SABR despite cookies](https://github.com/yt-dlp/yt-dlp/issues/13968)
- [YouTube.js #724 — streaming URLs failing due to PoToken experiment](https://github.com/LuanRT/YouTube.js/issues/724)
- Debug session: local Claude Code session 8d0e15c8 (2026-07-06 → 07-09) incl. 16 device console screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)