### PR TITLE
feat(NoShorts): Swift-side /shorts SPA guard (#232 P1) + follow-up plan

### DIFF
--- a/NoShorts/NoShorts/ContentView.swift
+++ b/NoShorts/NoShorts/ContentView.swift
@@ -20,7 +20,7 @@ import Network
 /// HTMLVideoElement.play() wrapper, and pushState wrappers were BotGuard-visible
 /// tampering that tripped YouTube's stream attestation and killed playback
 /// (V2_REMEDIATION_PLAN.md §3a). Do not reintroduce page-JS tampering here.
-/// /shorts SPA navs are currently unguarded — Swift-side replacement: issue #232.
+/// /shorts SPA navs are guarded Swift-side via KVO on webView.url (Coordinator).
 private let earlyScript = """
 (function() {
     const s = document.createElement('style');
@@ -227,11 +227,21 @@ struct YouTubeWebView: UIViewRepresentable {
             model.webView.configuration.userContentController.add(self, name: "video")
 
             // Catch SPA URL changes (history.pushState / replaceState). decidePolicyFor
-            // does NOT fire for these, so a YouTube-in-page Home tap can sneak past
-            // without KVO on the url property.
+            // does NOT fire for these, so a YouTube-in-page Home tap — or a Shorts
+            // link routed by YouTube's SPA — can sneak past without KVO on the url
+            // property. This replaces the old JS pushState wrappers, which were
+            // BotGuard-visible tampering (V2_REMEDIATION_PLAN.md §3a, issue #232 P1).
             urlObs = model.webView.observe(\.url, options: [.new]) { [weak self] _, change in
                 guard let self, let url = change.newValue ?? nil else { return }
-                if Self.isYouTubeHome(url) {
+                if url.path.hasPrefix("/shorts") {
+                    Task { @MainActor in
+                        if self.model.webView.canGoBack {
+                            self.model.webView.goBack()
+                        } else {
+                            self.model.goPlaylists()
+                        }
+                    }
+                } else if Self.isYouTubeHome(url) {
                     Task { @MainActor in self.model.goPlaylists() }
                 }
             }

--- a/NoShorts/README.md
+++ b/NoShorts/README.md
@@ -13,7 +13,7 @@ its diagnosis (Google stream attestation, not an OS network block), and the fix 
 - **Auto-rotate to landscape on video play**: JS reports `<video>` `play`/`pause`/`ended` events; a 400ms debounce coalesces buffering-driven pause↔play blips before flipping orientation. Portrait when not playing.
 - **Fullscreen on play**: a fresh video start (content or ad, `currentTime < 1s`) calls the element's native `webkitEnterFullscreen()`, with a retry on `playing` if media wasn't loaded yet. Resume-from-pause does *not* re-enter — a manual fullscreen exit isn't fought. Fullscreen exits automatically when the video ends. See the fullscreen gotcha below for why it's done exactly this way.
 - **Autoplay gated natively**: `mediaTypesRequiringUserActionForPlayback = .video`. The former JS `video.play()` wrapper was removed 2026-07-09 — prototype tampering tripped YouTube's stream attestation and killed playback (see [V2_REMEDIATION_PLAN.md](V2_REMEDIATION_PLAN.md) §3a).
-- **Shorts navigation guard**: full-page navigations to `/shorts` are cancelled in `WKNavigationDelegate`. SPA (`pushState`) navigations are currently unguarded — the JS `pushState` wrapper was removed with the attestation fix; a Swift-side replacement is tracked in [#232](https://github.com/DeviationLabs/homely-vibes/issues/232).
+- **Shorts navigation guard**: full-page navigations to `/shorts` are cancelled in `WKNavigationDelegate`; SPA (`pushState`) navigations are caught Swift-side by the KVO observer on `webView.url`, which bounces back (`goBack()`, else Playlists). The old JS `pushState` wrapper is gone for good — page-JS tampering trips attestation ([#232](https://github.com/DeviationLabs/homely-vibes/issues/232) P1).
 - **Session timer**: 30-minute countdown badge (top-right); turns orange at 5min, red at 1min, exits at 0.
 - **Top toolbar**: 4 destination shortcuts — Playlists, Liked Videos, All Subscriptions, Account/Login.
 - **Bottom toolbar**: back, forward, search (expands inline), home, reload. Back/forward mirror `WKWebView.canGoBack`/`canGoForward` via KVO — refreshed live rather than only at `didFinish` so the chevrons stay accurate through cancelled navs.
@@ -100,7 +100,7 @@ Three `WKUserScript` injections run on every page:
 
 `WKNavigationDelegate` intercepts full-page navigations to `/shorts` and to `/` (or empty path) on `*.youtube.com`, redirecting both to the All Subscriptions grid.
 
-A `KVO` observer on `webView.url` catches SPA URL changes (`history.pushState`/`replaceState` from YouTube's own Home tab) — `decidePolicyFor` does NOT fire for SPA navigations, so KVO is the catch-all. When the URL becomes `/`, the observer calls `goHome()` to force a real navigation; rewriting the URL alone wouldn't stop YouTube's home content from being rendered.
+A `KVO` observer on `webView.url` catches SPA URL changes (`history.pushState`/`replaceState` from YouTube's own routing) — `decidePolicyFor` does NOT fire for SPA navigations, so KVO is the catch-all. When the URL becomes `/shorts…`, the observer bounces back (`goBack()` if possible, else Playlists). When the URL becomes `/`, it forces a real navigation to Playlists; rewriting the URL alone wouldn't stop YouTube's home content from being rendered.
 
 ## Architecture Notes / Gotchas
 

--- a/NoShorts/V2_REMEDIATION_PLAN.md
+++ b/NoShorts/V2_REMEDIATION_PLAN.md
@@ -176,13 +176,12 @@ home host looks like plain HTTPS and dodges whatever gate exists). Re-check at e
 Restoring the behaviors stripped by the attestation fix, Swift-side only (hard constraint: no
 page-JS prototype/history tampering — §3a). Parts ordered by priority; 2 and 3 are evidence-gated.
 
-- [ ] **P1 — `/shorts` SPA guard (do now).** Full-page navs to `/shorts` are still cancelled in
-  `decidePolicyFor`, but YouTube's SPA routing bypasses it. Fix: add a `/shorts` case to the existing
-  KVO observer on `webView.url` in the Coordinator (same mechanism as the YouTube-home redirect —
-  KVO fires on SPA URL changes where `decidePolicyFor` does not). ~5 lines:
-  on `url.path.hasPrefix("/shorts")` → `goBack()` if possible, else `goPlaylists()`.
-  Verify on-device: Shorts unreachable via search results and channel Shorts tabs; playback
-  unaffected (inspector spot-check: segments flowing, no attestation regression).
+- [x] **P1 — `/shorts` SPA guard. DONE 2026-07-10 (this branch).** Full-page navs to `/shorts` were
+  still cancelled in `decidePolicyFor`, but YouTube's SPA routing bypassed it. Fix as planned: a
+  `/shorts` case in the existing KVO observer on `webView.url` in the Coordinator —
+  `goBack()` if possible, else `goPlaylists()`. Swift-side only, zero page-JS.
+  On-device verification (Shorts unreachable via search/channel tabs; playback unaffected) is the
+  post-merge check — the mechanism is identical to the proven YouTube-home KVO redirect.
 - [ ] **P2 — autoplay-next gate (evidence-gated, likely moot).** We rely on the native
   `mediaTypesRequiringUserActionForPlayback = .video` gate. The old claim that YouTube bypasses it
   dates from the broken-proxy era. Gate: observe real usage — does the next video ever auto-play

--- a/NoShorts/V2_REMEDIATION_PLAN.md
+++ b/NoShorts/V2_REMEDIATION_PLAN.md
@@ -171,6 +171,32 @@ home host looks like plain HTTPS and dodges whatever gate exists). Re-check at e
    cellular playback then rides home upload bandwidth.)
 4. **If it comes to it: A4 treadmill vs shelve?**
 
+## 7. Follow-up plan — issue #232 (post-resolution TODO)
+
+Restoring the behaviors stripped by the attestation fix, Swift-side only (hard constraint: no
+page-JS prototype/history tampering — §3a). Parts ordered by priority; 2 and 3 are evidence-gated.
+
+- [ ] **P1 — `/shorts` SPA guard (do now).** Full-page navs to `/shorts` are still cancelled in
+  `decidePolicyFor`, but YouTube's SPA routing bypasses it. Fix: add a `/shorts` case to the existing
+  KVO observer on `webView.url` in the Coordinator (same mechanism as the YouTube-home redirect —
+  KVO fires on SPA URL changes where `decidePolicyFor` does not). ~5 lines:
+  on `url.path.hasPrefix("/shorts")` → `goBack()` if possible, else `goPlaylists()`.
+  Verify on-device: Shorts unreachable via search results and channel Shorts tabs; playback
+  unaffected (inspector spot-check: segments flowing, no attestation regression).
+- [ ] **P2 — autoplay-next gate (evidence-gated, likely moot).** We rely on the native
+  `mediaTypesRequiringUserActionForPlayback = .video` gate. The old claim that YouTube bypasses it
+  dates from the broken-proxy era. Gate: observe real usage — does the next video ever auto-play
+  after one ends? (Fullscreen auto-exits on `ended`, landing on the endscreen in portrait, which
+  already breaks the binge flow.) Only if a leak is observed: design a Swift-side countermeasure
+  (e.g., video-event heuristic → `evaluateJavaScript` pause), design TBD on evidence.
+- [ ] **P3 — fresh sign-in workaround (deferred until it bites).** The `window.webkit` hide on
+  `accounts.google.com` was removed. Existing session cookies persist, so this only matters after a
+  sign-out/data wipe. If a fresh login is ever blocked: restore the hide scoped to
+  `accounts.google.com` only, then re-verify playback attestation (the hide never ran on
+  youtube.com pages, so risk is low — but verify, don't assume).
+- [ ] **Housekeeping:** issue #232 is authored by `mastrix-tech` (wrong-hat account was active).
+  Either accept it or recreate under `abutala` and update references (README ×3, this file, PR #233 body).
+
 ## References
 
 - [`V2_PRD.md`](V2_PRD.md) (esp. §7 fail-fast ladder, §8 outcome — to be amended per §3a)


### PR DESCRIPTION
## Summary

Implements **P1 of issue #232**: `/shorts` SPA navigations are now guarded Swift-side. YouTube's SPA routing bypasses `decidePolicyFor`, so the existing KVO observer on `webView.url` (the same proven mechanism as the YouTube-home redirect) now catches `/shorts` URLs and bounces back — `goBack()` when possible, else Playlists. Zero page-visible JS, so attestation-safe by construction (the constraint from #233).

Also carries the full #232 follow-up plan in `V2_REMEDIATION_PLAN.md` §7:
- [x] **P1** — /shorts SPA guard (this PR)
- [ ] **P2** — autoplay-next gate: evidence-gated, only if the native gate is observed leaking
- [ ] **P3** — fresh sign-in `window.webkit` hide: deferred until a fresh login is ever blocked
- [ ] Housekeeping — #232 authorship (filed as `mastrix-tech` by mistake)

Issue #232 stays open for P2/P3.

## Test plan

- [x] Simulator compile check (`BUILD SUCCEEDED`)
- [x] Mechanism precedent: identical KVO path has driven the YouTube-home redirect since V1/V2 without issues
- [ ] Post-merge on-device check: Shorts unreachable via search results / channel Shorts tabs; playback unaffected

## References

- Issue #232 (P1 of the plan; P2/P3 remain)
- PR #233 (attestation fix — the no-page-tampering constraint), PR #234 (fullscreen-on-play)
- `NoShorts/V2_REMEDIATION_PLAN.md` §3a (constraint) and §7 (this plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)